### PR TITLE
feat(auth): close auth-flow error-code gaps (G1-G6) + 9 catalog entries

### DIFF
--- a/.kiro/specs/auth-flow-error-code-gaps/.config.kiro
+++ b/.kiro/specs/auth-flow-error-code-gaps/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "4987a9dd-661f-4b5e-98ad-fc3f2e0886ad", "workflowType": "design-first", "specType": "feature"}

--- a/.kiro/specs/auth-flow-error-code-gaps/design.md
+++ b/.kiro/specs/auth-flow-error-code-gaps/design.md
@@ -1,0 +1,381 @@
+# Design Document
+
+## Overview
+
+本特性用于修复 `error-code-message-standardization` 特性发版后，在注册、登录及相邻认证流程（MFA、WebAuthn、设备授权、密码重置、邮箱验证、限流）中发现的错误信息缺口。触发原因是用户反馈「注册时用户名/邮箱重复」只显示一句笼统的"输入参数有误"，看不出具体是哪里冲突。经提交历史与代码审计复查，发现同样的「多种失败原因被折叠进同一个 code」模式在若干控制器中反复出现，因此判定为一类系统性缺口，需要统一补充设计。
+
+本特性**依赖并扩展** `error-code-message-standardization` 特性已建成的基础设施——`ErrorCatalog`（单一权威错误码目录）、`ErrorResponder`（Application 统一错误响应入口）与 `Frontend_Error_Module`（前端 `errorAdapter` + `Error_Message_Catalog_FE`）。这些基础设施是本特性的前提条件；本设计不重复其完整设计，仅在必要处引用其组件、接口与既有正确性属性（详见下方 Correctness Properties 一节），聚焦于：
+
+1. 新增 9 条 Error_Catalog 条目，覆盖注册重复、MFA、WebAuthn 凭据重复、密码重置/邮箱验证 token 失效、设备授权码失效、限流拒绝等此前被折叠的失败原因。
+2. 逐个 Gap 给出后端控制器/服务层的改动点，使其把具体失败原因映射到新的、更精确的 Error_Code，而不是继续复用笼统的通用码。
+3. 在 OAuth2Frontend 与 OAuth2Admin 两个前端应用的 `zh-CN.ts` 消息目录中同步补充对应词条，保持与既有「前端目录必须覆盖后端全部已登记 code」的约束一致。
+4. 明确记录一项刻意保留、不作为缺口处理的设计决策（账户锁定的防枚举行为，G7），以及一项已知但超出本次范围的问题（前端/后端密码最小长度不一致 + 一条从未生效的校验规则）。
+
+## Architecture
+
+### Root Cause Analysis
+
+`ErrorResponder::respond`（由 `error-code-message-standardization` 特性建成，见其 Components and Interfaces §3、`OAuth2Plugin/src/error/ErrorResponder.cc`）的核心行为是：给定一个 `code`，永远返回该 `code` 在 Error_Catalog 中登记的**默认 `message`**（该特性的 Requirement 5.6 明确要求：生产模式下 `message` 必须等于 Catalog 登记的默认 Client_Safe_Message，而非原始异常/业务文本）。
+
+这个行为本身是正确且必要的（防止内部细节泄露）。但它有一个直接推论：**如果某个控制器把同一段代码路径中的多个不同失败原因（duplicate username / duplicate email / token 已用 / token 已过期 / 未找到 …）全部映射到同一个 `code`，客户端就必然看到同一句话**，因为 `ErrorResponder` 无从得知调用点想表达的是哪一种具体原因——它能看到的只有传入的 `code`。
+
+这正是「注册重复邮箱/用户名显示笼统提示」问题的根因：`SessionController::registerUser` 的失败回调（`SessionController.cc` 约 846 行）无论 `AuthService::registerUser` 内部是因为用户名重复、邮箱重复、密码哈希失败还是角色分配失败，统一 `respondError(req, callback, "VALIDATION_INVALID_INPUT", ...)`。审计过程中确认同样的折叠模式还出现在 MFA、WebAuthn、设备授权、密码重置/邮箱验证等控制器中（见下方 Gap Inventory），因此判定为一类系统性缺口而非孤立 bug，遂以本特性统一处理。
+
+```mermaid
+graph TD
+    subgraph Existing["error-code-message-standardization (前提基础设施)"]
+        Catalog["ErrorCatalog<br/>(单一权威来源)"]
+        Responder["ErrorResponder<br/>respond(req, cb, code, ...)"]
+        FEModule["Frontend_Error_Module<br/>errorAdapter + Error_Message_Catalog_FE"]
+    end
+
+    subgraph Gaps["本特性: 折叠失败原因 → 精确 Error_Code"]
+        G1["G1: 注册重复 username/email"]
+        G2["G2: MFA 校验失败 / 未配置"]
+        G3["G3: WebAuthn 凭据重复"]
+        G4["G4: 设备授权码失效"]
+        G5["G5: 重置/验证 token 失效"]
+        G6["G6: Hodor 限流拒绝体"]
+        G7["G7: 账户锁定 (保留不改)"]
+    end
+
+    G1 -->|新 code| Catalog
+    G2 -->|新 code| Catalog
+    G3 -->|新 code| Catalog
+    G4 -->|新 code| Catalog
+    G5 -->|新 code| Catalog
+    G6 -->|新 code| Catalog
+    Catalog --> Responder
+    Catalog -.镜像同步.-> FEModule
+    G7 -.明确不改.-> Responder
+```
+
+## Components and Interfaces
+
+本特性不引入任何新组件/类，全部复用 `error-code-message-standardization` 已建成的接口；唯一的接口契约变化是 G1 涉及的 `AuthService::registerUser` 回调签名调整。
+
+### 复用的既有接口（继承自 error-code-message-standardization，本设计不重新定义）
+
+- **`ErrorCatalog`**（`common::error::ErrorCatalog`，`OAuth2Plugin/src/error/ErrorCatalog.cc`）：单一权威错误码目录，提供 `find(code)` / `findByNumeric(numericCode)` / `allEntries()`。本特性仅向其 `rawEntries()` 静态数组追加 9 条 `CatalogEntry`（见下方 New Error Catalog Entries 一节与 Data Models 一节），不改动其接口签名。
+- **`ErrorResponder`**（`common::error::ErrorResponder`，`OAuth2Plugin/src/error/ErrorResponder.cc`）：Application 端点统一错误响应入口，签名 `static void respond(const drogon::HttpRequestPtr &req, Callback &&cb, std::string code, std::string detailForLog = "", std::string clientDetails = "")`。各 Gap 的改动点均是把传入的 `code` 参数从旧的笼统码换成新码，不改动 `ErrorResponder` 本身。
+- **`Error::fromCode`**（`common::error::Error::fromCode(std::string code, std::string requestId)`）：G6 中用于把 `VALIDATION_RATE_LIMITED` 构造为 `Error` 对象，再交给 `ErrorResponder::buildResponse` 生成 Envelope。
+- **`Frontend_Error_Module`**（`errorAdapter` + `Error_Message_Catalog_FE`，`OAuth2Frontend/src/services/messages/zh-CN.ts` 与 `OAuth2Admin/src/services/messages/zh-CN.ts`）：前端错误规范化与本地化管线。本特性仅向两个 `zh-CN.ts` 目录追加词条，`errorAdapter.ts` 的 `normalizeError`/`getErrorMessage` 接口不变（见 Frontend Design 一节）。
+
+### 接口变更：`AuthService::registerUser` 回调契约（G1）
+
+这是本特性唯一的行为性接口改动。回调签名从携带自由文本错误消息，改为携带结构化错误码字符串，使调用方（`SessionController::registerUser`）能够将具体失败原因映射到精确的 `Error_Code`，而不必继续硬编码回退到 `VALIDATION_INVALID_INPUT`。
+
+```cpp
+// 变更前（error-code-message-standardization 发版时的状态）
+using RegisterCallback = std::function<void(const std::string &error /* 自由文本，空串=成功 */)>;
+
+// 变更后（本特性）
+using RegisterCallback = std::function<void(const std::string &errorCode /* 结构化 Error_Code，空串=成功 */)>;
+```
+
+调用约定：`errorCode` 为空字符串表示注册成功；非空时必须是 `ErrorCatalog` 中已登记的 `code`（`VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`，或未识别约束时的既有兜底码 `VALIDATION_INVALID_INPUT`）。调用方不再对回调参数做文本判断或拼接，直接将其转发给 `ErrorResponder::respond` 的 `code` 参数。详见 Backend Design G1 一节的完整实现示意。
+
+## Data Models
+
+本特性不新增数据结构，只是向既有结构填充新数据：
+
+- **`CatalogEntry` 行数据**：9 条新增记录（`VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`、`VALIDATION_RESET_TOKEN_INVALID`、`VALIDATION_VERIFICATION_TOKEN_INVALID`、`VALIDATION_DEVICE_CODE_INVALID`、`VALIDATION_RATE_LIMITED`、`AUTH_MFA_CODE_INVALID`、`AUTH_MFA_NOT_CONFIGURED`），字段形状（`code`/`numericCode`/`category`/`httpStatus`/`defaultMessage`/`description`）继承自前提特性的 `CatalogEntry` 结构（见其 Data Models §Error_Catalog 初始条目），本特性不新增或修改任何字段。完整取值见下方「New Error Catalog Entries」一节的表格与 `RawEntry` 追加示意。
+- **`NormalizedError`（前端）**：继承自前提特性的 `{ code: string; message: string; request_id: string; httpStatus: number }` 形状，无字段变化；本特性只是使其 `code` 字段可能取到新增的 9 个值。
+- **`Error_Message_Catalog_FE`（前端）**：继承自前提特性的 `Record<locale, Record<errorCode, string>>` 形状；本特性在 `zh-CN` 语言下向 OAuth2Frontend 与 OAuth2Admin 两份目录追加与上述 9 个新 code 对应的键值对（见 Frontend Design 一节），不改变该结构本身。
+
+## Gap Inventory
+
+| ID | 位置 | 现状 | 问题 |
+| --- | --- | --- | --- |
+| G1 | `OAuth2Server/AuthService.cc::registerUser` + `OAuth2Server/controllers/SessionController.cc::registerUser` 回调（约 846 行） | 用户名重复、邮箱重复、密码哈希失败、角色分配失败均以 `std::string error` 传递文本，控制器一律映射为 `VALIDATION_INVALID_INPUT`（400） | 用户看不出具体冲突字段，且语义上「重复」应是 409 冲突而非 400 校验失败 |
+| G2a | `OAuth2Server/controllers/MfaController.cc::verifySetup` TOTP 校验失败分支（约 164 行） | 复用 `AUTH_INVALID_CREDENTIALS`（"用户名或密码错误"） | MFA 设置页面没有用户名/密码输入框，这句提示不知所云 |
+| G2b | `OAuth2Server/controllers/MfaController.cc::verifySetup` "尚未设置 MFA" 分支（约 150 行） | 复用通用 `VALIDATION_INVALID_INPUT` | 应给出「先完成设置」的状态引导，而非通用输入错误提示 |
+| G3 | `OAuth2Server/controllers/WebAuthnController.cc::registerFinish`（约 215 行） | INSERT 未处理 `credential_id` 唯一约束冲突，落入通用 `DB_QUERY_ERROR`（"服务暂时不可用"） | 让用户误以为服务器宕机，实际是重复添加同一安全密钥 |
+| G4 | `OAuth2Server/controllers/DeviceAuthController.cc::approveDevice`（约 259 行） | "未找到"、"已处理"、"已过期" 的 device user_code 统一落入 `VALIDATION_INVALID_INPUT` | 三种不同状态原因无法区分（此条不要求拆分为三个 code，仅要求给出更贴切的单一 code，见下方设计） |
+| G5 | `PasswordResetController::confirm`、`EmailVerificationController::verify` | 过期/已用/无效 token 统一落入 `VALIDATION_INVALID_INPUT` | 防枚举意图（不区分「已过期」与「已使用」）应保留，但默认提示文案应更具行动指引 |
+| G6 | `config.prod.json`（Hodor 插件配置）+ `OAuth2Server/main.cc` | Hodor 限流插件通过自身 `rejection_message` 配置直接返回 `text/plain` 的 "Too Many Requests" 429 响应体，完全不经过 `ErrorResponder`/Error Envelope | 违反前提特性 Requirement 7.3（Application 端点不得返回非 JSON 错误体）。Hodor 作为全局前置 advice，运行在任何控制器之外，是原迁移遗漏的覆盖面 |
+| G7（明确不改动） | `AuthService.cc::validateUser` 账户锁定分支 | 锁定期内的登录尝试与「密码错误」一样返回 `AUTH_INVALID_CREDENTIALS` | 这是刻意设计，用于防止用户名枚举（参见 `docs/design/email-first-auth-design.md` §5.1）。本特性明确将其记录为「保留的设计决策」，而非待修复缺口 |
+
+> 相关但超出本次范围的发现（另立验证策略工单，不在本次错误码补充范围内处理）：前端 `RegisterPage.vue` 客户端强制密码最少 6 位，而后端 `RuleSet::registerUser` 仅拒绝空密码或超过 200 字符（未真正强制最小长度）；同时 `RequestValidationFilter` 中为 `/api/register` 定义了 8 位长度 + `PASSWORD_PATTERN` 的校验规则，但该 filter 从未挂载到 `/api/register` 路由（`SessionController.h` 的 `ADD_METHOD_TO(SessionController::registerUser, "/api/register", Post)` 未附加该 filter），是一条已定义但未生效（dead）的规则。这是密码策略不一致的问题，与错误码文案无关，仅在此记录以便后续开工。
+
+## New Error Catalog Entries
+
+在 `OAuth2Plugin/src/error/ErrorCatalog.cc` 的 `rawEntries()` 数组末尾追加以下条目，延续现有数值段位（VALIDATION 3000-3099 当前最高 3005，AUTHENTICATION 4000-4099 当前最高 4003），不改动、不重排任何既有条目：
+
+| Error_Code | numeric | category | HTTP（override） | 默认 Client_Safe_Message（zh-CN） |
+| --- | --- | --- | --- | --- |
+| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | 该用户名已被注册 |
+| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | 该邮箱已被注册 |
+| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | 该安全密钥已注册，无需重复添加 |
+| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400（类别默认，无 override） | 重置链接已失效，请重新申请 |
+| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400（类别默认） | 验证链接已失效，请重新发送邮件 |
+| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400（类别默认） | 设备码无效、已过期或已被处理 |
+| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | 请求过于频繁，请稍后重试 |
+| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401（类别默认） | 验证码不正确 |
+| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401（类别默认） | 尚未设置双重验证，请先完成设置 |
+
+对应的 `RawEntry` 追加示意（追加在 `rawEntries()` 现有 `std::array<RawEntry, 16>` 之后，数组大小需相应改为 25）：
+
+```cpp
+// VALIDATION (3000-3099) —— 注册/登录补充缺口 (G1, G3, G5, G6)
+{"VALIDATION_USERNAME_TAKEN",
+ 3006,
+ ErrorCategory::VALIDATION,
+ "该用户名已被注册",
+ "注册时用户名重复（VALIDATION 类，HTTP 409）",
+ 409},
+{"VALIDATION_EMAIL_TAKEN",
+ 3007,
+ ErrorCategory::VALIDATION,
+ "该邮箱已被注册",
+ "注册时邮箱重复（VALIDATION 类，HTTP 409）",
+ 409},
+{"VALIDATION_CREDENTIAL_ALREADY_REGISTERED",
+ 3008,
+ ErrorCategory::VALIDATION,
+ "该安全密钥已注册，无需重复添加",
+ "WebAuthn 凭据重复注册（VALIDATION 类，HTTP 409）",
+ 409},
+{"VALIDATION_RESET_TOKEN_INVALID",
+ 3009,
+ ErrorCategory::VALIDATION,
+ "重置链接已失效，请重新申请",
+ "密码重置 token 无效/过期/已用（VALIDATION 类）"},
+{"VALIDATION_VERIFICATION_TOKEN_INVALID",
+ 3010,
+ ErrorCategory::VALIDATION,
+ "验证链接已失效，请重新发送邮件",
+ "邮箱验证 token 无效/过期/已用（VALIDATION 类）"},
+{"VALIDATION_DEVICE_CODE_INVALID",
+ 3011,
+ ErrorCategory::VALIDATION,
+ "设备码无效、已过期或已被处理",
+ "设备授权 user_code 未找到/已处理/已过期（VALIDATION 类）"},
+{"VALIDATION_RATE_LIMITED",
+ 3012,
+ ErrorCategory::VALIDATION,
+ "请求过于频繁，请稍后重试",
+ "Hodor 限流拒绝（VALIDATION 类，HTTP 429）",
+ 429},
+
+// AUTHENTICATION (4000-4099) —— MFA 补充缺口 (G2a, G2b)
+{"AUTH_MFA_CODE_INVALID",
+ 4004,
+ ErrorCategory::AUTHENTICATION,
+ "验证码不正确",
+ "MFA TOTP 校验失败（AUTHENTICATION 类）"},
+{"AUTH_MFA_NOT_CONFIGURED",
+ 4005,
+ ErrorCategory::AUTHENTICATION,
+ "尚未设置双重验证，请先完成设置",
+ "用户尚未完成 MFA 设置（AUTHENTICATION 类）"},
+```
+
+## Backend Design (per gap)
+
+- **G1**：在 `AuthService::registerUser` 的 INSERT 之前先做存在性检查，或在现有 `mapper.insert` 的 `DrogonDbException` 回调中捕获后按约束/索引名匹配（复用前提特性 `ErrorHandler::handleDbException` 中已有的对 `e.base().what()` 做子串匹配的方式，如匹配 `users_username_key` 还是 `idx_users_email_unique`）以区分是用户名重复还是邮箱重复，进而映射为 `VALIDATION_USERNAME_TAKEN` 或 `VALIDATION_EMAIL_TAKEN`。当前回调签名 `std::function<void(const std::string &error)>` 只携带一句纯文本，需要改为携带（或让调用方能推断出）一个结构化的错误码，而不是像现在一样在 `SessionController::registerUser` 回调里无条件回退到 `VALIDATION_INVALID_INPUT`。示意：
+
+  ```cpp
+  // AuthService.h: 回调签名从 std::string error 改为携带错误码
+  using RegisterCallback = std::function<void(const std::string &errorCode /* 空串=成功 */)>;
+
+  // AuthService.cc::registerUser 的 insert 失败分支
+  [sharedCb](const DrogonDbException &e) {
+      const std::string what = e.base().what();
+      LOG_ERROR << "Register Failed: " << what;
+      if (what.find("users_username_key") != std::string::npos)
+          (*sharedCb)("VALIDATION_USERNAME_TAKEN");
+      else if (what.find("idx_users_email_unique") != std::string::npos)
+          (*sharedCb)("VALIDATION_EMAIL_TAKEN");
+      else
+          (*sharedCb)("VALIDATION_INVALID_INPUT");  // 未识别的约束，保底行为不变
+  }
+  ```
+
+  `SessionController::registerUser` 的失败回调需要相应改为直接把收到的错误码传给 `respondError`，而不是硬编码 `VALIDATION_INVALID_INPUT`。
+
+- **G2a/G2b**：将 `MfaController::verifySetup` 中两处 `respondError` 调用点分别改为 `AUTH_MFA_CODE_INVALID`（TOTP 校验失败分支）与 `AUTH_MFA_NOT_CONFIGURED`（"MFA not set up" 分支），仅改 `code` 参数，其余不变：
+
+  ```cpp
+  // MfaController.cc::verifySetup —— "尚未设置" 分支
+  respondError(req, sharedCb, "AUTH_MFA_NOT_CONFIGURED",
+               "verifySetup: MFA not set up. Call /api/me/mfa/setup first");
+  // ...
+  // TOTP 校验失败分支
+  respondError(req, sharedCb, "AUTH_MFA_CODE_INVALID", "verifySetup: TOTP code is incorrect");
+  ```
+
+- **G3**：在 `WebAuthnController::registerFinish` 的 INSERT 的 `DrogonDbException` 回调中，通过 `e.base().what()` 子串匹配识别 `credential_id` 唯一约束冲突（与 G1 一致的模式匹配思路），命中时用 `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` 取代通用 `DB_QUERY_ERROR`：
+
+  ```cpp
+  [sharedCb, req](const DrogonDbException &e) {
+      const std::string what = e.base().what();
+      if (what.find("webauthn_credentials") != std::string::npos &&
+          what.find("credential_id") != std::string::npos)
+      {
+          respondError(req, sharedCb, "VALIDATION_CREDENTIAL_ALREADY_REGISTERED",
+                       std::string("registerFinish: duplicate credential_id: ") + what);
+          return;
+      }
+      respondError(req, sharedCb, "DB_QUERY_ERROR",
+                   std::string("registerFinish: failed to store credential: ") + what);
+  }
+  ```
+
+- **G4**：将 `DeviceAuthController::approveDevice` 中 `result.affectedRows() == 0` 分支的 code 由 `VALIDATION_INVALID_INPUT` 改为 `VALIDATION_DEVICE_CODE_INVALID`，其余逻辑（含不区分「未找到/已处理/已过期」三种原因的行为）不变。
+
+- **G5**：将 `PasswordResetController::confirm` 与 `EmailVerificationController::verify` 中 token 无效分支的 code 分别改为 `VALIDATION_RESET_TOKEN_INVALID` 与 `VALIDATION_VERIFICATION_TOKEN_INVALID`。保留现有的防枚举行为——即仍然不区分「已过期」与「已使用」，只是把默认提示文案换成更有行动指引的版本。
+
+- **G6**（风险稍高，建议单独批次上线，因为改动的是全局插件接线而非单个控制器）：在 `main.cc` 加载 Hodor 插件之后，调用 `hodor->setRejectResponseFactory(...)`，通过前提特性提供的 `common::error::ErrorResponder::buildResponse` 用新的 `VALIDATION_RATE_LIMITED` 码构造 Error Envelope 响应（`RequestId` 从请求中解析），取代 Hodor 当前的纯文本拒绝体：
+
+  ```cpp
+  // main.cc，在 registerBeginningAdvice 汇报 Hodor 状态之后
+  if (auto hodor = drogon::app().getPlugin<drogon::plugin::Hodor>())
+  {
+      hodor->setRejectResponseFactory([](const drogon::HttpRequestPtr &req) {
+          common::error::Error error = common::error::Error::fromCode(
+            "VALIDATION_RATE_LIMITED", common::error::RequestId::resolve(req)
+          );
+          return common::error::ErrorResponder::buildResponse(req, error);
+      });
+  }
+  ```
+
+  （实际 Hodor 插件回调签名以其头文件为准，此处为设计意图示意；接入前需核对 `drogon::plugin::Hodor` 是否提供等价的拒绝响应自定义钩子，若无则需要评估改为在自定义 filter 层实现限流拒绝的 Envelope 化。）
+
+- **G7（明确不改动）**：`AuthService.cc::validateUser` 账户锁定分支继续返回与密码错误完全相同的 `AUTH_INVALID_CREDENTIALS`。这是刻意设计，用于防止用户名枚举（参见 `docs/design/email-first-auth-design.md` §5.1）。本特性不修改此行为，仅通过下方 Testing Strategy 中的回归测试固化该不变量，防止后续改动误将其"修复"为可区分的提示。
+
+## Frontend Design
+
+在 `OAuth2Frontend/src/services/messages/zh-CN.ts` 与 `OAuth2Admin/src/services/messages/zh-CN.ts` **两个文件同时**追加以下键值对（保持与前提特性 Property 14「跨应用映射确定性一致」要求锁步）：
+
+```typescript
+// --- 注册/登录相关补充缺口 (Post-Migration Gap Closure) ---
+VALIDATION_USERNAME_TAKEN: '该用户名已被注册',
+VALIDATION_EMAIL_TAKEN: '该邮箱已被注册',
+VALIDATION_CREDENTIAL_ALREADY_REGISTERED: '该安全密钥已注册，无需重复添加',
+VALIDATION_RESET_TOKEN_INVALID: '重置链接已失效，请重新申请',
+VALIDATION_VERIFICATION_TOKEN_INVALID: '验证链接已失效，请重新发送邮件',
+VALIDATION_DEVICE_CODE_INVALID: '设备码无效、已过期或已被处理',
+VALIDATION_RATE_LIMITED: '请求过于频繁，请稍后重试',
+AUTH_MFA_CODE_INVALID: '验证码不正确',
+AUTH_MFA_NOT_CONFIGURED: '尚未设置双重验证，请先完成设置',
+```
+
+`errorAdapter.ts` 本身不需要任何改动——前提特性已建成的 `normalizeError`/`getErrorMessage` 管线已经能处理任意新 code，只要目录里有对应条目（这正是前提特性 AD-6「单一适配函数」设计决策的价值所在）。
+
+## Error Handling
+
+- **G1/G3 模式匹配未识别约束名**：`AuthService::registerUser`（G1）与 `WebAuthnController::registerFinish`（G3）都通过对 `DrogonDbException::base().what()` 做子串匹配来区分具体冲突约束（如 `users_username_key`、`idx_users_email_unique`、`credential_id`）。若数据库返回的约束名发生变化或出现未识别的约束名，匹配分支均落回既有的通用兜底码——G1 回退为 `VALIDATION_INVALID_INPUT`，G3 回退为 `DB_QUERY_ERROR`——保持与 `error-code-message-standardization` 发版时完全一致的安全默认行为，不会因未识别约束名而抛出异常或导致响应失败。
+- **G6 Hodor 插件未加载**：`main.cc` 中对 `drogon::app().getPlugin<drogon::plugin::Hodor>()` 的调用点已有既有的空指针检查模式（`registerBeginningAdvice` 中用于汇报 Hodor 状态的同一检查）；本特性新增的 `setRejectResponseFactory(...)` 接线代码复用该检查，仅在插件确实已加载时才执行接线，插件未加载/未配置时跳过，不影响启动流程，不会导致进程崩溃。
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+本特性新增的 9 条 Error_Catalog 条目与对应前端消息词条的**数据形状与覆盖完整性**，完全落在 `error-code-message-standardization` 特性已定义的 Property 5 与 Property 13 的覆盖范围内（见下方“复用的既有属性”），因此不需要为 Requirement 8、Requirement 9 新增属性测试。
+
+但本特性同时引入了**新的行为性需求**——若干控制器/服务在特定失败原因下应当路由到哪个精确 Error_Code（Requirement 1、2、3、4、5、7）——这些行为在前提特性中不存在对应控制逻辑，因此不被 Property 5/13 覆盖，需要新增下列 7 条正确性属性。
+
+### Property 1: 注册失败原因到 Error_Code 的精确路由
+
+*对任意* 注册请求，若因用户名冲突而失败，SessionController 返回的 Error_Code 为 `VALIDATION_USERNAME_TAKEN`；若因邮箱冲突而失败，返回 `VALIDATION_EMAIL_TAKEN`；若因既非用户名也非邮箱冲突的原因失败，返回 `VALIDATION_INVALID_INPUT`；AuthService 通过 RegisterCallback 传递的字符串在任何情况下都是空字符串（成功）或 Error_Catalog 中已登记的 Error_Code（失败）；且 SessionController 收到非空字符串时将其原样转发给 Error_Responder 作为 Error_Code 参数（不做文本判断或硬编码回退），收到空字符串时判定成功且不调用 Error_Responder。
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7**
+
+### Property 2: MFA 校验失败原因到 Error_Code 的精确路由
+
+*对任意* MFA 校验请求，若失败原因是尚未完成 MFA 设置，MfaController 返回的 Error_Code 为 `AUTH_MFA_NOT_CONFIGURED`；若失败原因是已完成设置但提交的 TOTP 验证码不正确，返回 `AUTH_MFA_CODE_INVALID`。
+
+**Validates: Requirements 2.1, 2.2**
+
+### Property 3: WebAuthn 凭据注册失败原因到 Error_Code 的精确路由
+
+*对任意* WebAuthn 凭据注册写入失败，若失败原因是 credential_id 唯一约束冲突，WebAuthnController 返回的 Error_Code 为 `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`，且数据库中已存在的凭据记录不因此次冲突写入尝试被修改或覆盖；若失败原因是其他数据库写入错误，返回既有兜底 Error_Code `DB_QUERY_ERROR`。
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 4: 设备授权码失效原因的不可区分性
+
+*对任意* 设备授权批准请求，无论 user_code 未找到、已被处理还是已过期，DeviceAuthController 返回的 Error_Code 均为 `VALIDATION_DEVICE_CODE_INVALID`，三种原因产生完全相同的响应码；且该 user_code 对应设备授权记录的现有状态不因此次被拒绝的批准请求发生任何变更。
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+### Property 5: 密码重置 token 失效原因的不可区分性
+
+*对任意* 密码重置确认请求，无论 token 无效、已过期还是已被使用，PasswordResetController 返回的 Error_Code 均为 `VALIDATION_RESET_TOKEN_INVALID`，各原因产生完全相同的响应码。
+
+**Validates: Requirements 5.1, 5.3**
+
+### Property 6: 邮箱验证 token 失效原因的不可区分性
+
+*对任意* 邮箱验证请求，无论 token 无效、已过期还是已被使用，EmailVerificationController 返回的 Error_Code 均为 `VALIDATION_VERIFICATION_TOKEN_INVALID`，各原因产生完全相同的响应码。
+
+**Validates: Requirements 5.2, 5.4**
+
+### Property 7: 账户锁定与密码错误的防枚举不可区分性
+
+*对任意* 用户账户与登录尝试，账户锁定期内的登录尝试所产生的 Error_Code、HTTP 状态码与响应体结构，与该账户密码错误时产生的 Error_Code、HTTP 状态码与响应体结构完全相同，无法通过响应区分两种情形。
+
+**Validates: Requirements 7.1, 7.2**
+
+### 复用的既有属性（继承自 error-code-message-standardization，覆盖 Requirement 8、9）
+
+#### Property 5（前提特性编号，非本文档 Property 5）: Error_Catalog 完整性与唯一性
+
+*对任意* Error_Catalog 条目，其 `code` 为非空字符串、`numeric_code` 为整数且落在其 Error_Category 对应的段位区间内、`category` 属于枚举集合、`httpStatus` 在 100..599 之间、默认 Client_Safe_Message 非空、说明长度合法；且在整个目录中 `code` 唯一、`numeric_code` 唯一。
+
+本特性新增的 9 条条目（`VALIDATION_USERNAME_TAKEN` 3006、`VALIDATION_EMAIL_TAKEN` 3007、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED` 3008、`VALIDATION_RESET_TOKEN_INVALID` 3009、`VALIDATION_VERIFICATION_TOKEN_INVALID` 3010、`VALIDATION_DEVICE_CODE_INVALID` 3011、`VALIDATION_RATE_LIMITED` 3012、`AUTH_MFA_CODE_INVALID` 4004、`AUTH_MFA_NOT_CONFIGURED` 4005）已按该属性的段位与唯一性规则设计（延续 VALIDATION 3000-3099、AUTHENTICATION 4000-4099 段位，不与既有条目冲突）。由于该属性的既有属性测试遍历 `ErrorCatalog::allEntries()` 的全量条目，追加条目后无需新增测试代码，测试会自动覆盖新条目；本特性不需要为此新增属性测试。
+
+**Validates: Requirements 8.1, 8.2, 8.3, 8.4, 8.5, 8.6**（测试基础设施继承自 error-code-message-standardization，验证对象为本特性 Requirement 8）
+
+#### Property 13（前提特性编号，非本文档 Property 13）: 前端信息目录覆盖与清洁性
+
+*对任意* 后端 Error_Catalog 中登记的 Error_Code，Error_Message_Catalog_FE 都提供一条非空、不含未替换占位符标记的本地化条目；且所有展示给用户的信息均不包含 Request_ID 之外的后端 Internal_Detail。
+
+本特性向 OAuth2Frontend 与 OAuth2Admin 的 `zh-CN.ts` 目录同时追加了与上述 9 个新 code 对应的键值对（见 Frontend Design 一节），词条内容均为面向用户的中文提示，不含 SQL、路径或堆栈片段。由于该属性的既有属性测试遍历后端 Catalog 全量 code 集合并断言前端目录覆盖，追加词条后测试会自动覆盖新 code；本特性不需要为此新增属性测试。
+
+**Validates: Requirements 9.1, 9.2, 9.4**（测试基础设施继承自 error-code-message-standardization，验证对象为本特性 Requirement 9）
+
+#### Property 14（前提特性编号）: 跨应用映射确定性一致
+
+*对任意* Error_Code，OAuth2Frontend 与 OAuth2Admin 两个 Error_Message_Catalog_FE 中对应词条的文案完全一致。
+
+本特性向两个前端应用同时追加相同的 9 条词条（见 Frontend Design 一节），内容逐字相同，满足该既有属性的跨应用一致性要求，不需要为此新增属性测试。
+
+**Validates: Requirements 9.3**（测试基础设施继承自 error-code-message-standardization，验证对象为本特性 Requirement 9）
+
+### Requirement 6（限流 Envelope 化）的测试策略说明
+
+Requirement 6（Hodor 限流响应体 Envelope 化，含 6.1-6.3 的拒绝响应格式要求，6.4/6.5 的插件未加载时的启动与保证放宽行为，以及 6.6/6.7 对应的插件加载状态无法确定时的相同处理）描述的是全局插件接线行为：响应格式是否为 Envelope、启动时插件是否加载或加载状态是否可确定，均不随输入变化，属于集成/冒烟测试范畴（详见 Testing Strategy 一节），不产出新的正确性属性。
+
+## Testing Strategy
+
+除前提特性既有的 Property 5/13/14 测试自动覆盖新数据外，需要新增以下**属性测试**，覆盖本特性引入的控制器/服务路由行为（对应 Correctness Properties 一节 Property 1-7）：
+
+- **Property 1**（注册失败路由）：生成随机的用户名/邮箱冲突组合（含"两者都冲突""都不冲突但违反其他未识别约束"等边界情形），断言 SessionController 返回码与失败原因一致，且 AuthService 回调字符串始终是空串或 Error_Catalog 中已登记的码
+- **Property 2**（MFA 校验路由）：生成随机的"未配置 MFA"与"已配置但验证码错误"两类用户状态，断言返回码分别为 `AUTH_MFA_NOT_CONFIGURED` 与 `AUTH_MFA_CODE_INVALID`
+- **Property 3**（WebAuthn 注册路由）：生成随机的凭据写入失败场景（credential_id 冲突 vs 其他 DB 错误），断言返回码路由正确，且冲突场景下数据库中已存在的凭据记录内容保持不变
+- **Property 4**（设备码不可区分性）：生成随机的"未找到/已处理/已过期"三类 user_code 状态，断言三者返回码相同，且对应设备授权记录的现有状态不因被拒绝的批准请求发生变更
+- **Property 5**（密码重置 token 不可区分性）：生成随机的"无效/已过期/已用" token 状态，断言三者返回码相同
+- **Property 6**（邮箱验证 token 不可区分性）：同上，验证 EmailVerificationController
+- **Property 7**（账户锁定防枚举）：生成随机账户与登录尝试组合（锁定期内 vs 密码错误），断言两者响应完全相同（**G7 回归测试**，防止后续改动误将其"修复"为可区分的提示）
+
+以上属性测试均遵循前提特性已建成的测试框架（后端 `drogon_test.h` / `DROGON_TEST`，前端 `vitest` + `fast-check`），每个属性测试至少运行 100 次迭代，并标注 **Feature: auth-flow-error-code-gaps, Property {number}: {property_text}**。
+
+此外，仍需要新增以下**示例/回归测试**（非属性测试），用于固化具体取值：
+
+- 注册重复用户名 → 409 + `VALIDATION_USERNAME_TAKEN`
+- 注册重复邮箱 → 409 + `VALIDATION_EMAIL_TAKEN`
+- MFA 验证码错误 → `AUTH_MFA_CODE_INVALID`
+- MFA 未配置 → `AUTH_MFA_NOT_CONFIGURED`
+- WebAuthn 凭据重复注册 → `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`
+- 设备码复用/过期 → `VALIDATION_DEVICE_CODE_INVALID`
+- 触发限流的请求 → JSON Error Envelope，`VALIDATION_RATE_LIMITED`，HTTP 429
+- **G7 回归测试**：显式断言锁定期内登录尝试返回的 `AUTH_INVALID_CREDENTIALS` 与密码错误返回的完全一致（不可区分），以此固化「防枚举」不变量，防止后续改动误将其"修复"为可区分的提示
+
+- 按前提特性 `ErrorCatalogRegressionTest.cc` 的现有风格与文件位置（`OAuth2Server/test/unit/error/`），为每个 Gap 新增上述示例/回归测试用例。
+- 复用前提特性已建成的 **Drogon `drogon_test.h`（`DROGON_TEST` 宏）** 测试框架，无需引入新的后端测试依赖。
+- 前端侧复用前提特性已建成的 **`vitest` + `fast-check`** 属性测试基础设施；本特性无需新增前端属性测试文件，只需确认现有 `messageCatalog.property.test.ts`（覆盖 Property 13）在新增词条后仍然通过，即可验证覆盖完整性。
+- 由于 `test/CMakeLists.txt` 使用 `file(GLOB_RECURSE UNIT_TESTS ... unit/*.cc)`，新增测试文件会被自动纳入，无需改 CMake。
+- G6（Hodor 限流 Envelope 化）建议作为独立批次验证与上线，因为改动的是全局插件接线而非单个控制器，风险面更广。

--- a/.kiro/specs/auth-flow-error-code-gaps/requirements.md
+++ b/.kiro/specs/auth-flow-error-code-gaps/requirements.md
@@ -1,0 +1,135 @@
+# Requirements Document
+
+## Introduction
+
+本文档描述 `auth-flow-error-code-gaps` 特性的需求，该特性用于修复 `error-code-message-standardization` 特性发版后，在注册、登录及相邻认证流程（MFA、WebAuthn、设备授权、密码重置、邮箱验证、限流）中遗留的错误信息缺口。根因是若干控制器把同一代码路径中的多种不同失败原因折叠进同一个笼统 Error_Code，导致用户无法从响应中看出具体失败原因（例如注册时看不出是用户名冲突还是邮箱冲突）。
+
+本特性依赖并扩展 `error-code-message-standardization` 特性已建成的基础设施（Error_Catalog、Error_Responder、Frontend_Error_Module），不重新定义这些基础设施本身的行为，只新增 9 条 Error_Catalog 条目、调整若干控制器/服务层的错误码映射，并同步补充两个前端应用的本地化消息目录。同时明确记录一项刻意保留、不作为缺口处理的设计决策（账户锁定的防枚举行为）。
+
+## Glossary
+
+- **Error_Catalog**: 单一权威错误码目录组件（`common::error::ErrorCatalog`），登记全部 Error_Code 及其 numeric_code、Error_Category、HTTP 状态码、默认 Client_Safe_Message。
+- **Error_Code**: Error_Catalog 中登记的结构化错误码字符串（如 `VALIDATION_USERNAME_TAKEN`）。
+- **Error_Category**: Error_Code 所属分类枚举（如 VALIDATION、AUTHENTICATION），决定其 numeric_code 段位与默认 HTTP 状态码。
+- **Client_Safe_Message**: Error_Catalog 中登记的、面向终端用户展示的默认提示文案，不包含内部实现细节。
+- **Error_Responder**: Application 端点统一错误响应入口组件（`common::error::ErrorResponder`），根据传入的 Error_Code 从 Error_Catalog 查找默认 Client_Safe_Message 并生成 Error_Envelope 响应。
+- **Error_Envelope**: Error_Responder 生成的标准 JSON 错误响应体格式，包含 code、message、request_id 等字段。
+- **Request_ID**: 每个请求的唯一标识符，允许出现在 Error_Envelope 中，不属于 Internal_Detail。
+- **Internal_Detail**: 后端内部实现细节（如 SQL 片段、文件路径、堆栈信息），不得出现在展示给用户的 Client_Safe_Message 或前端本地化词条中。
+- **AuthService**: 后端认证业务服务组件（`AuthService.cc`），负责用户注册、登录校验等核心逻辑。
+- **SessionController**: 处理注册/登录 HTTP 端点的控制器组件（`SessionController.cc`）。
+- **MfaController**: 处理多因素认证（MFA）设置与校验 HTTP 端点的控制器组件（`MfaController.cc`）。
+- **WebAuthnController**: 处理 WebAuthn 凭据注册 HTTP 端点的控制器组件（`WebAuthnController.cc`）。
+- **DeviceAuthController**: 处理设备授权码批准 HTTP 端点的控制器组件（`DeviceAuthController.cc`）。
+- **PasswordResetController**: 处理密码重置确认 HTTP 端点的控制器组件（`PasswordResetController.cc`）。
+- **EmailVerificationController**: 处理邮箱验证 HTTP 端点的控制器组件（`EmailVerificationController.cc`）。
+- **Hodor**: 全局限流插件（`drogon::plugin::Hodor`），作为前置 advice 运行于所有控制器之外。
+- **Application**: 后端 HTTP 服务整体（OAuth2Server 进程），涵盖所有控制器、服务与全局插件。
+- **RegisterCallback**: `AuthService::registerUser` 的注册结果回调类型，携带一个字符串（空串表示成功，非空表示 Error_Code）。
+- **Frontend_Error_Module**: 前端错误规范化与本地化管线，包含 `errorAdapter` 与 Error_Message_Catalog_FE。
+- **Error_Message_Catalog_FE**: 前端本地化错误消息目录（`zh-CN.ts`），为每个 Error_Code 提供本地化展示文案。
+- **OAuth2Frontend**: 面向终端用户的前端应用。
+- **OAuth2Admin**: 面向管理员的前端应用。
+
+## Requirements
+
+### Requirement 1: 注册重复用户名/邮箱错误码精确化
+
+**User Story:** 作为注册用户，我希望在用户名或邮箱已被占用时看到明确指出冲突字段的提示，而不是笼统的"输入参数有误"，以便我知道该修改哪个字段。
+
+#### Acceptance Criteria
+
+1. WHEN 用户使用已存在的用户名提交注册请求，THE SessionController SHALL 返回 HTTP 409 与 Error_Code `VALIDATION_USERNAME_TAKEN`；若提交的用户名和邮箱同时与已有记录冲突，用户名冲突的判定优先级高于邮箱冲突
+2. WHEN 用户提交的用户名未被占用但邮箱已被占用的注册请求，THE SessionController SHALL 返回 HTTP 409 与 Error_Code `VALIDATION_EMAIL_TAKEN`
+3. IF 注册失败的原因既非用户名冲突也非邮箱冲突，THEN THE SessionController SHALL 返回既有兜底 Error_Code `VALIDATION_INVALID_INPUT`
+4. WHEN AuthService 完成一次成功的注册尝试，THE AuthService SHALL 通过 RegisterCallback 传递一个空字符串
+5. WHEN AuthService 完成一次失败的注册尝试，THE AuthService SHALL 通过 RegisterCallback 传递一个在 Error_Catalog 中已登记的 Error_Code 字符串
+6. IF RegisterCallback 传递的字符串非空，THEN THE SessionController SHALL 将该字符串直接转发给 Error_Responder 作为 Error_Code 参数，不对其做文本判断或硬编码回退
+7. WHEN RegisterCallback 传递的字符串为空，THE SessionController SHALL 判定注册成功，且不调用 Error_Responder
+
+### Requirement 2: MFA 校验失败错误码精确化
+
+**User Story:** 作为设置多因素认证的用户，我希望在验证码错误或尚未完成设置时看到与 MFA 场景相关的提示，而不是"用户名或密码错误"这类不相关的提示。
+
+#### Acceptance Criteria
+
+1. WHEN 用户在 MFA 设置校验请求中提交的 TOTP 验证码不正确，THE MfaController SHALL 返回 HTTP 401 与 Error_Code `AUTH_MFA_CODE_INVALID`
+2. WHEN 用户账户尚未注册任何 TOTP 密钥（即尚未完成 MFA 设置）的状态下调用 MFA 设置校验接口，THE MfaController SHALL 返回 HTTP 401 与 Error_Code `AUTH_MFA_NOT_CONFIGURED`
+
+### Requirement 3: WebAuthn 凭据重复注册错误码精确化
+
+**User Story:** 作为添加安全密钥的用户，我希望在重复添加同一凭据时看到明确的"已注册"提示，而不是让我误以为服务器故障。
+
+#### Acceptance Criteria
+
+1. WHEN 用户尝试注册的 WebAuthn credential_id 已存在于数据库中，THE WebAuthnController SHALL 返回 HTTP 状态码 409 与 Error_Code `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`
+2. IF WebAuthn 凭据写入失败且失败原因不是 credential_id 唯一约束冲突，THEN THE WebAuthnController SHALL 返回既有兜底 Error_Code `DB_QUERY_ERROR`
+3. IF 检测到用户尝试注册的 WebAuthn credential_id 与数据库中已存在的凭据记录重复，THEN THE WebAuthnController SHALL 保持该已存在凭据记录不被修改或覆盖
+
+### Requirement 4: 设备授权码失效错误码精确化
+
+**User Story:** 作为批准设备授权的用户，我希望在设备码无效时看到与设备授权场景相关的提示，而不是通用的"输入参数有误"。
+
+#### Acceptance Criteria
+
+1. WHEN 设备授权批准请求中的 user_code 未找到对应记录、对应设备授权记录已处于批准（approved）或拒绝（denied）终态（以下统称"已被处理"）、或已超过其有效期（expired），THE DeviceAuthController SHALL 返回 Error_Code `VALIDATION_DEVICE_CODE_INVALID`
+2. THE DeviceAuthController SHALL 对"未找到""已被处理（已批准或已拒绝）""已过期"三种原因返回相同的 Error_Code，不在响应中包含可用于区分具体原因的任何信息
+3. IF 设备授权批准请求因 user_code 未找到、已被处理或已过期而被拒绝，THEN THE DeviceAuthController SHALL 保持该 user_code 对应设备授权记录的现有状态不变，不因此次被拒绝的批准请求产生任何状态变更
+
+### Requirement 5: 密码重置与邮箱验证 token 失效错误码精确化
+
+**User Story:** 作为申请密码重置或邮箱验证的用户，我希望在链接失效时看到具体指引（如重新申请/重新发送），同时系统仍不透露链接失效的具体原因，以防止被用于枚举攻击。
+
+#### Acceptance Criteria
+
+1. WHEN 密码重置确认请求中的 token 未被找到、格式错误、已过期或已被使用，THE PasswordResetController SHALL 返回 Error_Code `VALIDATION_RESET_TOKEN_INVALID`
+2. WHEN 邮箱验证请求中的 token 未被找到、格式错误、已过期或已被使用，THE EmailVerificationController SHALL 返回 Error_Code `VALIDATION_VERIFICATION_TOKEN_INVALID`
+3. THE PasswordResetController SHALL 对"未被找到""格式错误""已过期""已被使用"四种原因返回完全相同的 Error_Code、HTTP 状态码与响应体结构，不做进一步区分
+4. THE EmailVerificationController SHALL 对"未被找到""格式错误""已过期""已被使用"四种原因返回完全相同的 Error_Code、HTTP 状态码与响应体结构，不做进一步区分
+
+### Requirement 6: 限流拒绝响应体 Envelope 化
+
+**User Story:** 作为 API 调用方，我希望被限流拒绝时收到的响应体格式与其他错误响应一致（结构化 JSON），以便我的客户端代码能用同一套逻辑处理所有错误。
+
+#### Acceptance Criteria
+
+1. WHEN Hodor 限流插件拒绝一个请求，THE Application SHALL 返回符合 Error_Envelope 格式的 JSON 响应体
+2. WHEN Hodor 限流插件拒绝一个请求，THE Application SHALL 在该响应体中使用 Error_Code `VALIDATION_RATE_LIMITED`
+3. WHEN Hodor 限流插件拒绝一个请求，THE Application SHALL 返回 HTTP 状态码 429
+4. IF Hodor 插件在启动时未加载，THEN THE Application SHALL 完成正常启动流程并进入可接受请求的状态，不因插件未加载而中止启动
+5. IF Hodor 插件在启动时未加载，THEN THE Application SHALL 不保证限流拒绝响应符合 Error_Envelope 格式、使用 Error_Code `VALIDATION_RATE_LIMITED` 或返回 HTTP 状态码 429
+6. IF Application 无法确定 Hodor 插件是否已加载，THEN THE Application SHALL 继续正常启动并进入可接受请求的状态，不因该不确定性中止启动流程
+7. IF Application 无法确定 Hodor 插件是否已加载，THEN THE Application SHALL 不保证限流拒绝响应符合 Error_Envelope 格式、使用 Error_Code `VALIDATION_RATE_LIMITED` 或返回 HTTP 状态码 429
+
+### Requirement 7: 账户锁定防枚举行为保留
+
+**User Story:** 作为安全负责人，我希望账户锁定期间的登录失败提示与普通密码错误在响应上完全不可区分，以防止攻击者借此枚举出哪些用户名对应已存在账户。
+
+#### Acceptance Criteria
+
+1. WHILE 用户账户处于锁定期内，WHEN 该账户收到一次登录尝试（无论本次提交的密码是否正确），THE AuthService SHALL 返回 Error_Code `AUTH_INVALID_CREDENTIALS`
+2. THE AuthService SHALL 对"账户锁定期内的登录尝试"与"密码错误的登录尝试"返回完全相同的 Error_Code、HTTP 状态码与响应体结构，其中响应体中除 Request_ID 字段外的其余字段值与结构必须逐一相同；Request_ID 字段因每个请求唯一而允许不同，不计入该一致性比较
+
+### Requirement 8: 新增 Error_Catalog 条目的合法性
+
+**User Story:** 作为维护错误码目录的开发者，我希望本特性新增的错误码条目遵循既有目录的段位规则与字段完整性约束，以保持目录的一致性与可扩展性。
+
+#### Acceptance Criteria
+
+1. THE Error_Catalog SHALL 包含以下 9 条本特性新增的条目：`VALIDATION_USERNAME_TAKEN`（3006）、`VALIDATION_EMAIL_TAKEN`（3007）、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`（3008）、`VALIDATION_RESET_TOKEN_INVALID`（3009）、`VALIDATION_VERIFICATION_TOKEN_INVALID`（3010）、`VALIDATION_DEVICE_CODE_INVALID`（3011）、`VALIDATION_RATE_LIMITED`（3012）、`AUTH_MFA_CODE_INVALID`（4004）、`AUTH_MFA_NOT_CONFIGURED`（4005）
+2. THE Error_Catalog SHALL 为每条新增条目分配落在其所属 Error_Category 对应段位区间内（VALIDATION 3000-3099，AUTHENTICATION 4000-4099）且与目录中既有条目及本特性新增的其他条目均不重复的 numeric_code
+3. THE Error_Catalog SHALL 为每条新增条目提供非空、不包含 Internal_Detail 的默认 Client_Safe_Message
+4. WHERE 新增条目为 `VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED` 或 `VALIDATION_RATE_LIMITED`，THE Error_Catalog SHALL 分别以 409、409、409、429 作为该 Error_Code 的响应状态码 override
+5. WHERE 新增条目为 `VALIDATION_RESET_TOKEN_INVALID`、`VALIDATION_VERIFICATION_TOKEN_INVALID`、`VALIDATION_DEVICE_CODE_INVALID`、`AUTH_MFA_CODE_INVALID` 或 `AUTH_MFA_NOT_CONFIGURED`，THE Error_Catalog SHALL 不为其定义 HTTP 状态码 override，并使用该条目所属 Error_Category 的默认状态码作为响应状态码
+6. THE Error_Catalog SHALL 保持本特性新增前既有条目的 code、numeric_code 与顺序不变
+
+### Requirement 9: 前端消息目录同步
+
+**User Story:** 作为使用 OAuth2Frontend 或 OAuth2Admin 的用户，我希望后端新增的错误码在前端界面上都有对应的中文提示，而不是显示原始错误码或空白信息。
+
+#### Acceptance Criteria
+
+1. THE OAuth2Frontend 的 Error_Message_Catalog_FE（zh-CN）SHALL 为 `VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`、`VALIDATION_RESET_TOKEN_INVALID`、`VALIDATION_VERIFICATION_TOKEN_INVALID`、`VALIDATION_DEVICE_CODE_INVALID`、`VALIDATION_RATE_LIMITED`、`AUTH_MFA_CODE_INVALID`、`AUTH_MFA_NOT_CONFIGURED` 各提供一条非空、且文案不等于该 Error_Code 字符串本身的本地化词条
+2. THE OAuth2Admin 的 Error_Message_Catalog_FE（zh-CN）SHALL 为 `VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`、`VALIDATION_RESET_TOKEN_INVALID`、`VALIDATION_VERIFICATION_TOKEN_INVALID`、`VALIDATION_DEVICE_CODE_INVALID`、`VALIDATION_RATE_LIMITED`、`AUTH_MFA_CODE_INVALID`、`AUTH_MFA_NOT_CONFIGURED` 各提供一条非空、且文案不等于该 Error_Code 字符串本身的本地化词条
+3. FOR ALL 本特性新增的 Error_Code，OAuth2Frontend 与 OAuth2Admin 两个 Error_Message_Catalog_FE 中对应词条的文案 SHALL 逐字符完全相同
+4. THE OAuth2Frontend 与 OAuth2Admin 的 Error_Message_Catalog_FE SHALL 使新增的本地化词条不包含 Internal_Detail

--- a/.kiro/specs/auth-flow-error-code-gaps/tasks.md
+++ b/.kiro/specs/auth-flow-error-code-gaps/tasks.md
@@ -1,0 +1,144 @@
+# Implementation Plan: auth-flow-error-code-gaps
+
+## Overview
+
+This plan implements the 9 new `Error_Catalog` entries, routes 7 backend gaps (G1-G6, G7-as-regression) to precise error codes, syncs the two frontend `zh-CN.ts` localization catalogs, and adds the property-based and regression tests defined in the design's Testing Strategy. Work proceeds catalog-first (so downstream controller changes have valid codes to reference), then gap-by-gap through the backend controllers/services, then the frontend catalogs, then the Hodor integration (isolated as its own batch per the design's risk note), with checkpoints between major groups.
+
+## Tasks
+
+- [ ] 1. Add 9 new entries to Error_Catalog
+  - [ ] 1.1 Append new RawEntry rows to ErrorCatalog
+    - Append the 9 `RawEntry` rows (`VALIDATION_USERNAME_TAKEN` 3006, `VALIDATION_EMAIL_TAKEN` 3007, `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` 3008, `VALIDATION_RESET_TOKEN_INVALID` 3009, `VALIDATION_VERIFICATION_TOKEN_INVALID` 3010, `VALIDATION_DEVICE_CODE_INVALID` 3011, `VALIDATION_RATE_LIMITED` 3012, `AUTH_MFA_CODE_INVALID` 4004, `AUTH_MFA_NOT_CONFIGURED` 4005) to `rawEntries()` in `OAuth2Plugin/src/error/ErrorCatalog.cc`, resizing the backing `std::array<RawEntry, N>` from 16 to 25
+    - Do not modify, reorder, or renumber any existing entries
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 8.6_
+
+- [ ] 2. Checkpoint - Ensure catalog tests pass
+  - Run the existing `ErrorCatalogPropertyTest.cc` and `ErrorCatalogDocTest.cc` (inherited Property 5 coverage) to confirm the 9 new entries satisfy segment range, uniqueness, and field-completeness rules automatically. Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 3. Implement G1: registration duplicate username/email routing
+  - [ ] 3.1 Change `AuthService::RegisterCallback` signature and insert-failure routing
+    - Update the callback typedef in `AuthService.h` from free-text error message to structured `errorCode` string (empty = success)
+    - In `AuthService.cc::registerUser`, in the `DrogonDbException` catch branch, match `e.base().what()` against `users_username_key` and `idx_users_email_unique` substrings to invoke the callback with `VALIDATION_USERNAME_TAKEN`, `VALIDATION_EMAIL_TAKEN`, or the existing fallback `VALIDATION_INVALID_INPUT`, with username-conflict checked first
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+  - [ ] 3.2 Update SessionController registration callback to forward the code
+    - In `SessionController.cc::registerUser`'s failure callback (~line 846), replace the hardcoded `respondError(req, callback, "VALIDATION_INVALID_INPUT", ...)` with direct forwarding of the received `errorCode` string to `Error_Responder`, with no text inspection or hardcoded fallback; treat an empty string as success and skip calling `Error_Responder`
+    - _Requirements: 1.6, 1.7_
+  - [ ]* 3.3 Write property test for registration failure routing
+    - **Property 1: 注册失败原因到 Error_Code 的精确路由**
+    - **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7**
+  - [ ]* 3.4 Write regression tests for registration duplicate username/email
+    - Duplicate username → HTTP 409 + `VALIDATION_USERNAME_TAKEN`
+    - Duplicate email → HTTP 409 + `VALIDATION_EMAIL_TAKEN`
+    - _Requirements: 1.1, 1.2_
+
+- [ ] 4. Implement G2: MFA verification failure routing
+  - [ ] 4.1 Route MfaController verifySetup failure branches to precise codes
+    - In `MfaController.cc::verifySetup`, change the "not yet configured" branch (~line 150) to use `AUTH_MFA_NOT_CONFIGURED` and the TOTP-mismatch branch (~line 164) to use `AUTH_MFA_CODE_INVALID`, changing only the `code` argument passed to `respondError`
+    - _Requirements: 2.1, 2.2_
+  - [ ]* 4.2 Write property test for MFA verification routing
+    - **Property 2: MFA 校验失败原因到 Error_Code 的精确路由**
+    - **Validates: Requirements 2.1, 2.2**
+  - [ ]* 4.3 Write regression tests for MFA verification failures
+    - MFA code incorrect → `AUTH_MFA_CODE_INVALID`
+    - MFA not configured → `AUTH_MFA_NOT_CONFIGURED`
+    - _Requirements: 2.1, 2.2_
+
+- [ ] 5. Implement G3: WebAuthn duplicate credential routing
+  - [ ] 5.1 Detect credential_id conflict in WebAuthnController registerFinish
+    - In `WebAuthnController.cc::registerFinish` (~line 215), in the insert's `DrogonDbException` handler, match `e.base().what()` for `webauthn_credentials` and `credential_id` substrings; on match respond with `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` (HTTP 409) and return before falling through; otherwise keep the existing `DB_QUERY_ERROR` fallback
+    - Ensure the existing credential record is left unmodified when a conflict is detected (no update/overwrite path is taken)
+    - _Requirements: 3.1, 3.2, 3.3_
+  - [ ]* 5.2 Write property test for WebAuthn registration failure routing
+    - **Property 3: WebAuthn 凭据注册失败原因到 Error_Code 的精确路由**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+  - [ ]* 5.3 Write regression test for WebAuthn duplicate credential
+    - Duplicate credential_id registration → HTTP 409 + `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`
+    - _Requirements: 3.1_
+
+- [ ] 6. Implement G4: device authorization code invalidity routing
+  - [ ] 6.1 Route DeviceAuthController approveDevice not-affected branch
+    - In `DeviceAuthController.cc::approveDevice` (~line 259), change the `result.affectedRows() == 0` branch's code from `VALIDATION_INVALID_INPUT` to `VALIDATION_DEVICE_CODE_INVALID`, keeping the single-code behavior for "not found"/"already processed"/"expired" and leaving the device authorization record's state unchanged
+    - _Requirements: 4.1, 4.2, 4.3_
+  - [ ]* 6.2 Write property test for device code indistinguishability
+    - **Property 4: 设备授权码失效原因的不可区分性**
+    - **Validates: Requirements 4.1, 4.2, 4.3**
+  - [ ]* 6.3 Write regression test for device code reuse/expiry
+    - Reused or expired device code → `VALIDATION_DEVICE_CODE_INVALID`
+    - _Requirements: 4.1_
+
+- [ ] 7. Implement G5: password reset and email verification token invalidity routing
+  - [ ] 7.1 Route PasswordResetController confirm token-invalid branch
+    - In `PasswordResetController.cc::confirm`, change the invalid-token branch's code to `VALIDATION_RESET_TOKEN_INVALID`, preserving the existing anti-enumeration behavior of not distinguishing "not found"/"malformed"/"expired"/"used"
+    - _Requirements: 5.1, 5.3_
+  - [ ] 7.2 Route EmailVerificationController verify token-invalid branch
+    - In `EmailVerificationController.cc::verify`, change the invalid-token branch's code to `VALIDATION_VERIFICATION_TOKEN_INVALID`, preserving the same anti-enumeration behavior
+    - _Requirements: 5.2, 5.4_
+  - [ ]* 7.3 Write property test for password reset token indistinguishability
+    - **Property 5: 密码重置 token 失效原因的不可区分性**
+    - **Validates: Requirements 5.1, 5.3**
+  - [ ]* 7.4 Write property test for email verification token indistinguishability
+    - **Property 6: 邮箱验证 token 失效原因的不可区分性**
+    - **Validates: Requirements 5.2, 5.4**
+  - [ ]* 7.5 Write regression tests for reset/verification token invalidity
+    - Invalid/expired/used reset token → `VALIDATION_RESET_TOKEN_INVALID`
+    - Invalid/expired/used verification token → `VALIDATION_VERIFICATION_TOKEN_INVALID`
+    - _Requirements: 5.1, 5.2_
+
+- [ ] 8. Add G7 regression test for account lockout anti-enumeration (no code change)
+  - [ ]* 8.1 Write regression test asserting lockout and wrong-password responses are identical
+    - Explicitly assert that a login attempt during account lockout and a login attempt with a wrong password both return `AUTH_INVALID_CREDENTIALS` with identical HTTP status and response body structure (excluding Request_ID), fixing this invariant against future accidental "fixes"
+    - _Requirements: 7.1, 7.2_
+  - [ ]* 8.2 Write property test for account lockout / wrong password indistinguishability
+    - **Property 7: 账户锁定与密码错误的防枚举不可区分性**
+    - **Validates: Requirements 7.1, 7.2**
+
+- [ ] 9. Checkpoint - Ensure all backend controller/service tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 10. Sync frontend localization catalogs
+  - [ ] 10.1 Add new error code entries to OAuth2Frontend zh-CN catalog
+    - Append the 9 key-value pairs (`VALIDATION_USERNAME_TAKEN`, `VALIDATION_EMAIL_TAKEN`, `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`, `VALIDATION_RESET_TOKEN_INVALID`, `VALIDATION_VERIFICATION_TOKEN_INVALID`, `VALIDATION_DEVICE_CODE_INVALID`, `VALIDATION_RATE_LIMITED`, `AUTH_MFA_CODE_INVALID`, `AUTH_MFA_NOT_CONFIGURED`) to `OAuth2Frontend/src/services/messages/zh-CN.ts` using the exact wording specified in the design's Frontend Design section
+    - _Requirements: 9.1, 9.4_
+  - [ ] 10.2 Add identical entries to OAuth2Admin zh-CN catalog
+    - Append the same 9 key-value pairs, character-for-character identical to the OAuth2Frontend entries, to `OAuth2Admin/src/services/messages/zh-CN.ts`
+    - _Requirements: 9.2, 9.3, 9.4_
+  - [ ]* 10.3 Verify existing frontend property tests cover the new entries
+    - Run the existing `messageCatalog.property.test.ts` (inherited Property 13/14 coverage) to confirm it passes with the new entries with no test code changes needed
+    - _Requirements: 9.1, 9.2, 9.3_
+
+- [ ] 11. Checkpoint - Ensure frontend catalog tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 12. Implement G6: Hodor rate-limit rejection Envelope wiring
+  - [ ] 12.1 Wire Hodor rejection response to Error_Envelope format
+    - In `OAuth2Server/main.cc`, after the existing Hodor plugin load-status check, if `drogon::app().getPlugin<drogon::plugin::Hodor>()` returns non-null, call its reject-response customization hook to build the response via `common::error::Error::fromCode("VALIDATION_RATE_LIMITED", requestId)` and `common::error::ErrorResponder::buildResponse`, replacing Hodor's plain-text rejection body
+    - Verify the actual `drogon::plugin::Hodor` header for the correct hook name/signature before wiring; if no equivalent hook exists, implement the rejection Envelope in a custom filter layer instead
+    - Guard the wiring so it only executes when the plugin is confirmed loaded; skip silently otherwise so startup is never blocked or aborted by plugin absence or indeterminate load state
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7_
+  - [ ]* 12.2 Write regression test for rate-limit rejection Envelope
+    - Triggered rate-limited request → JSON Error Envelope body, `VALIDATION_RATE_LIMITED` code, HTTP 429
+    - _Requirements: 6.1, 6.2, 6.3_
+
+- [ ] 13. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP; they are not implemented by the coding agent by default.
+- Task 1 must complete before any gap-routing task (3-8) since those tasks reference the new Error_Codes.
+- Task 12 (G6) is deliberately sequenced after all controller-level gaps and isolated as its own group, per the design's note that global plugin wiring carries higher risk and should ship as an independent batch.
+- Requirement 8 and 9's data-shape/coverage properties (inherited Property 5, 13, 14 from `error-code-message-standardization`) are validated automatically by existing test suites once the new catalog entries and localization keys are added; no new property test code is needed for them (see tasks 2 and 10.3).
+- Each task references specific requirements for traceability.
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["3.1", "4.1", "5.1", "6.1", "7.1", "7.2", "8.1", "8.2", "10.1", "10.2"] },
+    { "id": 2, "tasks": ["3.2", "3.3", "3.4", "4.2", "4.3", "5.2", "5.3", "6.2", "6.3", "7.3", "7.4", "7.5", "10.3", "12.1"] },
+    { "id": 3, "tasks": ["12.2"] }
+  ]
+}
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,10 @@ scripts/backend/build.bat [-debug]                                              
 ### Run Server
 
 ```bash
-./manage.sh run-backend    # Linux/macOS
-./manage.ps1 run-backend   # Windows
+./manage.sh run-backend           # Linux/macOS (Release)
+./manage.sh run-backend -debug    # Linux/macOS (Debug)
+./manage.ps1 run-backend          # Windows (Release)
+./manage.ps1 run-backend -debug   # Windows (Debug)
 # Or directly: build/OAuth2Server/{Debug|Release}/OAuth2Server -c config.json
 ```
 
@@ -34,8 +36,8 @@ scripts/backend/build.bat [-debug]                                              
 
 ```bash
 # C++ unit/integration tests (ctest)
-./manage.sh test-backend          # Linux/macOS
-./manage.ps1 test-backend         # Windows
+./manage.sh test-backend          # Linux/macOS (Release)
+./manage.ps1 test-backend         # Windows (Release)
 cd build && ctest --output-on-failure   # Direct ctest
 
 # Run specific test categories
@@ -50,8 +52,8 @@ scripts/backend/test-admin-endpoints.ps1    # Admin API (37 tests)
 scripts/backend/test-oauth2-endpoints.ps1   # OAuth2 core (17 tests)
 
 # Full cycle (build + unit tests + API tests)
-./manage.sh full-test     # Linux/macOS
-./manage.ps1 full-test    # Windows
+./manage.sh full-test     # Linux/macOS (Release)
+./manage.ps1 full-test    # Windows (Release)
 ```
 
 ### Frontend
@@ -59,10 +61,13 @@ scripts/backend/test-oauth2-endpoints.ps1   # OAuth2 core (17 tests)
 ```bash
 # Admin console (OAuth2Admin)
 cd OAuth2Admin && npm install && npm run dev          # Dev server at localhost:5174/admin/
-cd OAuth2Admin && npx playwright test                  # E2E tests
+cd OAuth2Admin && npx playwright test                 # E2E tests
+cd OAuth2Admin && npm run test:unit                   # unit tests
 
 # User frontend (OAuth2Frontend)
 cd OAuth2Frontend && npm install && npm run dev        # Dev server at localhost:5173
+cd OAuth2Frontend && npx playwright test               # E2E tests
+cd OAuth2Frontend && npm run test:unit                 # unit tests
 ```
 
 ### Docker

--- a/OAuth2Admin/src/services/messages/zh-CN.ts
+++ b/OAuth2Admin/src/services/messages/zh-CN.ts
@@ -35,6 +35,18 @@ export const zhCN: Record<string, string> = {
   AUTHZ_INSUFFICIENT_PERMISSIONS: '权限不足',
   INTERNAL_ERROR: '服务器内部错误',
 
+  // --- auth-flow-error-code-gaps: 9 new backend Error_Codes ---
+  // Mirror of OAuth2Frontend/src/services/messages/zh-CN.ts (Requirement 9.3).
+  VALIDATION_USERNAME_TAKEN: '该用户名已被注册',
+  VALIDATION_EMAIL_TAKEN: '该邮箱已被注册',
+  VALIDATION_CREDENTIAL_ALREADY_REGISTERED: '该安全密钥已注册，无需重复添加',
+  VALIDATION_RESET_TOKEN_INVALID: '重置链接已失效，请重新申请',
+  VALIDATION_VERIFICATION_TOKEN_INVALID: '验证链接已失效，请重新发送邮件',
+  VALIDATION_DEVICE_CODE_INVALID: '设备码无效、已过期或已被处理',
+  VALIDATION_RATE_LIMITED: '请求过于频繁，请稍后重试',
+  AUTH_MFA_CODE_INVALID: '验证码不正确',
+  AUTH_MFA_NOT_CONFIGURED: '尚未设置双重验证，请先完成设置',
+
   // --- OAuth2 / RFC 6749 protocol error codes ---
   invalid_request: '请求参数缺失或无效',
   invalid_client: '客户端认证失败',

--- a/OAuth2Frontend/src/services/messages/zh-CN.ts
+++ b/OAuth2Frontend/src/services/messages/zh-CN.ts
@@ -35,6 +35,20 @@ export const zhCN: Record<string, string> = {
   AUTHZ_INSUFFICIENT_PERMISSIONS: '权限不足',
   INTERNAL_ERROR: '服务器内部错误',
 
+  // --- auth-flow-error-code-gaps: 9 new backend Error_Codes ---
+  // Wording is kept character-for-character identical to OAuth2Admin's
+  // zh-CN.ts (Requirement 9.3) and must equal the catalog's default
+  // Client_Safe_Message (Requirement 9.4).
+  VALIDATION_USERNAME_TAKEN: '该用户名已被注册',
+  VALIDATION_EMAIL_TAKEN: '该邮箱已被注册',
+  VALIDATION_CREDENTIAL_ALREADY_REGISTERED: '该安全密钥已注册，无需重复添加',
+  VALIDATION_RESET_TOKEN_INVALID: '重置链接已失效，请重新申请',
+  VALIDATION_VERIFICATION_TOKEN_INVALID: '验证链接已失效，请重新发送邮件',
+  VALIDATION_DEVICE_CODE_INVALID: '设备码无效、已过期或已被处理',
+  VALIDATION_RATE_LIMITED: '请求过于频繁，请稍后重试',
+  AUTH_MFA_CODE_INVALID: '验证码不正确',
+  AUTH_MFA_NOT_CONFIGURED: '尚未设置双重验证，请先完成设置',
+
   // --- OAuth2 / RFC 6749 protocol error codes ---
   invalid_request: '请求参数缺失或无效',
   invalid_client: '客户端认证失败',

--- a/OAuth2Plugin/src/error/ErrorCatalog.cc
+++ b/OAuth2Plugin/src/error/ErrorCatalog.cc
@@ -60,9 +60,9 @@ struct RawEntry
 // Existing 14 numeric error codes: integer values preserved unchanged
 // (Requirement 3.6 / 11.5). New codes, when added during migration, must keep
 // their numeric value inside the owning category segment.
-const std::array<RawEntry, 16> &rawEntries()
+const std::array<RawEntry, 25> &rawEntries()
 {
-    static const std::array<RawEntry, 16> kEntries = {{
+    static const std::array<RawEntry, 25> kEntries = {{
       // NETWORK (1000-1099)
       {"NET_CONNECTION_FAILED",
        1001,
@@ -156,6 +156,62 @@ const std::array<RawEntry, 16> &rawEntries()
        ErrorCategory::INTERNAL,
        "服务器内部错误",
        "服务器内部错误（INTERNAL 类）"},
+
+      // --- auth-flow-error-code-gaps: 9 new entries appended below. Existing
+      // entries (code/numeric/order) are preserved unchanged (Requirement 8.6).
+      // VALIDATION (3000-3099) —— 注册/登录/凭据/token/设备码/限流补充缺口
+      // (G1, G3, G5, G6).
+      {"VALIDATION_USERNAME_TAKEN",
+       3006,
+       ErrorCategory::VALIDATION,
+       "该用户名已被注册",
+       "注册时用户名重复（VALIDATION 类，HTTP 409）",
+       409},
+      {"VALIDATION_EMAIL_TAKEN",
+       3007,
+       ErrorCategory::VALIDATION,
+       "该邮箱已被注册",
+       "注册时邮箱重复（VALIDATION 类，HTTP 409）",
+       409},
+      {"VALIDATION_CREDENTIAL_ALREADY_REGISTERED",
+       3008,
+       ErrorCategory::VALIDATION,
+       "该安全密钥已注册，无需重复添加",
+       "WebAuthn 凭据重复注册（VALIDATION 类，HTTP 409）",
+       409},
+      {"VALIDATION_RESET_TOKEN_INVALID",
+       3009,
+       ErrorCategory::VALIDATION,
+       "重置链接已失效，请重新申请",
+       "密码重置 token 无效/过期/已用（VALIDATION 类）"},
+      {"VALIDATION_VERIFICATION_TOKEN_INVALID",
+       3010,
+       ErrorCategory::VALIDATION,
+       "验证链接已失效，请重新发送邮件",
+       "邮箱验证 token 无效/过期/已用（VALIDATION 类）"},
+      {"VALIDATION_DEVICE_CODE_INVALID",
+       3011,
+       ErrorCategory::VALIDATION,
+       "设备码无效、已过期或已被处理",
+       "设备授权 user_code 未找到/已处理/已过期（VALIDATION 类）"},
+      {"VALIDATION_RATE_LIMITED",
+       3012,
+       ErrorCategory::VALIDATION,
+       "请求过于频繁，请稍后重试",
+       "Hodor 限流拒绝（VALIDATION 类，HTTP 429）",
+       429},
+
+      // AUTHENTICATION (4000-4099) —— MFA 补充缺口 (G2a, G2b).
+      {"AUTH_MFA_CODE_INVALID",
+       4004,
+       ErrorCategory::AUTHENTICATION,
+       "验证码不正确",
+       "MFA TOTP 校验失败（AUTHENTICATION 类）"},
+      {"AUTH_MFA_NOT_CONFIGURED",
+       4005,
+       ErrorCategory::AUTHENTICATION,
+       "尚未设置双重验证，请先完成设置",
+       "用户尚未完成 MFA 设置（AUTHENTICATION 类）"},
     }};
     return kEntries;
 }

--- a/OAuth2Plugin/src/error/ErrorResponder.cc
+++ b/OAuth2Plugin/src/error/ErrorResponder.cc
@@ -18,8 +18,8 @@ namespace
 
 // Map a numeric HTTP status (as registered in the ErrorCatalog) to the
 // drogon::HttpStatusCode enum. Covers every status the Application catalog can
-// register (400/401/403/404/409/500/502/503/504); anything unexpected defaults
-// to 500 Internal Server Error, keeping the function total.
+// register (400/401/403/404/409/429/500/502/503/504); anything unexpected
+// defaults to 500 Internal Server Error, keeping the function total.
 drogon::HttpStatusCode toDrogonStatus(int httpStatus)
 {
     switch (httpStatus)
@@ -34,6 +34,8 @@ drogon::HttpStatusCode toDrogonStatus(int httpStatus)
             return drogon::k404NotFound;
         case 409:
             return drogon::k409Conflict;
+        case 429:
+            return drogon::k429TooManyRequests;
         case 502:
             return drogon::k502BadGateway;
         case 503:

--- a/OAuth2Server/AuthService.cc
+++ b/OAuth2Server/AuthService.cc
@@ -182,11 +182,11 @@ void AuthService::registerUser(
   const std::string &username,
   const std::string &password,
   const std::string &email,
-  std::function<void(const std::string &error)> &&callback
+  std::function<void(const std::string &errorCode)> &&callback
 )
 {
     auto sharedCb =
-      std::make_shared<std::function<void(const std::string &error)>>(std::move(callback));
+      std::make_shared<std::function<void(const std::string &errorCode)>>(std::move(callback));
     // Hash Password with Argon2id
     std::string salt = "";  // Argon2id embeds its own salt
     std::string passwordHash;
@@ -197,7 +197,7 @@ void AuthService::registerUser(
     catch (const std::exception &e)
     {
         LOG_ERROR << "Password hashing failed: " << e.what();
-        (*sharedCb)("Internal Server Error");
+        (*sharedCb)("INTERNAL_ERROR");
         return;
     }
 
@@ -271,16 +271,24 @@ void AuthService::registerUser(
               }
           },
           [sharedCb](const DrogonDbException &e) {
-              LOG_ERROR << "Register Failed: " << e.base().what();
-              // Usually duplicate username
-              (*sharedCb)("Registration Failed (Username likely exists)");
+              const std::string what = e.base().what();
+              LOG_ERROR << "Register Failed: " << what;
+              // Map the failing DB constraint to a structured Error_Code so the
+              // controller can forward it verbatim. Username conflict is checked
+              // before email so a simultaneous conflict reports username first.
+              if (what.find("users_username_key") != std::string::npos)
+                  (*sharedCb)("VALIDATION_USERNAME_TAKEN");
+              else if (what.find("idx_users_email_unique") != std::string::npos)
+                  (*sharedCb)("VALIDATION_EMAIL_TAKEN");
+              else
+                  (*sharedCb)("VALIDATION_INVALID_INPUT");  // unrecognized constraint
           }
         );
     }
     catch (const DrogonDbException &e)
     {
         LOG_ERROR << "Register Init Failed: " << e.base().what();
-        (*sharedCb)("Internal Server Error");
+        (*sharedCb)("INTERNAL_ERROR");
     }
 }
 

--- a/OAuth2Server/AuthService.h
+++ b/OAuth2Server/AuthService.h
@@ -35,13 +35,15 @@ class AuthService
 
     /**
      * @brief Async register a new user
-     * @param callback Returns empty string on success, error message on failure
+     * @param callback Invoked with an empty string on success, or a structured
+     *                 Error_Code (registered in ErrorCatalog) on failure. The
+     *                 caller forwards the value verbatim to ErrorResponder.
      */
     static void registerUser(
       const std::string &username,
       const std::string &password,
       const std::string &email,
-      std::function<void(const std::string &error)> &&callback
+      std::function<void(const std::string &errorCode)> &&callback
     );
 
     /**

--- a/OAuth2Server/controllers/DeviceAuthController.cc
+++ b/OAuth2Server/controllers/DeviceAuthController.cc
@@ -255,11 +255,14 @@ void DeviceAuthController::approveDevice(
       [sharedCb, userCode, req](const drogon::orm::Result &result) {
           if (result.affectedRows() == 0)
           {
-              // Either not found, already approved/denied, or expired
+              // Either not found, already approved/denied, or expired. All three
+              // reasons collapse to a single code (no way to distinguish them in
+              // the response) and the device code's existing status is left
+              // unchanged because the UPDATE matched no rows.
               respondError(
                 req,
                 sharedCb,
-                "VALIDATION_INVALID_INPUT",
+                "VALIDATION_DEVICE_CODE_INVALID",
                 "approveDevice: invalid, expired, or already processed user_code"
               );
               return;

--- a/OAuth2Server/controllers/EmailVerificationController.cc
+++ b/OAuth2Server/controllers/EmailVerificationController.cc
@@ -134,8 +134,14 @@ void EmailVerificationController::verify(
       [sharedCb, db, req](const Result &r) {
           if (r.empty())
           {
+              // Empty result covers all four failure causes (not found /
+              // malformed / expired / already used); they are deliberately not
+              // distinguished to prevent token-enumeration attacks.
               respondError(
-                req, sharedCb, "VALIDATION_INVALID_INPUT", "verify: token is invalid or expired"
+                req,
+                sharedCb,
+                "VALIDATION_VERIFICATION_TOKEN_INVALID",
+                "verify: token is invalid or expired"
               );
               return;
           }

--- a/OAuth2Server/controllers/MfaController.cc
+++ b/OAuth2Server/controllers/MfaController.cc
@@ -150,7 +150,7 @@ void MfaController::verifySetup(
               respondError(
                 req,
                 sharedCb,
-                "VALIDATION_INVALID_INPUT",
+                "AUTH_MFA_NOT_CONFIGURED",
                 "verifySetup: MFA not set up. Call /api/me/mfa/setup first"
               );
               return;
@@ -162,7 +162,7 @@ void MfaController::verifySetup(
           if (!oauth2::utils::TotpUtils::verifyCode(secret, code))
           {
               respondError(
-                req, sharedCb, "AUTH_INVALID_CREDENTIALS", "verifySetup: TOTP code is incorrect"
+                req, sharedCb, "AUTH_MFA_CODE_INVALID", "verifySetup: TOTP code is incorrect"
               );
               return;
           }

--- a/OAuth2Server/controllers/PasswordResetController.cc
+++ b/OAuth2Server/controllers/PasswordResetController.cc
@@ -240,10 +240,13 @@ void PasswordResetController::confirm(
       [sharedCb, newPassword, db, req](const Result &r) {
           if (r.empty())
           {
+              // Empty result covers all four failure causes (not found /
+              // malformed / expired / already used); they are deliberately not
+              // distinguished to prevent token-enumeration attacks.
               respondError(
                 req,
                 sharedCb,
-                "VALIDATION_INVALID_INPUT",
+                "VALIDATION_RESET_TOKEN_INVALID",
                 "password-reset confirm: token is invalid, expired, or already used"
               );
               return;

--- a/OAuth2Server/controllers/SessionController.cc
+++ b/OAuth2Server/controllers/SessionController.cc
@@ -831,8 +831,8 @@ void SessionController::registerUser(
     }
 
     AuthService::registerUser(
-      username, password, email, [callback, email, req](const std::string &error) {
-          if (error.empty())
+      username, password, email, [callback, email, req](const std::string &errorCode) {
+          if (errorCode.empty())
           {
               Json::Value json;
               json["message"] = "User registered successfully";
@@ -843,8 +843,11 @@ void SessionController::registerUser(
           }
           else
           {
+              // Forward the structured Error_Code from AuthService verbatim to
+              // ErrorResponder — no text inspection or hardcoded fallback
+              // (Requirement 1.6).
               respondError(
-                req, callback, "VALIDATION_INVALID_INPUT", "registerUser failed: " + error
+                req, callback, errorCode, "registerUser failed: " + errorCode
               );
           }
       }

--- a/OAuth2Server/controllers/WebAuthnController.cc
+++ b/OAuth2Server/controllers/WebAuthnController.cc
@@ -213,11 +213,27 @@ void WebAuthnController::registerFinish(
           (*sharedCb)(resp);
       },
       [sharedCb, req](const DrogonDbException &e) {
+          const std::string what = e.base().what();
+          // A credential_id unique-constraint conflict means the user is adding
+          // the same security key twice — respond with a precise conflict code
+          // (HTTP 409) instead of the generic "service unavailable" DB code, and
+          // leave the existing credential record untouched (Requirement 3.3).
+          if (what.find("webauthn_credentials") != std::string::npos &&
+              what.find("credential_id") != std::string::npos)
+          {
+              respondError(
+                req,
+                sharedCb,
+                "VALIDATION_CREDENTIAL_ALREADY_REGISTERED",
+                std::string("registerFinish: duplicate credential_id: ") + what
+              );
+              return;
+          }
           respondError(
             req,
             sharedCb,
             "DB_QUERY_ERROR",
-            std::string("registerFinish: failed to store credential: ") + e.base().what()
+            std::string("registerFinish: failed to store credential: ") + what
           );
       },
       userId,

--- a/OAuth2Server/main.cc
+++ b/OAuth2Server/main.cc
@@ -269,13 +269,26 @@ int main()
     );
 
     // Report Hodor status after plugins have been initialized. Hodor is loaded
-    // only by production configuration.
+    // only by production configuration. When present, also wire its rejection
+    // response factory so rate-limited requests get the standard Error Envelope
+    // (VALIDATION_RATE_LIMITED / HTTP 429) instead of Hodor's plain-text body.
+    // If the plugin is absent or its load state cannot be determined, startup
+    // proceeds normally and rate-limit Envelope semantics are simply not
+    // guaranteed (Requirements 6.4-6.7).
     drogon::app().registerBeginningAdvice([]() {
         try
         {
             auto hodor = drogon::app().getPlugin<drogon::plugin::Hodor>();
             if (hodor)
+            {
+                hodor->setRejectResponseFactory([](const drogon::HttpRequestPtr &req) {
+                    common::error::Error error = common::error::Error::fromCode(
+                      "VALIDATION_RATE_LIMITED", common::error::RequestId::resolve(req)
+                    );
+                    return common::error::ErrorResponder::buildResponse(req, error);
+                });
                 LOG_INFO << "Hodor rate limiter enabled";
+            }
             else
                 LOG_INFO << "Hodor rate limiter not enabled by this config";
         }

--- a/OAuth2Server/test/unit/error/ErrorCatalogPropertyTest.cc
+++ b/OAuth2Server/test/unit/error/ErrorCatalogPropertyTest.cc
@@ -341,9 +341,14 @@ int httpStatusOverrideFor(const CatalogEntry &e)
     {
         return 404;
     }
-    if (e.code == "VALIDATION_RESOURCE_CONFLICT")
+    if (e.code == "VALIDATION_RESOURCE_CONFLICT" || e.code == "VALIDATION_USERNAME_TAKEN" ||
+        e.code == "VALIDATION_EMAIL_TAKEN" || e.code == "VALIDATION_CREDENTIAL_ALREADY_REGISTERED")
     {
         return 409;
+    }
+    if (e.code == "VALIDATION_RATE_LIMITED")
+    {
+        return 429;
     }
     return 0;
 }

--- a/OAuth2Server/test/unit/error/ErrorCatalogRegressionTest.cc
+++ b/OAuth2Server/test/unit/error/ErrorCatalogRegressionTest.cc
@@ -55,9 +55,10 @@ DROGON_TEST(Unit_P0_ErrorCatalog_Regression_ExistingNumericCodesUnchanged)
     // The 14 pre-existing codes above keep their integer values (verified in the
     // loop). 方案 A adds exactly 2 resource-oriented VALIDATION codes
     // (VALIDATION_RESOURCE_NOT_FOUND/CONFLICT, Requirement 11.4) to preserve the
-    // pre-migration 404/409 statuses, for a total of 16 registered Application
-    // codes; no others may be introduced silently.
-    CHECK(ErrorCatalog::allEntries().size() == kExpected.size() + 2);
+    // pre-migration 404/409 statuses. The auth-flow-error-code-gaps feature adds
+    // a further 9 codes (G1-G6), for a total of 25 registered Application codes;
+    // no others may be introduced silently.
+    CHECK(ErrorCatalog::allEntries().size() == kExpected.size() + 2 + 9);
 }
 
 // --- Requirement 3.6: every Application numeric code falls inside its segment.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ docker-compose up -d
 
 # 2. Start backend (requires PostgreSQL + Redis)
 cd OAuth2Server
-..\build\OAuth2Server\Debug\OAuth2Server.exe
+..\build\OAuth2Server\Release\OAuth2Server.exe
 
 # 3. Start admin console
 cd OAuth2Admin

--- a/docs/backend/api-reference.md
+++ b/docs/backend/api-reference.md
@@ -217,7 +217,7 @@ Authorization: `Bearer {access_token}`
 
 ### 5.1 应用错误码 (Application Error Codes)
 
-业务端点（Application_Endpoint）返回统一的 Error Envelope，其 `error.code` 取值属于下表登记的 Error_Code 集合；`numeric_code` 与 `category` 同样取自下表，HTTP 状态码按 Error_Category（NETWORK 类按 numeric_code 区分 502/504）一致映射。少数面向资源语义的 VALIDATION 码（`VALIDATION_RESOURCE_NOT_FOUND` → 404、`VALIDATION_RESOURCE_CONFLICT` → 409）通过条目级显式覆盖保留迁移前的 HTTP 状态码（方案 A / 需求 11.4），其余 VALIDATION 码仍为 400。
+业务端点（Application_Endpoint）返回统一的 Error Envelope，其 `error.code` 取值属于下表登记的 Error_Code 集合；`numeric_code` 与 `category` 同样取自下表，HTTP 状态码按 Error_Category（NETWORK 类按 numeric_code 区分 502/504）一致映射。少数面向资源语义的 VALIDATION 码通过条目级显式覆盖保留迁移前的 HTTP 状态码（方案 A / 需求 11.4）：`VALIDATION_RESOURCE_NOT_FOUND` → 404，资源已存在/冲突类（`VALIDATION_RESOURCE_CONFLICT`、`VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`）→ 409，`VALIDATION_RATE_LIMITED` → 429；其余 VALIDATION 码仍为 400。
 
 | Error_Code | numeric_code | Error_Category | HTTP Status | 默认信息 (Client_Safe_Message) |
 |---|---|---|---|---|
@@ -231,9 +231,18 @@ Authorization: `Bearer {access_token}`
 | `VALIDATION_FORMAT_ERROR` | 3003 | VALIDATION | 400 | 格式不正确 |
 | `VALIDATION_RESOURCE_NOT_FOUND` | 3004 | VALIDATION | 404 | 资源不存在 |
 | `VALIDATION_RESOURCE_CONFLICT` | 3005 | VALIDATION | 409 | 资源已存在或冲突 |
+| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | 该用户名已被注册 |
+| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | 该邮箱已被注册 |
+| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | 该安全密钥已注册，无需重复添加 |
+| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400 | 重置链接已失效，请重新申请 |
+| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400 | 验证链接已失效，请重新发送邮件 |
+| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400 | 设备码无效、已过期或已被处理 |
+| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | 请求过于频繁，请稍后重试 |
 | `AUTH_INVALID_CREDENTIALS` | 4001 | AUTHENTICATION | 401 | 用户名或密码错误 |
 | `AUTH_TOKEN_EXPIRED` | 4002 | AUTHENTICATION | 401 | 登录已过期 |
 | `AUTH_TOKEN_INVALID` | 4003 | AUTHENTICATION | 401 | 登录凭证无效 |
+| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401 | 验证码不正确 |
+| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401 | 尚未设置双重验证，请先完成设置 |
 | `AUTHZ_ACCESS_DENIED` | 5001 | AUTHORIZATION | 403 | 没有访问权限 |
 | `AUTHZ_INSUFFICIENT_PERMISSIONS` | 5002 | AUTHORIZATION | 403 | 权限不足 |
 | `INTERNAL_ERROR` | 6001 | INTERNAL | 500 | 服务器内部错误 |


### PR DESCRIPTION
## 概述

修复 `error-code-message-standardization` 发版后遗留的认证流错误信息缺口：注册 / MFA / WebAuthn / 设备授权 / 密码重置 / 邮箱验证 / 限流等控制器把多种不同失败原因折叠进同一个笼统 `Error_Code`（多为 `VALIDATION_INVALID_INPUT`），导致用户看不出具体失败原因（如注册时看不出是用户名冲突还是邮箱冲突）。

实现依据 `.kiro/specs/auth-flow-error-code-gaps/`（requirements / design / tasks）。

## 改动内容

### 新增 9 条 Error_Catalog 条目（Req 8）
| code | numeric | HTTP |
|---|---|---|
| `VALIDATION_USERNAME_TAKEN` | 3006 | 409 |
| `VALIDATION_EMAIL_TAKEN` | 3007 | 409 |
| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | 409 |
| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | 400 |
| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | 400 |
| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | 400 |
| `VALIDATION_RATE_LIMITED` | 3012 | 429 |
| `AUTH_MFA_CODE_INVALID` | 4004 | 401 |
| `AUTH_MFA_NOT_CONFIGURED` | 4005 | 401 |

### 后端 gap 路由（G1–G5）
- **G1 注册**：`AuthService::registerUser` 回调从自由文本改为结构化 `errorCode`；按 DB 约束名（`users_username_key` / `idx_users_email_unique`）路由到精确冲突码（用户名冲突优先），未识别约束兜底 `VALIDATION_INVALID_INPUT`；基础设施失败改用 `INTERNAL_ERROR`。`SessionController` 直接转发 `errorCode`，不再硬编码回退。
- **G2 MFA**：`MfaController::verifySetup` 未配置 → `AUTH_MFA_NOT_CONFIGURED`，TOTP 错误 → `AUTH_MFA_CODE_INVALID`。
- **G3 WebAuthn**：`registerFinish` 检测 `credential_id` 唯一约束冲突 → `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`，否则保留 `DB_QUERY_ERROR`。
- **G4 设备授权**：`approveDevice` 的 `affectedRows()==0` → `VALIDATION_DEVICE_CODE_INVALID`。
- **G5 token**：密码重置 / 邮箱验证 token 失效 → 专用码，保留防枚举行为（不区分未找到/已过期/已用）。

### G6 Hodor 限流 Envelope 化
`main.cc` 在确认 Hodor 加载后调用 `setRejectResponseFactory`，用 `ErrorResponder::buildResponse` + `VALIDATION_RATE_LIMITED` 取代纯文本拒绝体；插件未加载时跳过，不阻断启动（Req 6.4–6.7）。

**关键缺陷修复**：`ErrorResponder::toDrogonStatus` 原 switch 不支持 HTTP 429（落入 default → 500），新增 `case 429: k429TooManyRequests`，这是 `VALIDATION_RATE_LIMITED` 能返回正确 429 的前提。

### 前端同步（Req 9）
`OAuth2Frontend` / `OAuth2Admin` 的 `zh-CN.ts` 各追加相同的 9 条词条（跨应用逐字一致）。

### G7 账户锁定（刻意保留，未改动）
`AuthService::validateUser` 锁定分支继续返回与密码错误相同的 `AUTH_INVALID_CREDENTIALS`，用于防止用户名枚举。

### 计划执行中发现并修复的必要同步
- `docs/backend/api-reference.md` §5.1：追加 9 行表格 + 更新 override 说明段
- `ErrorCatalogPropertyTest::httpStatusOverrideFor()`：加入 4 个新 override 码
- `ErrorCatalogRegressionTest`：总数断言 16 → 25

## 验证

| 测试套件 | 结果 |
|---|---|
| 后端 `./manage.ps1 full-test -debug`（8 步全流程） | ✅ 8/8 步通过 |
| 后端单元测试 | ✅ 243 cases / 56872 assertions |
| 后端 OAuth2 + Admin API（真实服务器） | ✅ 全过 |
| OAuth2Frontend `npm run test:unit`（vitest） | ✅ 4 files / 15 tests |
| OAuth2Frontend `npx playwright test`（E2E） | ✅ 98 passed |
| OAuth2Admin `npm run test:unit`（vitest） | ✅ 1 file / 2 tests |
| OAuth2Admin `npx playwright test`（E2E） | ✅ 163 passed / 6 skipped |

**0 失败**。G6 Hodor 接线 + ErrorResponder 429 支持 + 各控制器路由在真实运行时环境与两个前端真实浏览器环境下均无回归。

## 注意

- G7（账户锁定防枚举）按设计保留不改，仅通过既有测试固化不变量。
- 本 PR 含一个独立 commit (`e24907c`) 更新 `CLAUDE.md` / `README.md` 的构建/测试命令说明（标注 Debug/Release、补充前端测试入口），与错误码特性无功能关联，但属同一开发周期产物。