### PR TITLE
fix(admin): session persistence, token timestamps, audit log filters + test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ graphify-out/*
 
 # Superpowers SDD scratch (task briefs, reports, progress ledger)
 .superpowers/
+
+.playwright-mcp/

--- a/OAuth2Admin/src/main.ts
+++ b/OAuth2Admin/src/main.ts
@@ -2,9 +2,17 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
+import { useAuthStore } from './stores/auth'
 import './style.css'
 
 const app = createApp(App)
-app.use(createPinia())
+const pinia = createPinia()
+app.use(pinia)
 app.use(router)
+
+// Attempt to restore an existing session (refresh token persisted in
+// sessionStorage) before mounting + initial navigation. The auth guard reads
+// isAuthenticated, which requires the access token to be present. See A-LOGIN-014.
+await useAuthStore().restoreSession()
+
 app.mount('#app')

--- a/OAuth2Admin/src/pages/logs/LogsPage.vue
+++ b/OAuth2Admin/src/pages/logs/LogsPage.vue
@@ -8,11 +8,19 @@ const loading = ref(true)
 const page = ref(1)
 const errorMessage = ref('')
 
+// Filters (A-LOG-004). action/outcome/actor_id are passed as query params; the
+// backend applies them server-side.
+const actionFilter = ref('')
+const outcomeFilter = ref('')
+
 async function fetchLogs() {
   loading.value = true
   errorMessage.value = ''
   try {
-    const resp = await axios.get('/api/admin/logs', { params: { page: page.value, per_page: 50 } })
+    const params: Record<string, string | number> = { page: page.value, per_page: 50 }
+    if (actionFilter.value) params.action = actionFilter.value
+    if (outcomeFilter.value) params.outcome = outcomeFilter.value
+    const resp = await axios.get('/api/admin/logs', { params })
     logs.value = resp.data.logs || []
   } catch (e) {
     const normalized = normalizeError(e)
@@ -21,6 +29,18 @@ async function fetchLogs() {
   } finally {
     loading.value = false
   }
+}
+
+function applyFilters() {
+  page.value = 1
+  fetchLogs()
+}
+
+function clearFilters() {
+  actionFilter.value = ''
+  outcomeFilter.value = ''
+  page.value = 1
+  fetchLogs()
 }
 
 function formatTime(ts: string) {
@@ -34,6 +54,43 @@ onMounted(fetchLogs)
 <template>
   <div>
     <h2 class="text-2xl font-bold text-gray-900 mb-6">Audit Logs</h2>
+
+    <!-- Filter bar -->
+    <div class="bg-white shadow rounded-lg p-4 mb-4 flex items-center gap-4 flex-wrap">
+      <div class="flex items-center gap-2">
+        <label class="text-sm font-medium text-gray-700">Action:</label>
+        <input
+          v-model="actionFilter"
+          type="text"
+          placeholder="e.g. login_success"
+          class="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:ring-indigo-500 focus:border-indigo-500"
+          @keyup.enter="applyFilters"
+        />
+      </div>
+      <div class="flex items-center gap-2">
+        <label class="text-sm font-medium text-gray-700">Outcome:</label>
+        <select
+          v-model="outcomeFilter"
+          class="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:ring-indigo-500 focus:border-indigo-500"
+        >
+          <option value="">(any)</option>
+          <option value="success">success</option>
+          <option value="failure">failure</option>
+        </select>
+      </div>
+      <button
+        @click="applyFilters"
+        class="px-4 py-1.5 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+      >
+        Apply
+      </button>
+      <button
+        @click="clearFilters"
+        class="px-4 py-1.5 border border-gray-300 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50"
+      >
+        Clear
+      </button>
+    </div>
 
     <!-- Error Banner -->
     <div v-if="errorMessage" class="mb-6 rounded-md bg-red-50 p-4">

--- a/OAuth2Admin/src/pages/tokens/TokensPage.vue
+++ b/OAuth2Admin/src/pages/tokens/TokensPage.vue
@@ -130,6 +130,14 @@ async function revokeByUser() {
 
 function formatTime(ts: string) {
   if (!ts) return '—'
+  // The backend returns expires_at/created_at as a Unix-epoch-seconds string
+  // (e.g. "1751464800"); a numeric string parsed by new Date(string) yields
+  // "Invalid Date". Detect epoch-seconds and convert to milliseconds. ISO 8601
+  // strings (logs) pass through unchanged. See A-TOK-012.
+  const asNum = Number(ts)
+  if (!Number.isNaN(asNum) && /^-?\d+$/.test(ts.trim())) {
+    try { return new Date(asNum * 1000).toLocaleString() } catch { return ts }
+  }
   try { return new Date(ts).toLocaleString() } catch { return ts }
 }
 

--- a/OAuth2Admin/src/router/index.ts
+++ b/OAuth2Admin/src/router/index.ts
@@ -76,10 +76,18 @@ const router = createRouter({
   ],
 })
 
-router.beforeEach((to, _from, next) => {
+router.beforeEach(async (to, _from, next) => {
   const auth = useAuthStore()
   if (to.meta.requiresAuth !== false && !auth.isAuthenticated) {
-    next({ name: 'login' })
+    // Wait for the one-shot session restoration before deciding. On a fresh
+    // load with a valid persisted refresh token, this flips isAuthenticated to
+    // true so the user is not bounced to /login. See A-LOGIN-014.
+    const restored = await auth.ensureSessionRestored()
+    if (restored) {
+      next()
+    } else {
+      next({ name: 'login' })
+    }
   } else {
     next()
   }

--- a/OAuth2Admin/src/stores/auth.ts
+++ b/OAuth2Admin/src/stores/auth.ts
@@ -4,6 +4,40 @@ import axios from 'axios'
 import { normalizeError, sessionExpiredError } from '../services/errorAdapter'
 import type { NormalizedError } from '../services/errorAdapter'
 
+// Refresh token is persisted in sessionStorage so a page refresh can restore the
+// session without re-prompting credentials. The access token stays in memory only
+// (never persisted), limiting exposure to XSS. sessionStorage is scoped to the
+// tab and cleared when the tab closes. See A-LOGIN-014 / A-SEC-002.
+const REFRESH_TOKEN_STORAGE_KEY = 'admin_refresh_token'
+
+function persistRefreshToken(token: string | null) {
+  try {
+    if (token) {
+      sessionStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, token)
+    } else {
+      sessionStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY)
+    }
+  } catch {
+    // sessionStorage may be unavailable (private mode, disabled); degrade to
+    // in-memory only — login still works for the lifetime of the tab.
+  }
+}
+
+function loadPersistedRefreshToken(): string | null {
+  try {
+    return sessionStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+// Shared promise so the router guard, the app bootstrap, and any component
+// mounting during the first tick all wait for the same one-shot session
+// restoration. Without this, the initial navigation can run before
+// restoreSession() finishes, see isAuthenticated === false, and bounce to
+// /login even though the refresh token is valid. See A-LOGIN-014.
+let sessionRestorePromise: Promise<boolean> | null = null
+
 /**
  * Navigate to the login view after a failed 401 token refresh
  * (Requirement 10.5).
@@ -74,6 +108,7 @@ export const useAuthStore = defineStore('auth', () => {
 
       accessToken.value = tokenResp.data.access_token
       refreshToken.value = tokenResp.data.refresh_token
+      persistRefreshToken(refreshToken.value)
 
       // Step 3: Fetch user info
       await fetchUserInfo()
@@ -106,29 +141,72 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  // In-flight refresh promise. When multiple requests 401 concurrently (common
+  // on page load: userinfo + dashboard + list endpoints), all of them must share
+  // a single refresh_token exchange — the backend rotates the refresh token on
+  // each use, so a second concurrent exchange would hit the now-invalidated
+  // token and log the user out. See A-LOGIN-014.
+  let refreshInFlight: Promise<boolean> | null = null
+
   async function refreshAccessToken() {
     if (!refreshToken.value) return false
-    try {
-      const resp = await axios.post('/oauth2/token', new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken.value,
-        client_id: 'admin-console',
-      }), {
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      })
-      accessToken.value = resp.data.access_token
-      refreshToken.value = resp.data.refresh_token
-      return true
-    } catch {
-      logout()
-      return false
-    }
+    if (refreshInFlight) return refreshInFlight
+    refreshInFlight = (async () => {
+      try {
+        const resp = await axios.post('/oauth2/token', new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken.value,
+          client_id: 'admin-console',
+        }), {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        })
+        accessToken.value = resp.data.access_token
+        refreshToken.value = resp.data.refresh_token
+        persistRefreshToken(refreshToken.value)
+        return true
+      } catch {
+        logout()
+        return false
+      } finally {
+        refreshInFlight = null
+      }
+    })()
+    return refreshInFlight
   }
 
   function logout() {
     accessToken.value = null
     refreshToken.value = null
     user.value = null
+    persistRefreshToken(null)
+  }
+
+  /**
+   * Restore a previously established session after a page refresh.
+   * Uses the persisted refresh token to obtain a fresh access token. If the
+   * refresh fails (expired/revoked), the session is cleared silently and the
+   * user is treated as unauthenticated. Returns true if the session was
+   * restored. See A-LOGIN-014.
+   */
+  async function restoreSession(): Promise<boolean> {
+    const persisted = loadPersistedRefreshToken()
+    if (!persisted) return false
+    refreshToken.value = persisted
+    const ok = await refreshAccessToken()
+    if (!ok) return false
+    await fetchUserInfo()
+    // Verify the restored session still has the admin role.
+    return !!user.value?.roles?.includes('admin')
+  }
+
+  // Deduplicate session restoration across concurrent callers (router guard +
+  // app bootstrap). Returns a shared promise; the underlying restoreSession
+  // runs at most once per page load. See A-LOGIN-014.
+  function ensureSessionRestored(): Promise<boolean> {
+    if (!sessionRestorePromise) {
+      sessionRestorePromise = restoreSession()
+    }
+    return sessionRestorePromise
   }
 
   // Axios interceptor for auto-attaching token
@@ -184,6 +262,8 @@ export const useAuthStore = defineStore('auth', () => {
     login,
     fetchUserInfo,
     refreshAccessToken,
+    restoreSession,
+    ensureSessionRestored,
     logout,
   }
 })

--- a/OAuth2Admin/tests/e2e/dashboard.spec.ts
+++ b/OAuth2Admin/tests/e2e/dashboard.spec.ts
@@ -71,5 +71,30 @@ test.describe('Dashboard - unhealthy state', () => {
     await loginAsAdmin(page)
     await expect(page.locator('text=Unhealthy')).toBeVisible()
   })
+
+  // A-DASH-006: stats API failure must surface a descriptive error banner.
+  // The Frontend_Error_Module (normalizeError) maps the backend error CODE to
+  // a localized message — INTERNAL_ERROR → "服务器内部错误" — rather than
+  // echoing the raw backend message string (Requirement 8.6). We assert the
+  // banner renders the localized mapping, not the raw payload.
+  test('shows descriptive error banner when stats API fails (A-DASH-006)', async ({ page }) => {
+    await setupAuthenticatedMocks(page)
+    await page.route('**/api/admin/dashboard/stats', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          error: { code: 'INTERNAL_ERROR', category: 'SYSTEM', message: 'Stats query failed' },
+        }),
+      })
+    })
+    await loginAsAdmin(page)
+    const banner = page.locator('.bg-red-50')
+    await expect(banner).toBeVisible()
+    // INTERNAL_ERROR is mapped to its localized message; the raw backend
+    // message is intentionally NOT surfaced to the UI.
+    await expect(banner).toContainText('服务器内部错误')
+    await expect(banner).not.toContainText('Stats query failed')
+  })
 })
 

--- a/OAuth2Admin/tests/e2e/security.spec.ts
+++ b/OAuth2Admin/tests/e2e/security.spec.ts
@@ -110,4 +110,35 @@ test.describe('Security', () => {
       expect(pageContent).not.toContain('new-secret-after-reset')
     })
   })
+
+  // A-SEC-001: This SPA uses Bearer tokens (Authorization header), not cookies,
+  // for authentication. Classic CSRF exploits the browser's automatic cookie
+  // attachment — irrelevant here because the auth credential is never in a
+  // cookie. Cross-origin protection is enforced server-side by a strict
+  // CORS Origin allowlist (main.cc, exact match, no wildcards). These tests
+  // verify the CSRF-immune invariants the frontend must maintain.
+  test.describe('CSRF protection (Bearer-token + CORS)', () => {
+    test('auth credential is not stored in a cookie', async ({ page }) => {
+      await setupAuthenticatedMocks(page)
+      await loginAsAdmin(page)
+      // No auth cookie is set — the credential lives in sessionStorage
+      // (refresh token) + memory (access token), immune to automatic
+      // cross-origin submission.
+      const cookieBlob = await page.evaluate(() => document.cookie)
+      expect(cookieBlob).toBe('')
+    })
+
+    test('API requests carry Bearer token in Authorization header', async ({ page }) => {
+      await setupAuthenticatedMocks(page)
+      await loginAsAdmin(page)
+      // Re-trigger an API call and capture its Authorization header. The
+      // axios request interceptor must attach the access token as Bearer.
+      const [request] = await Promise.all([
+        page.waitForRequest((req) => req.url().includes('/api/admin/dashboard/stats')),
+        page.click('nav a:has-text("Dashboard")'),
+      ])
+      const authHeader = await request.headerValue('authorization')
+      expect(authHeader).toMatch(/^Bearer\s+\S+/)
+    })
+  })
 })

--- a/OAuth2Admin/tests/e2e/users.spec.ts
+++ b/OAuth2Admin/tests/e2e/users.spec.ts
@@ -108,6 +108,39 @@ test.describe('User Management', () => {
     expect(apiCalled).toBe(false)
   })
 
+  // A-USR-RL-005: assigning a non-existent role must surface the backend error
+  // through the Frontend_Error_Module. normalizeError maps the error CODE to a
+  // localized message (Requirement 8.6) — the raw backend message is not shown.
+  // VALIDATION_RESOURCE_NOT_FOUND is the catalog code for a missing resource.
+  test('non-existent role shows error message (A-USR-RL-005)', async ({ page }) => {
+    await page.route('**/api/admin/users/*/roles', async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: {
+              code: 'VALIDATION_RESOURCE_NOT_FOUND',
+              category: 'VALIDATION',
+              message: 'Role does not exist',
+            },
+          }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+    await page.locator('button:has-text("Assign Roles")').first().click()
+    await page.fill('input[placeholder="admin, user"]', 'superadmin')
+    await page.click('button:has-text("Save Roles")')
+    // VALIDATION_RESOURCE_NOT_FOUND is mapped to "资源不存在"; the raw backend
+    // message is intentionally NOT surfaced.
+    const errorEl = page.locator('.bg-red-50')
+    await expect(errorEl.first()).toBeVisible()
+    await expect(errorEl.first()).toContainText('资源不存在')
+    await expect(errorEl.first()).not.toContainText('Role does not exist')
+  })
+
   test('API error displays error message', async ({ page }) => {
     await page.route('**/api/admin/users', async (route) => {
       await route.fulfill({

--- a/OAuth2Server/controllers/AdminController.cc
+++ b/OAuth2Server/controllers/AdminController.cc
@@ -1274,84 +1274,105 @@ void AdminController::listLogs(
     {
         auto db = drogon::app().getDbClient();
 
-        // Build query with optional filters
-        std::string query =
-          "SELECT id, timestamp, actor_type, actor_id, action, "
-          "target_type, target_id, outcome, ip, user_agent, request_id, details "
-          "FROM audit_logs WHERE 1=1 ";
-        std::vector<std::string> params;
+        // Build the parameterized WHERE clause from the optional action / outcome
+        // / actor_id filters. The previous implementation built this clause but
+        // then discarded it, executing an unfiltered query (A-LOG-004).
+        std::string whereClause = " WHERE 1=1";
+        std::string actionParam = action;
+        std::string outcomeParam = outcome;
+        std::string actorParam = actorId;
         int paramIdx = 1;
+        if (!actionParam.empty())
+            whereClause += " AND action = $" + std::to_string(paramIdx++);
+        if (!outcomeParam.empty())
+            whereClause += " AND outcome = $" + std::to_string(paramIdx++);
+        if (!actorParam.empty())
+            whereClause += " AND actor_id = $" + std::to_string(paramIdx++);
 
-        if (!action.empty())
-        {
-            query += " AND action = $" + std::to_string(paramIdx++);
-            params.push_back(action);
-        }
-        if (!outcome.empty())
-        {
-            query += " AND outcome = $" + std::to_string(paramIdx++);
-            params.push_back(outcome);
-        }
-        if (!actorId.empty())
-        {
-            query += " AND actor_id = $" + std::to_string(paramIdx++);
-            params.push_back(actorId);
-        }
-
-        query += " ORDER BY timestamp DESC LIMIT " + std::to_string(perPage) + " OFFSET " +
-                 std::to_string(offset);
-
-        // Execute with dynamic params (simplified: use raw SQL for flexibility)
-        // For simplicity with variable params, build the full query
-        std::string finalQuery =
+        std::string dataQuery =
           "SELECT id, timestamp, actor_type, actor_id, action, "
           "target_type, target_id, outcome, ip "
-          "FROM audit_logs ORDER BY timestamp DESC "
-          "LIMIT " +
-          std::to_string(perPage) + " OFFSET " + std::to_string(offset);
+          "FROM audit_logs" +
+          whereClause + " ORDER BY timestamp DESC LIMIT " + std::to_string(perPage) + " OFFSET " +
+          std::to_string(offset);
 
-        db->execSqlAsync(
-          finalQuery,
-          [sharedCb, req, page, perPage](const drogon::orm::Result &result) {
-              Json::Value json;
-              json["status"] = "success";
-              json["page"] = page;
-              json["per_page"] = perPage;
-              Json::Value logs(Json::arrayValue);
+        // Build the JSON response from the query result. `total` reflects the
+        // number of rows on this page (matches the pre-fix behavior; the logs
+        // table is not expected to drive precise pagination counts here).
+        auto buildLogs = [sharedCb, req, page, perPage](const drogon::orm::Result &result) {
+            Json::Value json;
+            json["status"] = "success";
+            json["page"] = page;
+            json["per_page"] = perPage;
+            json["total"] = static_cast<int>(result.size());
+            Json::Value logs(Json::arrayValue);
 
-              for (const auto &row : result)
-              {
-                  Json::Value log;
-                  log["id"] = row["id"].as<int64_t>();
-                  log["timestamp"] =
-                    row["timestamp"].isNull() ? "" : row["timestamp"].as<std::string>();
-                  log["actor_type"] =
-                    row["actor_type"].isNull() ? "" : row["actor_type"].as<std::string>();
-                  log["actor_id"] =
-                    row["actor_id"].isNull() ? "" : row["actor_id"].as<std::string>();
-                  log["action"] = row["action"].isNull() ? "" : row["action"].as<std::string>();
-                  log["target_type"] =
-                    row["target_type"].isNull() ? "" : row["target_type"].as<std::string>();
-                  log["target_id"] =
-                    row["target_id"].isNull() ? "" : row["target_id"].as<std::string>();
-                  log["outcome"] = row["outcome"].isNull() ? "" : row["outcome"].as<std::string>();
-                  log["ip"] = row["ip"].isNull() ? "" : row["ip"].as<std::string>();
-                  logs.append(log);
-              }
+            for (const auto &row : result)
+            {
+                Json::Value log;
+                log["id"] = row["id"].as<int64_t>();
+                log["timestamp"] =
+                  row["timestamp"].isNull() ? "" : row["timestamp"].as<std::string>();
+                log["actor_type"] =
+                  row["actor_type"].isNull() ? "" : row["actor_type"].as<std::string>();
+                log["actor_id"] = row["actor_id"].isNull() ? "" : row["actor_id"].as<std::string>();
+                log["action"] = row["action"].isNull() ? "" : row["action"].as<std::string>();
+                log["target_type"] =
+                  row["target_type"].isNull() ? "" : row["target_type"].as<std::string>();
+                log["target_id"] =
+                  row["target_id"].isNull() ? "" : row["target_id"].as<std::string>();
+                log["outcome"] = row["outcome"].isNull() ? "" : row["outcome"].as<std::string>();
+                log["ip"] = row["ip"].isNull() ? "" : row["ip"].as<std::string>();
+                logs.append(log);
+            }
 
-              json["logs"] = logs;
-              json["total"] = static_cast<int>(result.size());
-              (*sharedCb)(HttpResponse::newHttpJsonResponse(json));
-          },
-          [sharedCb, req](const drogon::orm::DrogonDbException &e) {
-              respondError(
-                req,
-                sharedCb,
-                "DB_QUERY_ERROR",
-                std::string("Failed to fetch audit logs: ") + e.base().what()
-              );
-          }
-        );
+            json["logs"] = logs;
+            (*sharedCb)(HttpResponse::newHttpJsonResponse(json));
+        };
+
+        auto onDbError = [sharedCb, req](const drogon::orm::DrogonDbException &e) {
+            respondError(
+              req,
+              sharedCb,
+              "DB_QUERY_ERROR",
+              std::string("Failed to fetch audit logs: ") + e.base().what()
+            );
+        };
+
+        // Drogon's execSqlAsync binds trailing variadic arguments positionally;
+        // dispatch on the number of active filters so the right overload is used.
+        int nParams = (!actionParam.empty() ? 1 : 0) + (!outcomeParam.empty() ? 1 : 0) +
+                      (!actorParam.empty() ? 1 : 0);
+
+        if (nParams == 0)
+        {
+            db->execSqlAsync(dataQuery, buildLogs, onDbError);
+        }
+        else if (nParams == 1)
+        {
+            const std::string &p1 = !actionParam.empty()
+                                      ? actionParam
+                                      : (!outcomeParam.empty() ? outcomeParam : actorParam);
+            db->execSqlAsync(dataQuery, buildLogs, onDbError, p1);
+        }
+        else if (nParams == 2)
+        {
+            // Bind list in declaration order: action, outcome, actor_id.
+            std::vector<std::string> binds;
+            if (!actionParam.empty())
+                binds.push_back(actionParam);
+            if (!outcomeParam.empty())
+                binds.push_back(outcomeParam);
+            if (!actorParam.empty())
+                binds.push_back(actorParam);
+            db->execSqlAsync(dataQuery, buildLogs, onDbError, binds[0], binds[1]);
+        }
+        else
+        {
+            db->execSqlAsync(
+              dataQuery, buildLogs, onDbError, actionParam, outcomeParam, actorParam
+            );
+        }
     }
     catch (...)
     {

--- a/docs/admin/test-cases.md
+++ b/docs/admin/test-cases.md
@@ -248,7 +248,7 @@
 
 | ID | Test Case | Steps | Expected Result | Priority |
 |----|-----------|-------|-----------------|----------|
-| A-SEC-001 | CSRF protection | Submit forms | CSRF token included in requests | P0 |
+| A-SEC-001 | CSRF protection (CORS same-origin) | Submit forms / send API requests | Bearer-token architecture: auth token is NOT in a cookie, so classic CSRF does not apply. Protection is enforced by backend CORS with strict exact-match Origin allowlist (no wildcards) — `main.cc` origin check. Cross-origin requests from non-allowlisted origins are rejected | P0 |
 | A-SEC-002 | Token storage | After login | Auth token not in URL or localStorage in plaintext | P0 |
 | A-SEC-003 | Route guard bypass | Manually enter `/admin/users` URL without auth | Redirected to login | P0 |
 | A-SEC-004 | Client secret display | View/create client secret | Secret shown only once, not persisted in page state | P0 |


### PR DESCRIPTION
## Summary

Three bug fixes found via manual browser testing of the admin console, plus E2E test coverage for previously untested mock-dependent cases.

### Fixes

- **A-LOGIN-014 / A-SEC-002 — Session persistence.** The auth store kept tokens only in memory, so any page refresh kicked the user back to `/admin/login`. Now persists the refresh token in `sessionStorage` (access token stays in memory — XSS-safe). Router guard awaits a one-shot, deduplicated restore promise to avoid the initial-navigation race; refresh-token requests are deduplicated to survive the backend's refresh-token rotation.
- **A-TOK-012 — Token expiry timestamps.** The backend returns `expires_at` / `created_at` as Unix-epoch-seconds strings; `new Date(string)` produced "Invalid Date". `formatTime` now detects epoch-seconds and converts to ms.
- **A-LOG-004 — Audit log filters.** The backend built a filtered `WHERE` clause but then discarded it, running an unfiltered query. Now applies `action` / `outcome` / `actor_id` server-side (parameterized). Frontend adds Action / Outcome filter UI.

### Test coverage added

- **A-DASH-006** — stats API failure surfaces the localized error banner.
- **A-USR-RL-005** — assigning a non-existent role surfaces the localized error.
- **A-SEC-001** — redefined for the Bearer-token + CORS architecture: classic CSRF does not apply (auth credential not in a cookie). Added tests verifying no auth cookie is set and API requests carry a Bearer Authorization header. `test-cases.md` updated.

## Test plan

- [x] Manual browser verification: refresh stays on Dashboard, token timestamps render, audit log action/outcome filters reduce result set correctly
- [x] `npx playwright test dashboard users security` — 27/27 pass
- [ ] Reviewer: spot-check that refresh-token rotation + concurrent request dedup behaves under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)