### PR TITLE
build: first-party warning governance (W4 / Wall+Wextra) with CI WERROR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
             runs_on: ubuntu-22.04
             cmake_preset: linux-release
             preset_dir: build/linux-release
+            configure_extra_args: "-DAUTHFORGE_WERROR=ON"
             use_database: true
             use_ci_config: false
             run_named_test_gates: true
@@ -99,6 +100,7 @@ jobs:
             runs_on: windows-2022
             cmake_preset: windows-msvc
             preset_dir: build/windows-msvc
+            configure_extra_args: "-DAUTHFORGE_WERROR=ON"
             use_database: false
             use_ci_config: true
             run_named_test_gates: true
@@ -113,7 +115,7 @@ jobs:
             cmake_preset: macos-arm64
             preset_dir: build/macos-arm64
             conan_extra_settings: "-s arch=armv8"
-            configure_extra_args: "-DOAUTH2_MEMORY_TESTS_ONLY=ON"
+            configure_extra_args: "-DOAUTH2_MEMORY_TESTS_ONLY=ON -DAUTHFORGE_WERROR=ON"
             use_database: false
             use_ci_config: true
             run_named_test_gates: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(Version)
 include(Compatibility)
 include(Sanitizers)
+# Warnings.cmake provides oauth2_apply_warnings(target) (/W4 resp.
+# -Wall -Wextra, PRIVATE only) plus the AUTHFORGE_WERROR option (default
+# OFF; the CI pipeline passes -DAUTHFORGE_WERROR=ON). Applied per-target
+# inside each libs/*, apps/server and tests CMakeLists.
+include(Warnings)
 # Paths.cmake parses the top-level paths.env (single source of truth for
 # source/build/SQL/config paths, review H2) and exposes OAUTH2_PATH_* vars.
 include(Paths)

--- a/apps/server/CMakeLists.txt
+++ b/apps/server/CMakeLists.txt
@@ -66,6 +66,9 @@ endif()
 # Compiler compatibility (shared module)
 oauth2_apply_compat(${PROJECT_NAME})
 
+# First-party warning level (shared module, included from the repo root)
+oauth2_apply_warnings(${PROJECT_NAME})
+
 # Copy Swagger UI to build directory (repo-root docs/, two levels up from
 # apps/server/)
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -47,6 +47,14 @@ function(oauth2_apply_warnings target)
             -Wextra
             -Wno-missing-field-initializers
         )
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            # -Wno-unused-lambda-capture (Clang-only diagnostic): the async
+            # Drogon callback chains routinely over-capture (req/plugin/ids
+            # kept for lifetime clarity); ~50 sites fire this with zero
+            # behavioural impact and neither MSVC /W4 nor GCC checks it.
+            # Silenced as noise; targeted cleanup can revisit per-site.
+            target_compile_options(${target} PRIVATE -Wno-unused-lambda-capture)
+        endif()
         if(AUTHFORGE_WERROR)
             target_compile_options(${target} PRIVATE -Werror)
         endif()

--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -38,7 +38,15 @@ function(oauth2_apply_warnings target)
             target_compile_options(${target} PRIVATE /WX)
         endif()
     else()
-        target_compile_options(${target} PRIVATE -Wall -Wextra)
+        # -Wno-missing-field-initializers: -Wextra flags designated/partial
+        # aggregate init (e.g. the OpenAPI descriptor structs), but the
+        # remaining members are value-initialized per the standard, so this
+        # subset is pure noise rather than a defect signal.
+        target_compile_options(${target} PRIVATE
+            -Wall
+            -Wextra
+            -Wno-missing-field-initializers
+        )
         if(AUTHFORGE_WERROR)
             target_compile_options(${target} PRIVATE -Werror)
         endif()

--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -1,0 +1,46 @@
+# cmake/Warnings.cmake
+# Warning-level governance for first-party targets (warning phase 2).
+#
+# Provides function oauth2_apply_warnings(target) which raises the warning
+# level on FIRST-PARTY code only:
+#   - MSVC:      /W4, plus /external:anglebrackets /external:W0 so headers
+#                pulled in from Conan dependencies (Drogon/Trantor/OpenSSL/
+#                jsoncpp) do not add third-party noise at /W4
+#   - GCC/Clang: -Wall -Wextra (third-party includes already arrive as
+#                SYSTEM includes via the imported targets, so they are
+#                exempt from these flags)
+#
+# Option AUTHFORGE_WERROR (default OFF) additionally promotes warnings to
+# errors (/WX resp. -Werror). It stays OFF for local developer builds; the
+# CI presets turn it ON now that the warning baseline is clean.
+#
+# Function-style (NOT an INTERFACE library) for the same reason as
+# oauth2_apply_compat in Compatibility.cmake: an INTERFACE target that is
+# PRIVATE-linked into the exported static libs would be dragged into
+# install(EXPORT) and pollute the authforge-*Config.cmake consumer surface.
+# All flags below are PRIVATE and leave zero footprint on SDK consumers.
+
+option(AUTHFORGE_WERROR
+    "Treat compiler warnings as errors on first-party AuthForge targets" OFF)
+
+function(oauth2_apply_warnings target)
+    if(NOT TARGET ${target})
+        message(FATAL_ERROR "oauth2_apply_warnings: target '${target}' does not exist")
+    endif()
+
+    if(MSVC)
+        target_compile_options(${target} PRIVATE
+            /W4
+            /external:anglebrackets
+            /external:W0
+        )
+        if(AUTHFORGE_WERROR)
+            target_compile_options(${target} PRIVATE /WX)
+        endif()
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra)
+        if(AUTHFORGE_WERROR)
+            target_compile_options(${target} PRIVATE -Werror)
+        endif()
+    endif()
+endfunction()

--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -23,6 +23,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-common VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -55,6 +58,9 @@ endif()
 # use ORM-generated code; keeps compile flags (e.g. /utf-8 on MSVC)
 # consistent across every target in the tree.
 oauth2_apply_compat(${PROJECT_NAME})
+
+# First-party warning level (shared module); PRIVATE, no SDK-consumer leak.
+oauth2_apply_warnings(${PROJECT_NAME})
 
 # --- arch-guard note (enforced by tooling in a later M6 task, Task 33) ---
 # This target must never gain a Drogon dependency. There is no automated

--- a/libs/common/testing/CMakeLists.txt
+++ b/libs/common/testing/CMakeLists.txt
@@ -31,6 +31,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-common-testing VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -53,6 +56,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC authforge::common OpenSSL::Crypto)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 oauth2_apply_compat(${PROJECT_NAME})
+oauth2_apply_warnings(${PROJECT_NAME})
 
 # --- arch-guard note (see libs/common/CMakeLists.txt's identical note) ---
 # This target must never gain a Drogon dependency either -- manually

--- a/libs/drogon/CMakeLists.txt
+++ b/libs/drogon/CMakeLists.txt
@@ -52,6 +52,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-drogon VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -148,6 +151,7 @@ endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 oauth2_apply_compat(${PROJECT_NAME})
+oauth2_apply_warnings(${PROJECT_NAME})
 
 include(GNUInstallDirs)
 install(DIRECTORY include/authforge DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/libs/drogon/src/AuthService.cc
+++ b/libs/drogon/src/AuthService.cc
@@ -332,7 +332,7 @@ void AuthService::getUserInfo(
                 Criteria(
                   drogon_model::oauth2_db::UserRoles::Cols::_user_id, CompareOperator::EQ, userId
                 ),
-                [sharedCb, db, user, userId](
+                [sharedCb, db, user](
                   const std::vector<drogon_model::oauth2_db::UserRoles> &userRoles
                 ) {
                     if (userRoles.empty())

--- a/libs/drogon/src/controllers/DeviceAuthController.cc
+++ b/libs/drogon/src/controllers/DeviceAuthController.cc
@@ -255,11 +255,6 @@ void DeviceAuthController::approveDevice(
         return;
     }
 
-    auto now = std::chrono::duration_cast<std::chrono::seconds>(
-                 std::chrono::system_clock::now().time_since_epoch()
-    )
-                 .count();
-
     // Task B5: replaced raw UPDATE SQL with DeviceCodeService
     ::authforge::drogon::services::DeviceCodeService::findByUserCode(
       userCode,

--- a/libs/drogon/src/controllers/DiscoveryController.cc
+++ b/libs/drogon/src/controllers/DiscoveryController.cc
@@ -55,7 +55,7 @@ void DiscoveryController::initApiDocsImpl()
 }
 
 void DiscoveryController::metadata(
-  const ::drogon::HttpRequestPtr &req,
+  const ::drogon::HttpRequestPtr & /*req*/,
   std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 )
 {
@@ -150,7 +150,7 @@ void DiscoveryController::metadata(
 }
 
 void DiscoveryController::oidcDiscovery(
-  const ::drogon::HttpRequestPtr &req,
+  const ::drogon::HttpRequestPtr & /*req*/,
   std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 )
 {
@@ -222,7 +222,7 @@ void DiscoveryController::oidcDiscovery(
 }
 
 void DiscoveryController::jwks(
-  const ::drogon::HttpRequestPtr &req,
+  const ::drogon::HttpRequestPtr & /*req*/,
   std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 )
 {

--- a/libs/drogon/src/controllers/GitHubController.cc
+++ b/libs/drogon/src/controllers/GitHubController.cc
@@ -380,7 +380,7 @@ void GitHubController::login(
                                subject,
                                req](const std::vector<Oauth2SubjectMappings> &mappings) {
                                   auto issueTokens = [this, callbackPtr, req](
-                                                       int userId, const std::string &username
+                                                       int userId, const std::string & /*username*/
                                                      ) {
                                       // Issue access_token and refresh_token
                                       auto plugin = resolvePlugin();

--- a/libs/drogon/src/controllers/HealthController.cc
+++ b/libs/drogon/src/controllers/HealthController.cc
@@ -12,7 +12,7 @@ OAuth2Plugin *HealthController::resolvePlugin() const
 }
 
 void HealthController::health(
-  const ::drogon::HttpRequestPtr &req,
+  const ::drogon::HttpRequestPtr & /*req*/,
   std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 )
 {
@@ -56,7 +56,7 @@ void HealthController::health(
 }
 
 void HealthController::healthLive(
-  const ::drogon::HttpRequestPtr &req,
+  const ::drogon::HttpRequestPtr & /*req*/,
   std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 )
 {
@@ -68,7 +68,7 @@ void HealthController::healthLive(
 }
 
 void HealthController::healthReady(
-  const ::drogon::HttpRequestPtr &req,
+  const ::drogon::HttpRequestPtr & /*req*/,
   std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 )
 {

--- a/libs/drogon/src/plugin/OAuth2CleanupService.cc
+++ b/libs/drogon/src/plugin/OAuth2CleanupService.cc
@@ -139,7 +139,7 @@ void OAuth2CleanupService::runCleanup()
                   LOG_ERROR << "Error during OAuth2 cleanup: " << e.what();
               }
           },
-          [weakSelf](const std::exception &e) {
+          [weakSelf](const std::exception & /*e*/) {
               auto self = weakSelf.lock();
               if (!self || !self->running_)
                   return;

--- a/libs/drogon/src/services/IdentityService.cc
+++ b/libs/drogon/src/services/IdentityService.cc
@@ -58,7 +58,9 @@ void IdentityService::ensureSubjectMapping(
     repos_.subjectMapping->getInternalUserId(
       sub,
       provider,
-      [self, this, sub, provider, internalUserId, callback = std::move(callback)](
+      // init-captures: plain capture of structured bindings is a C++20
+      // extension (AppleClang -Wc++20-extensions), copies are C++17-clean
+      [self, this, sub = sub, provider = provider, internalUserId, callback = std::move(callback)](
         auto existingUserId
       ) {
           if (existingUserId)
@@ -101,7 +103,10 @@ void IdentityService::handleFirstTimeLogin(
     repos_.subjectMapping->createUserForExternalLogin(
       sub,
       prov,
-      [self, this, sub, prov, callback = std::move(callback)](std::optional<int32_t> newUserId) {
+      // init-captures: see note above on structured bindings vs C++17
+      [self, this, sub = sub, prov = prov, callback = std::move(callback)](
+        std::optional<int32_t> newUserId
+      ) {
           if (!newUserId || *newUserId == 0)
           {
               LOG_ERROR << "Failed to create user for external login: " << prov << ":" << sub;

--- a/libs/drogon/src/validation/RuleEngine.cc
+++ b/libs/drogon/src/validation/RuleEngine.cc
@@ -214,8 +214,8 @@ Result RuleEngine::validateToken(const std::string &token)
 }
 
 std::vector<Result> RuleEngine::validateAll(
-  const std::vector<std::pair<std::string, std::string>> &fieldsAndValues,
-  const std::vector<RuleType> &rules
+  const std::vector<std::pair<std::string, std::string>> & /*fieldsAndValues*/,
+  const std::vector<RuleType> & /*rules*/
 )
 {
     std::vector<Result> results;

--- a/libs/identity/CMakeLists.txt
+++ b/libs/identity/CMakeLists.txt
@@ -104,6 +104,15 @@ if(WITH_SOCIAL)
     target_compile_definitions(authforge-identity PUBLIC WITH_SOCIAL)
 endif()
 
+# First-party warning level (shared module, same convention as the other
+# libs/*). Guarded for the standalone-configure path, mirroring the
+# oauth2_apply_compat guard before add_subdirectory(test) below.
+if(NOT COMMAND oauth2_apply_warnings)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+    include(Warnings)
+endif()
+oauth2_apply_warnings(authforge-identity)
+
 # Install rules
 install(DIRECTORY include/
     DESTINATION include

--- a/libs/identity/include/authforge/identity/ISubjectMappingRepository.h
+++ b/libs/identity/include/authforge/identity/ISubjectMappingRepository.h
@@ -69,11 +69,13 @@ class ISubjectMappingRepository
      * registration flows need before createSubjectMapping.
      */
     virtual void createUserForExternalLogin(
-      const std::string & /*externalId*/,
-      const std::string & /*provider*/,
+      const std::string &externalId,
+      const std::string &provider,
       OptionalIntCallback &&cb
     )
     {
+        (void)externalId;
+        (void)provider;
         cb(std::nullopt);
     }
 };

--- a/libs/identity/include/authforge/identity/ISubjectMappingRepository.h
+++ b/libs/identity/include/authforge/identity/ISubjectMappingRepository.h
@@ -69,8 +69,8 @@ class ISubjectMappingRepository
      * registration flows need before createSubjectMapping.
      */
     virtual void createUserForExternalLogin(
-      const std::string &externalId,
-      const std::string &provider,
+      const std::string & /*externalId*/,
+      const std::string & /*provider*/,
       OptionalIntCallback &&cb
     )
     {

--- a/libs/oauth2/CMakeLists.txt
+++ b/libs/oauth2/CMakeLists.txt
@@ -27,6 +27,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-oauth2 VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -61,6 +64,7 @@ if(MSVC)
 endif()
 
 oauth2_apply_compat(${PROJECT_NAME})
+oauth2_apply_warnings(${PROJECT_NAME})
 
 # --- arch-guard note (see libs/common/CMakeLists.txt's identical note) ---
 # This target must never gain a Drogon dependency, and must never depend

--- a/libs/storage-memory/CMakeLists.txt
+++ b/libs/storage-memory/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-storage-memory VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -52,6 +55,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Drogon::Drogon JsonCpp::JsonCpp aut
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 oauth2_apply_compat(${PROJECT_NAME})
+oauth2_apply_warnings(${PROJECT_NAME})
 
 include(GNUInstallDirs)
 install(DIRECTORY include/authforge DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/libs/storage-memory/src/MemoryIdentityRepository.cc
+++ b/libs/storage-memory/src/MemoryIdentityRepository.cc
@@ -115,7 +115,7 @@ void MemoryIdentityRepository::findByPublicSub(
 }
 
 void MemoryIdentityRepository::findByEmail(
-  const std::string &email,
+  const std::string & /*email*/,
   std::function<void(std::optional<UserData>)> &&callback
 )
 {
@@ -123,7 +123,7 @@ void MemoryIdentityRepository::findByEmail(
 }
 
 void MemoryIdentityRepository::findByUsername(
-  const std::string &username,
+  const std::string & /*username*/,
   std::function<void(std::optional<UserData>)> &&callback
 )
 {
@@ -131,7 +131,7 @@ void MemoryIdentityRepository::findByUsername(
 }
 
 void MemoryIdentityRepository::create(
-  const UserData &userData,
+  const UserData & /*userData*/,
   std::function<void(std::optional<int32_t>, std::string)> &&callback
 )
 {
@@ -141,8 +141,8 @@ void MemoryIdentityRepository::create(
 }
 
 void MemoryIdentityRepository::updatePasswordHash(
-  int32_t userId,
-  const std::string &newHash,
+  int32_t /*userId*/,
+  const std::string & /*newHash*/,
   std::function<void(bool)> &&callback
 )
 {
@@ -150,7 +150,7 @@ void MemoryIdentityRepository::updatePasswordHash(
 }
 
 void MemoryIdentityRepository::resetFailedLogins(
-  int32_t userId,
+  int32_t /*userId*/,
   std::function<void(bool)> &&callback
 )
 {
@@ -158,7 +158,7 @@ void MemoryIdentityRepository::resetFailedLogins(
 }
 
 void MemoryIdentityRepository::incrementFailedLogins(
-  int32_t userId,
+  int32_t /*userId*/,
   std::function<void(bool)> &&callback
 )
 {

--- a/libs/storage-postgres/CMakeLists.txt
+++ b/libs/storage-postgres/CMakeLists.txt
@@ -34,6 +34,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-storage-postgres VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -57,6 +60,20 @@ target_include_directories(${PROJECT_NAME}
 
 file(GLOB AUTHFORGE_STORAGE_POSTGRES_SOURCES "src/models/*.cc")
 target_sources(${PROJECT_NAME} PRIVATE ${AUTHFORGE_STORAGE_POSTGRES_SOURCES})
+
+# The drogon_ctl ORM-generated model sources above are exempt from rewrite
+# (regeneration would lose any hand-edit), so the unused-parameter warnings
+# they emit at /W4 resp. -Wextra (e.g. updateArgs()'s unused `id` /
+# `isForCreation`) are silenced at the SOURCE level here instead of touching
+# generated code or lowering the warning level of the whole target -- the
+# handwritten Postgres*.cc sources below stay at full warning level.
+if(MSVC)
+    set_source_files_properties(${AUTHFORGE_STORAGE_POSTGRES_SOURCES}
+        PROPERTIES COMPILE_OPTIONS "/wd4100")
+else()
+    set_source_files_properties(${AUTHFORGE_STORAGE_POSTGRES_SOURCES}
+        PROPERTIES COMPILE_OPTIONS "-Wno-unused-parameter")
+endif()
 
 # Task 19: PostgresIdentityRepository.cc implements libs/identity's
 # repository interfaces (IUserRepository/IRoleRepository/
@@ -99,6 +116,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Drogon::Drogon authforge::identity 
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 oauth2_apply_compat(${PROJECT_NAME})
+oauth2_apply_warnings(${PROJECT_NAME})
 
 include(GNUInstallDirs)
 install(DIRECTORY include/authforge DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/libs/storage-postgres/CMakeLists.txt
+++ b/libs/storage-postgres/CMakeLists.txt
@@ -64,15 +64,17 @@ target_sources(${PROJECT_NAME} PRIVATE ${AUTHFORGE_STORAGE_POSTGRES_SOURCES})
 # The drogon_ctl ORM-generated model sources above are exempt from rewrite
 # (regeneration would lose any hand-edit), so the unused-parameter warnings
 # they emit at /W4 resp. -Wextra (e.g. updateArgs()'s unused `id` /
-# `isForCreation`) are silenced at the SOURCE level here instead of touching
-# generated code or lowering the warning level of the whole target -- the
-# handwritten Postgres*.cc sources below stay at full warning level.
+# `isForCreation`) and the deprecated std::codecvt usage flagged by Clang
+# (-Wdeprecated-declarations) are silenced at the SOURCE level here instead
+# of touching generated code or lowering the warning level of the whole
+# target -- the handwritten Postgres*.cc sources below stay at full warning
+# level.
 if(MSVC)
     set_source_files_properties(${AUTHFORGE_STORAGE_POSTGRES_SOURCES}
         PROPERTIES COMPILE_OPTIONS "/wd4100")
 else()
     set_source_files_properties(${AUTHFORGE_STORAGE_POSTGRES_SOURCES}
-        PROPERTIES COMPILE_OPTIONS "-Wno-unused-parameter")
+        PROPERTIES COMPILE_OPTIONS "-Wno-unused-parameter;-Wno-deprecated-declarations")
 endif()
 
 # Task 19: PostgresIdentityRepository.cc implements libs/identity's

--- a/libs/storage-postgres/src/PostgresGrantRepository.cc
+++ b/libs/storage-postgres/src/PostgresGrantRepository.cc
@@ -128,7 +128,7 @@ void PostgresGrantRepository::markAuthCodeUsed(const std::string &code, VoidCall
 
         mapper.update(
           updateObj,
-          [sharedCb](const size_t count) {
+          [sharedCb](const size_t /*count*/) {
               if (*sharedCb)
                   (*sharedCb)();
           },

--- a/libs/storage-postgres/src/PostgresIdentityRepository.cc
+++ b/libs/storage-postgres/src/PostgresIdentityRepository.cc
@@ -285,7 +285,7 @@ void PostgresIdentityRepository::updatePasswordHash(
     Mapper<Users> mapper(dbClient_);
     mapper.findBy(
       Criteria(Users::Cols::_id, CompareOperator::EQ, userId),
-      [sharedCb, userId, newHash, self = shared_from_this()](const std::vector<Users> &users) {
+      [sharedCb, newHash, self = shared_from_this()](const std::vector<Users> &users) {
           if (users.empty())
           {
               (*sharedCb)(false);
@@ -368,7 +368,7 @@ void PostgresIdentityRepository::incrementFailedLogins(
     Mapper<Users> mapper(dbClient_);
     mapper.findBy(
       Criteria(Users::Cols::_id, CompareOperator::EQ, userId),
-      [sharedCb, userId, self = shared_from_this()](const std::vector<Users> &users) {
+      [sharedCb, self = shared_from_this()](const std::vector<Users> &users) {
           int failedCount = users.empty() ? 0 : users[0].getValueOfFailedLoginCount();
           int newFailedCount = failedCount + 1;
           int64_t now = std::chrono::duration_cast<std::chrono::seconds>(

--- a/libs/storage-postgres/src/PostgresTokenRepository.cc
+++ b/libs/storage-postgres/src/PostgresTokenRepository.cc
@@ -606,7 +606,7 @@ void PostgresTokenRepository::revokeAccessToken(
     mapper.findOne(
       Criteria(Oauth2AccessTokens::Cols::_token, CompareOperator::EQ, token),
       [sharedCb, now, revokedBy, token, self = shared_from_this()](
-        const Oauth2AccessTokens &found
+        const Oauth2AccessTokens & /*found*/
       ) {
           Oauth2AccessTokens updated;
           updated.setToken(token);

--- a/libs/storage-postgres/src/PostgresTokenRepository.cc
+++ b/libs/storage-postgres/src/PostgresTokenRepository.cc
@@ -482,7 +482,7 @@ void PostgresTokenRepository::introspectToken(
     Mapper<Oauth2AccessTokens> atMapper(dbClientReader_);
     atMapper.findOne(
       Criteria(Oauth2AccessTokens::Cols::_token, CompareOperator::EQ, token),
-      [sharedCb, now, token, self = shared_from_this(), this](
+      [sharedCb, now, token, self = shared_from_this()](
         const Oauth2AccessTokens &accessToken
       ) {
           // 检查是否吊销或过期

--- a/libs/storage-redis/CMakeLists.txt
+++ b/libs/storage-redis/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 if(NOT COMMAND oauth2_apply_compat)
     include(Compatibility)
 endif()
+if(NOT COMMAND oauth2_apply_warnings)
+    include(Warnings)
+endif()
 
 project(authforge-storage-redis VERSION ${OAUTH2_PROJECT_VERSION} LANGUAGES CXX)
 
@@ -62,6 +65,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC Drogon::Drogon JsonCpp::JsonCpp aut
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 oauth2_apply_compat(${PROJECT_NAME})
+oauth2_apply_warnings(${PROJECT_NAME})
 
 include(GNUInstallDirs)
 install(DIRECTORY include/authforge DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/libs/storage-redis/src/RedisTokenRepository.cc
+++ b/libs/storage-redis/src/RedisTokenRepository.cc
@@ -152,13 +152,13 @@ void RedisTokenRepository::getAccessToken(const std::string &token, AccessTokenC
 
 // Verbatim preservation of RedisOAuth2Storage's no-op: Redis mode never
 // actually stored/retrieved refresh tokens.
-void RedisTokenRepository::saveRefreshToken(const OAuth2RefreshToken &token, VoidCallback &&cb)
+void RedisTokenRepository::saveRefreshToken(const OAuth2RefreshToken & /*token*/, VoidCallback &&cb)
 {
     if (cb)
         cb();
 }
 
-void RedisTokenRepository::getRefreshToken(const std::string &token, RefreshTokenCallback &&cb)
+void RedisTokenRepository::getRefreshToken(const std::string & /*token*/, RefreshTokenCallback &&cb)
 {
     if (cb)
         cb(std::nullopt);
@@ -325,7 +325,7 @@ void RedisTokenRepository::incrementIntrospectCount(const std::string &token, Vo
 
     std::string key = "oauth2:token:" + token;
     redisClient_->execCommandAsync(
-      [cb](const RedisResult &result) {
+      [cb](const RedisResult & /*result*/) {
           // Note: Redis doesn't have atomic increment for JSON fields
           // We need to get the JSON, update the field, and set it back
           // For now, this is a no-op in Redis storage to avoid race conditions

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,6 +127,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon OpenSSL::Crypto aut
 # Platform compatibility (shared module)
 oauth2_apply_compat(${PROJECT_NAME})
 
+# First-party warning level (shared module, included from the repo root)
+oauth2_apply_warnings(${PROJECT_NAME})
+
 # Optional TSan/ASan instrumentation (shared module).
 # Controlled by the cache option OAUTH2_SANITIZER = off|thread|address.
 # GCC/Clang + Debug only; TSan and ASan are mutually exclusive (two builds).

--- a/tests/e2e-backend/oauth2_flows/FunctionalTest.cc
+++ b/tests/e2e-backend/oauth2_flows/FunctionalTest.cc
@@ -402,7 +402,7 @@ DROGON_TEST(E2E_P1_RateLimit_DetectRateLimiting_Limited)
 
     // Rate limiting may or may not be triggered depending on configuration
     // The test verifies the mechanism exists
-    ;
+    (void)rateLimitDetected;
 }
 
 // ============================================================================

--- a/tests/e2e-backend/oauth2_flows/FunctionalTest.cc
+++ b/tests/e2e-backend/oauth2_flows/FunctionalTest.cc
@@ -368,6 +368,7 @@ DROGON_TEST(E2E_P1_Input_LongPassword_Handled)
 
 DROGON_TEST(E2E_P1_RateLimit_DetectRateLimiting_Limited)
 {
+    (void)TEST_CTX;
     // Test: Multiple rapid requests should trigger rate limiting
     // Expected: Should eventually return 429 Too Many Requests
 

--- a/tests/e2e-backend/oauth2_flows/OAuth2FlowE2ETest.cc
+++ b/tests/e2e-backend/oauth2_flows/OAuth2FlowE2ETest.cc
@@ -209,7 +209,7 @@ DROGON_TEST(E2E_P0_OAuth2Flow_AuthCode_Works)
             std::promise<HttpResponsePtr> p;
             auto f = p.get_future();
 
-            client->sendRequest(req, [&](ReqResult result, const HttpResponsePtr &resp) {
+            client->sendRequest(req, [&](ReqResult /*result*/, const HttpResponsePtr &resp) {
                 p.set_value(resp);
             });
 
@@ -322,6 +322,7 @@ DROGON_TEST(Integration_P0_Session_Management_Works)
 
 DROGON_TEST(Integration_P0_Client_Authentication_Works)
 {
+    (void)TEST_CTX;
     LOG_INFO << "=== E2E Test: Client Authentication ===";
 
     auto plugin = drogon::app().getPlugin<OAuth2Plugin>();

--- a/tests/integration/auth/LoginEnforcementTest.cc
+++ b/tests/integration/auth/LoginEnforcementTest.cc
@@ -87,7 +87,7 @@ DROGON_TEST(Integration_P1_Login_EmailVerification_Field)
           // Column exists and is readable
           pCheck.set_value(!r.empty());
       },
-      [&](const DrogonDbException &e) {
+      [&](const DrogonDbException & /*e*/) {
           // Column doesn't exist
           pCheck.set_value(false);
       }

--- a/tests/integration/concurrency/Property4_RbacDecisionBaselineTest.cc
+++ b/tests/integration/concurrency/Property4_RbacDecisionBaselineTest.cc
@@ -251,7 +251,7 @@ RealFilterResult driveRealFilterNoToken(const std::string &path)
 // {"error":"unauthorized"} for any path, before any RBAC/role evaluation.
 DROGON_TEST(Integration_P1_RealFilter_Property4_3_7_NoToken_Returns401_Baseline)
 {
-    for (const std::string &path :
+    for (const char *path :
          {"/api/admin/users", "/api/user/profile", "/random/unmatched/path", "/api/public/health"})
     {
         auto r = driveRealFilterNoToken(path);

--- a/tests/integration/plugin/P1FeatureTest.cc
+++ b/tests/integration/plugin/P1FeatureTest.cc
@@ -39,7 +39,7 @@ DROGON_TEST(Integration_P1_Features_General_Works)
           "",
           "",
           "",  // nonce
-          [&](bool success, std::string code, std::string error) {
+          [&](bool success, std::string code, std::string /*error*/) {
               codeP.set_value(success ? code : "");
           }
         );

--- a/tests/integration/plugin/PluginTest.cc
+++ b/tests/integration/plugin/PluginTest.cc
@@ -56,7 +56,7 @@ DROGON_TEST(Integration_P0_Plugin_General_Works)
           "",                     // codeChallenge (empty for non-PKCE test)
           "",                     // codeChallengeMethod (empty for non-PKCE test)
           "",                     // nonce
-          [&](bool success, std::string code, std::string error) {
+          [&](bool success, std::string code, std::string /*error*/) {
               if (success)
               {
                   p.set_value(code);
@@ -164,7 +164,7 @@ DROGON_TEST(Integration_P0_Plugin_General_Works)
           "",                     // codeChallenge (empty for non-PKCE test)
           "",                     // codeChallengeMethod (empty for non-PKCE test)
           "",                     // nonce
-          [&](bool success, std::string code, std::string error) {
+          [&](bool success, std::string code, std::string /*error*/) {
               if (success)
               {
                   p.set_value(code);

--- a/tests/integration/token/RefreshTokenReuseTest.cc
+++ b/tests/integration/token/RefreshTokenReuseTest.cc
@@ -32,7 +32,7 @@ DROGON_TEST(Integration_P0_RefreshToken_NormalRotation)
           "",
           "",
           "",  // nonce
-          [&](bool success, std::string code, std::string error) {
+          [&](bool success, std::string code, std::string /*error*/) {
               if (success)
                   p.set_value(code);
               else

--- a/tests/security/injection/DbLeakVerificationTest.cc
+++ b/tests/security/injection/DbLeakVerificationTest.cc
@@ -20,6 +20,7 @@ namespace db_leak_test
 
 DROGON_TEST(Security_P0_DbLeak_AuthServiceConnectionManagement_Verified)
 {
+    (void)TEST_CTX;
     // Skip this test in memory storage mode (no database)
     auto plugin = drogon::app().getPlugin<OAuth2Plugin>();
     if (plugin && plugin->getStorageType() == "memory")
@@ -36,8 +37,7 @@ DROGON_TEST(Security_P0_DbLeak_AuthServiceConnectionManagement_Verified)
     // [db, callback](const Users &u) { ... }
     // does NOT leak database connections
 
-    // Get initial connection count
-    int initialConnections = 0;
+    // Trigger an initial request to warm up the connection pool
     try
     {
         auto client = drogon::HttpClient::newHttpClient("http://127.0.0.1:5555");

--- a/tests/security/injection/SecurityTest.cc
+++ b/tests/security/injection/SecurityTest.cc
@@ -311,7 +311,7 @@ DROGON_TEST(Security_P1_RateLimit_DetectRateLimiting_Limited)
 
     // Rate limiting should be active (even if threshold is high)
     // This test verifies the mechanism exists
-    ;
+    (void)rateLimitDetected;
 }
 
 // ============================================================================

--- a/tests/security/injection/SecurityTest.cc
+++ b/tests/security/injection/SecurityTest.cc
@@ -138,6 +138,7 @@ DROGON_TEST(Security_P0_InputValidation_EmptyCredentials_Prevented)
 
 DROGON_TEST(Security_P0_Auth_InvalidCredentials_Rejected)
 {
+    (void)TEST_CTX;
     // Test: Login with completely invalid credentials
     // Expected: Should fail with error message
     std::string response = makeLoginRequest("invalid_user_xyz", "invalid_pass_xyz");
@@ -285,6 +286,7 @@ DROGON_TEST(Security_P1_Headers_HstsNotSetOnHttp_Present)
 
 DROGON_TEST(Security_P1_RateLimit_DetectRateLimiting_Limited)
 {
+    (void)TEST_CTX;
     // Test: Multiple rapid requests should trigger rate limiting
     // Expected: Should return 429 after threshold
     bool rateLimitDetected = false;

--- a/tests/unit/error/ErrorCatalogPropertyTest.cc
+++ b/tests/unit/error/ErrorCatalogPropertyTest.cc
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <random>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -31,6 +32,16 @@ using namespace authforge::common::error;
 
 namespace
 {
+
+// trantor's LogStream has no overload for iostream manipulators: streaming
+// std::hex would convert the function address to bool and print `1`
+// (AppleClang -Wpointer-bool-conversion). Pre-format the seed instead.
+std::string seedHex(unsigned int seed)
+{
+    std::ostringstream oss;
+    oss << std::hex << seed;
+    return oss.str();
+}
 
 // Category enum set membership (Error_Category): the 7 stable enum names.
 bool isKnownCategory(ErrorCategory category)
@@ -266,7 +277,7 @@ DROGON_TEST(Unit_P0_ErrorCatalog_Property5_RandomizedSamplingHoldsInvariants)
         if (!checkApplicationEntryInvariants(appEntry))
         {
             // Print the reproduction context: seed, iteration and offending index.
-            LOG_ERROR << "Property 5 failed: seed=0x" << std::hex << kSeed << std::dec
+            LOG_ERROR << "Property 5 failed: seed=0x" << seedHex(kSeed)
                       << " iteration=" << i << " appEntryIndex=" << appIdx
                       << " code=" << std::string(appEntry.code);
             FAULT(
@@ -282,7 +293,7 @@ DROGON_TEST(Unit_P0_ErrorCatalog_Property5_RandomizedSamplingHoldsInvariants)
                              oauthEntry.httpStatus <= 599 && !oauthEntry.defaultErrorDesc.empty();
         if (!oauthOk)
         {
-            LOG_ERROR << "Property 5 failed: seed=0x" << std::hex << kSeed << std::dec
+            LOG_ERROR << "Property 5 failed: seed=0x" << seedHex(kSeed)
                       << " iteration=" << i << " oauthEntryIndex=" << oauthIdx
                       << " error=" << std::string(oauthEntry.error);
             FAULT(
@@ -547,7 +558,7 @@ DROGON_TEST(Unit_P0_HttpStatus_Property4_RandomizedSamplingHoldsInvariants)
                         runtimeStatus == err.toHttpStatusCode();
         if (!ok)
         {
-            LOG_ERROR << "Property 4 failed: seed=0x" << std::hex << kSeed << std::dec
+            LOG_ERROR << "Property 4 failed: seed=0x" << seedHex(kSeed)
                       << " iteration=" << i << " entryIndex=" << idx
                       << " code=" << std::string(e.code) << " (" << categoryName(e.category)
                       << ", numeric " << e.numericCode << ") runtimeStatus=" << runtimeStatus

--- a/tests/unit/error/ErrorEnvelopePropertyTest.cc
+++ b/tests/unit/error/ErrorEnvelopePropertyTest.cc
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <memory>
 #include <random>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -47,6 +48,16 @@ using namespace authforge::common::error;
 // ============================================================================
 namespace
 {
+
+// trantor's LogStream has no overload for iostream manipulators: streaming
+// std::hex would convert the function address to bool and print `1`
+// (AppleClang -Wpointer-bool-conversion). Pre-format the seed instead.
+std::string seedHex(unsigned int seed)
+{
+    std::ostringstream oss;
+    oss << std::hex << seed;
+    return oss.str();
+}
 
 // Serialize a Json::Value to a compact string using JsonCpp's StreamWriter.
 // Matches the production write path (basic types only) so a round-trip through
@@ -162,8 +173,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
 {
     // Fixed, printable seed so any failure is reproducible.
     constexpr unsigned int kSeed = 0xE12C0DEu;
-    LOG_INFO << "Property 3 Error Envelope round-trip test, fixed seed=0x" << std::hex << kSeed
-             << std::dec;
+    LOG_INFO << "Property 3 Error Envelope round-trip test, fixed seed=0x" << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
 
@@ -188,7 +198,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
         const bool parsed = parseJson(wire, decoded);
         if (!parsed)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] round-trip parse failed for code=" << original.code
                       << " includeDetails=" << includeDetails << " wire=" << wire;
         }
@@ -203,7 +213,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
         // --- code preserved ---------------------------------------------------
         if (!err.isMember("code") || err["code"].asString() != original.code)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code mismatch: expected='" << original.code << "' got='"
                       << err["code"].asString() << "'";
         }
@@ -214,7 +224,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
         const std::string expectedCategory = toString(original.category);
         if (!err.isMember("category") || err["category"].asString() != expectedCategory)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] category mismatch for code=" << original.code << ": expected='"
                       << expectedCategory << "' got='" << err["category"].asString() << "'";
         }
@@ -224,7 +234,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
         // --- message preserved (verbatim, incl. escaped / non-ASCII content) --
         if (!err.isMember("message") || err["message"].asString() != original.message)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] message mismatch for code=" << original.code << ": expected='"
                       << original.message << "' got='" << err["message"].asString() << "'";
         }
@@ -234,7 +244,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
         // --- request_id preserved --------------------------------------------
         if (!err.isMember("request_id") || err["request_id"].asString() != original.requestId)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] request_id mismatch for code=" << original.code << ": expected='"
                       << original.requestId << "' got='" << err["request_id"].asString() << "'";
         }
@@ -246,7 +256,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property3_SerializationRoundTrip)
         const int expectedNumeric = original.numericCode();
         if (!err.isMember("numeric_code") || err["numeric_code"].asInt() != expectedNumeric)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] numeric_code mismatch for code=" << original.code
                       << ": expected=" << expectedNumeric
                       << " present=" << err.isMember("numeric_code")
@@ -286,8 +296,8 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
 {
     // Fixed, printable seed so any failure is reproducible.
     constexpr unsigned int kSeed = 0x51'70C0DEu;
-    LOG_INFO << "Property 1 Error Envelope structural-invariant test, fixed seed=0x" << std::hex
-             << kSeed << std::dec;
+    LOG_INFO << "Property 1 Error Envelope structural-invariant test, fixed seed=0x"
+             << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
 
@@ -344,7 +354,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         REQUIRE(root.isObject());
         if (root.getMemberNames().size() != 1 || !root.isMember("error"))
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] top-level is not a single `error` key for code=" << code
                       << " keys=" << static_cast<int>(root.getMemberNames().size());
         }
@@ -358,7 +368,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         {
             if (kAllowedKeys.find(key) == kAllowedKeys.end())
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] code=" << code << " has disallowed key '" << key << "'";
             }
             CHECK(kAllowedKeys.find(key) != kAllowedKeys.end());
@@ -373,7 +383,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         const std::string codeValue = err["code"].asString();
         if (codeValue.empty() || registeredCodes.find(codeValue) == registeredCodes.end())
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code value not registered / empty: '" << codeValue << "'";
         }
         CHECK(!codeValue.empty());
@@ -385,7 +395,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         const std::string categoryValue = err["category"].asString();
         if (kCategorySet.find(categoryValue) == kCategorySet.end())
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " category not in enum set: '" << categoryValue
                       << "'";
         }
@@ -397,7 +407,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         const std::string messageValue = err["message"].asString();
         if (messageValue.empty() || messageValue.size() > 500)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code
                       << " message length out of [1,500]: " << messageValue.size();
         }
@@ -409,7 +419,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         REQUIRE(err["request_id"].isString());
         if (err["request_id"].asString().empty())
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " request_id is empty";
         }
         CHECK(!err["request_id"].asString().empty());
@@ -423,7 +433,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         REQUIRE(resp != nullptr);
         if (resp->contentType() != ::drogon::CT_APPLICATION_JSON)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " Content-Type is not application/json";
         }
         CHECK(resp->contentType() == ::drogon::CT_APPLICATION_JSON);
@@ -434,7 +444,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property1_StructuralInvariants)
         const bool parsed = parseJson(std::string(resp->getBody()), respRoot);
         if (!parsed)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " response body is not parseable JSON";
         }
         REQUIRE(parsed);
@@ -472,8 +482,8 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property2_NumericCodeCorrectnessAndOmission)
 {
     // Fixed, printable seed so any failure is reproducible.
     constexpr unsigned int kSeed = 0x2'4D'C0DEu;
-    LOG_INFO << "Property 2 numeric_code correctness/omission test, fixed seed=0x" << std::hex
-             << kSeed << std::dec;
+    LOG_INFO << "Property 2 numeric_code correctness/omission test, fixed seed=0x"
+             << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
 
@@ -538,7 +548,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property2_NumericCodeCorrectnessAndOmission)
             // equals the catalog entry's numeric code.
             if (!error.hasNumericCode() || error.numericCode() != entry.numericCode)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] PRESENT branch: code=" << code
                           << " hasNumericCode=" << error.hasNumericCode()
                           << " numericCode=" << error.numericCode()
@@ -558,7 +568,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property2_NumericCodeCorrectnessAndOmission)
               err["numeric_code"].asInt() != entry.numericCode
             )
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] PRESENT branch: code=" << code
                           << " present=" << err.isMember("numeric_code")
                           << " value=" << err["numeric_code"].asInt()
@@ -585,7 +595,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property2_NumericCodeCorrectnessAndOmission)
             // Unregistered -> hasNumericCode() is false.
             if (error.hasNumericCode())
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] OMISSION branch: code=" << code
                           << " unexpectedly reports hasNumericCode()=true";
             }
@@ -600,7 +610,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property2_NumericCodeCorrectnessAndOmission)
 
             if (err.isMember("numeric_code"))
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] OMISSION branch: code=" << code
                           << " unexpectedly has numeric_code key (isNull="
                           << err["numeric_code"].isNull() << ")";
@@ -649,8 +659,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property6_ProductionModeSafetyIsolation)
 {
     // Fixed, printable seed so any failure is reproducible.
     constexpr unsigned int kSeed = 0x6'5AFE'0DEu;
-    LOG_INFO << "Property 6 production-mode safety-isolation test, fixed seed=0x" << std::hex
-             << kSeed << std::dec;
+    LOG_INFO << "Property 6 production-mode safety-isolation test, fixed seed=0x" << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
 
@@ -750,7 +759,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property6_ProductionModeSafetyIsolation)
             const CatalogEntry *mapped = ErrorCatalog::find(error.code);
             if (mapped == nullptr)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] fromException produced UNREGISTERED code='" << error.code
                           << "' (hint category=" << toString(hint) << ")";
             }
@@ -774,7 +783,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property6_ProductionModeSafetyIsolation)
         const bool parsed = parseJson(std::string(resp->getBody()), respRoot);
         if (!parsed)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] buildResponse body is not parseable JSON for code=" << sourceCode;
         }
         REQUIRE(parsed);
@@ -799,7 +808,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property6_ProductionModeSafetyIsolation)
             // (a) Production_Mode: `details` is fully omitted (Requirement 5.1).
             if (err.isMember("details"))
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << " via=" << which << "] code=" << sourceCode
                           << " unexpectedly carries `details` in Production_Mode";
             }
@@ -811,7 +820,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property6_ProductionModeSafetyIsolation)
             REQUIRE(err["message"].isString());
             if (err["message"].asString() != expectedMessage)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << " via=" << which << "] code=" << sourceCode
                           << " message mismatch: expected catalog default='" << expectedMessage
                           << "' got='" << err["message"].asString() << "'";
@@ -832,7 +841,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property6_ProductionModeSafetyIsolation)
                 {
                     if (value.find(frag) != std::string::npos)
                     {
-                        LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                        LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                                   << " via=" << which << "] code=" << sourceCode << " field '"
                                   << key << "' leaked sensitive fragment '" << frag << "' (value='"
                                   << value << "')";
@@ -886,8 +895,8 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
 {
     // Fixed, printable seed so any failure is reproducible.
     constexpr unsigned int kSeed = 0x7DE7'A0DEu;
-    LOG_INFO << "Property 7 non-production diagnostic-details test, fixed seed=0x" << std::hex
-             << kSeed << std::dec;
+    LOG_INFO << "Property 7 non-production diagnostic-details test, fixed seed=0x"
+             << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
 
@@ -950,7 +959,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
                 // presence assertion below is meaningful.
                 if (error.details != diagnosticText)
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << "] fromException did not capture what() as details: code="
                               << sourceCode << " details='" << error.details << "' expected='"
                               << diagnosticText << "'";
@@ -969,7 +978,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             const bool parsed = parseJson(std::string(resp->getBody()), respRoot);
             if (!parsed)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] buildResponse body is not parseable JSON for code=" << sourceCode;
             }
             REQUIRE(parsed);
@@ -992,7 +1001,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
                 // (a) Non-Production_Mode: `details` is PRESENT (Requirement 5.4).
                 if (!err.isMember("details"))
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << " via=" << which << "] code=" << sourceCode
                               << " is missing `details` in non-Production_Mode";
                 }
@@ -1003,7 +1012,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
                 const std::string detailsValue = err["details"].asString();
                 if (detailsValue.empty() || detailsValue.find(diagnosticText) == std::string::npos)
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << " via=" << which << "] code=" << sourceCode
                               << " details does not carry diagnostic text: details='"
                               << detailsValue << "' expected to contain='" << diagnosticText << "'";
@@ -1043,7 +1052,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             const bool parsed = parseJson(std::string(captured->getBody()), respRoot);
             if (!parsed)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] respondValidation body is not parseable JSON";
             }
             REQUIRE(parsed);
@@ -1057,7 +1066,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             REQUIRE(err["code"].isString());
             if (err["code"].asString() != "VALIDATION_INVALID_INPUT")
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] validation code mismatch: got='" << err["code"].asString()
                           << "' expected='VALIDATION_INVALID_INPUT'";
             }
@@ -1069,7 +1078,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             const std::string expectedCategory = toString(ErrorCategory::VALIDATION);
             if (err["category"].asString() != expectedCategory)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] validation category mismatch: got='" << err["category"].asString()
                           << "' expected='" << expectedCategory << "'";
             }
@@ -1078,7 +1087,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             // HTTP 400 for VALIDATION (Requirement 7.4).
             if (captured->statusCode() != ::drogon::k400BadRequest)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] validation HTTP status mismatch: got="
                           << static_cast<int>(captured->statusCode()) << " expected=400";
             }
@@ -1088,7 +1097,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             // (Requirement 7.6).
             if (!err.isMember("details"))
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] validation Envelope missing `details` in non-Production_Mode";
             }
             REQUIRE(err.isMember("details"));
@@ -1100,7 +1109,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
             {
                 if (detailsValue.find(fe.field) == std::string::npos)
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << "] validation details missing field name '" << fe.field
                               << "': details='" << detailsValue << "'";
                 }
@@ -1108,7 +1117,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property7_NonProductionDiagnosticDetails)
 
                 if (detailsValue.find(fe.reason) == std::string::npos)
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << "] validation details missing reason '" << fe.reason
                               << "': details='" << detailsValue << "'";
                 }
@@ -1154,8 +1163,8 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
 {
     // Fixed, printable seed so any failure is reproducible.
     constexpr unsigned int kSeed = 0x8'F00'0DEu;
-    LOG_INFO << "Property 8 unmapped-exception internal-fallback test, fixed seed=0x" << std::hex
-             << kSeed << std::dec;
+    LOG_INFO << "Property 8 unmapped-exception internal-fallback test, fixed seed=0x"
+             << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
 
@@ -1211,7 +1220,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
           // The mapped code is the INTERNAL fallback regardless of exception text.
           if (error.code != expectedCode || error.category != ErrorCategory::INTERNAL)
           {
-              LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << iter
+              LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << iter
                         << " hint=" << toString(hint) << "] fromException did not fall back to "
                         << expectedCode << ": code='" << error.code
                         << "' category=" << toString(error.category) << " what='" << ex.what()
@@ -1238,7 +1247,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
           const bool parsed = parseJson(std::string(captured->getBody()), respRoot);
           if (!parsed)
           {
-              LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << iter
+              LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << iter
                         << "] respondException body is not parseable JSON; what='" << ex.what()
                         << "'";
           }
@@ -1264,7 +1273,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
               REQUIRE(err["category"].isString());
               if (err["category"].asString() != "INTERNAL")
               {
-                  LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << iter
+                  LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << iter
                             << " via=" << which << "] category mismatch: got='"
                             << err["category"].asString() << "' expected='INTERNAL' what='"
                             << ex.what() << "'";
@@ -1276,7 +1285,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
               REQUIRE(err["code"].isString());
               if (err["code"].asString() != expectedCode)
               {
-                  LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << iter
+                  LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << iter
                             << " via=" << which << "] code mismatch: got='"
                             << err["code"].asString() << "' expected='" << expectedCode << "'";
               }
@@ -1286,7 +1295,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
               REQUIRE(err["numeric_code"].isInt());
               if (err["numeric_code"].asInt() != 6001)
               {
-                  LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << iter
+                  LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << iter
                             << " via=" << which
                             << "] numeric_code mismatch: got=" << err["numeric_code"].asInt()
                             << " expected=6001";
@@ -1299,7 +1308,7 @@ DROGON_TEST(Unit_P0_ErrorEnvelope_Property8_UnmappedExceptionInternalFallback)
               REQUIRE(err["message"].isString());
               if (err["message"].asString() != expectedMessage)
               {
-                  LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << iter
+                  LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << iter
                             << " via=" << which << "] message mismatch: got='"
                             << err["message"].asString() << "' expected catalog default='"
                             << expectedMessage << "'";

--- a/tests/unit/error/OAuth2ErrorPropertyTest.cc
+++ b/tests/unit/error/OAuth2ErrorPropertyTest.cc
@@ -33,6 +33,7 @@
 #include <cctype>
 #include <memory>
 #include <random>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -43,6 +44,16 @@ using namespace authforge::common::error;
 
 namespace
 {
+
+// trantor's LogStream has no overload for iostream manipulators: streaming
+// std::hex would convert the function address to bool and print `1`
+// (AppleClang -Wpointer-bool-conversion). Pre-format the seed instead.
+std::string seedHex(unsigned int seed)
+{
+    std::ostringstream oss;
+    oss << std::hex << seed;
+    return oss.str();
+}
 
 // Fixed, printable seed so any failure is reproducible.
 constexpr unsigned int kSeed = 0x0A07'2E99u;
@@ -156,8 +167,7 @@ const std::vector<std::string> &cleanDescriptions()
 // --- Main property test: random protocol code + description/error_uri variation.
 DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
 {
-    LOG_INFO << "Property 9 OAuth2 RFC 6749 compliance test, fixed seed=0x" << std::hex << kSeed
-             << std::dec;
+    LOG_INFO << "Property 9 OAuth2 RFC 6749 compliance test, fixed seed=0x" << seedHex(kSeed);
 
     const auto &oauthEntries = ErrorCatalog::allOAuthEntries();
     REQUIRE(!oauthEntries.empty());
@@ -194,7 +204,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         const HttpResponsePtr resp = capture(code, description, errorUri);
         if (resp == nullptr)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] null response for code=" << code;
         }
         REQUIRE(resp != nullptr);
@@ -203,7 +213,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         // Content-Type: application/json (typed + raw header).
         if (resp->contentType() != CT_APPLICATION_JSON)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " contentType is not application/json";
         }
         CHECK(resp->contentType() == CT_APPLICATION_JSON);
@@ -215,7 +225,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         // Cache-Control: no-store, Pragma: no-cache.
         if (resp->getHeader("Cache-Control") != "no-store")
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " Cache-Control=" << resp->getHeader("Cache-Control");
         }
         CHECK(resp->getHeader("Cache-Control") == "no-store");
@@ -226,7 +236,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         const bool parsed = parseBody(resp, root);
         if (!parsed)
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " body is not valid JSON: " << resp->getBody();
         }
         REQUIRE(parsed);
@@ -236,7 +246,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         REQUIRE(root.isMember("error"));
         if (!root["error"].isString())
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " top-level error is not a string (Envelope leak?)";
         }
         CHECK(root["error"].isString());
@@ -247,7 +257,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         const std::string errorValue = root["error"].asString();
         if (allowedCodes.find(errorValue) == allowedCodes.end())
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] error value '" << errorValue << "' not in allowed protocol set";
         }
         CHECK(allowedCodes.find(errorValue) != allowedCodes.end());
@@ -260,7 +270,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         const std::string desc = root["error_description"].asString();
         if (desc.empty())
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " empty error_description";
         }
         CHECK(!desc.empty());
@@ -276,7 +286,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
             // Empty argument falls back to the catalog default (Requirement 2.8).
             if (desc != catalogDefault)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] code=" << code << " error_description='" << desc
                           << "' != catalog default '" << catalogDefault << "'";
             }
@@ -286,7 +296,7 @@ DROGON_TEST(Unit_P0_OAuth2Error_Property9_Rfc6749Compliance)
         // Client_Safe_Message: no Internal_Detail leakage (Requirement 2.8).
         if (containsInternalDetail(desc))
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                       << "] code=" << code << " error_description leaks Internal_Detail: " << desc;
         }
         CHECK(!containsInternalDetail(desc));

--- a/tests/unit/error/RequestIdPropertyTest.cc
+++ b/tests/unit/error/RequestIdPropertyTest.cc
@@ -22,6 +22,7 @@
 
 #include <random>
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,16 @@ using authforge::common::error::RequestId;
 
 namespace
 {
+
+// trantor's LogStream has no overload for iostream manipulators: streaming
+// std::hex would convert the function address to bool and print `1`
+// (AppleClang -Wpointer-bool-conversion). Pre-format the seed instead.
+std::string seedHex(unsigned int seed)
+{
+    std::ostringstream oss;
+    oss << std::hex << seed;
+    return oss.str();
+}
 
 // Fixed seed: reproducible across runs; printed on failure for replay.
 constexpr unsigned int kSeed = 0x5EED'1D10u;
@@ -127,7 +138,7 @@ drogon::HttpRequestPtr makeRequestWithHeader(const std::string &value)
 // uniqueness, all in one hand-written loop (>= 100 iterations).
 DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
 {
-    LOG_INFO << "Property 10 RequestId test, fixed seed=0x" << std::hex << kSeed << std::dec;
+    LOG_INFO << "Property 10 RequestId test, fixed seed=0x" << seedHex(kSeed);
 
     std::mt19937 gen(kSeed);
     std::uniform_int_distribution<int> categoryDist(0, 4);
@@ -152,7 +163,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
 
             if (!RequestId::isValid(sample))
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] expected valid sample but isValid==false: " << escapeForLog(sample);
             }
             CHECK(RequestId::isValid(sample) == true);
@@ -161,7 +172,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
             const std::string resolved = RequestId::resolve(req);
             if (resolved != sample)
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << "] valid header not reused. header=" << escapeForLog(sample)
                           << " resolved=" << escapeForLog(resolved);
             }
@@ -215,7 +226,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
             {
                 if (RequestId::isValid(sample))
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << " cat=" << label << "] expected invalid sample but isValid==true: "
                               << escapeForLog(sample);
                 }
@@ -229,7 +240,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
             // Resolution must be a freshly generated, valid id (Req 6.1 / 6.4).
             if (!RequestId::isValid(resolved))
             {
-                LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                           << " cat=" << label
                           << "] resolved id is not valid: " << escapeForLog(resolved)
                           << " (sample=" << escapeForLog(sample) << ")";
@@ -245,7 +256,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
             {
                 if (resolved == sample)
                 {
-                    LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec << " iter=" << i
+                    LOG_ERROR << "[seed=0x" << seedHex(kSeed) << " iter=" << i
                               << " cat=" << label
                               << "] invalid header was reused: " << escapeForLog(sample);
                 }
@@ -264,7 +275,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
         const std::string id = RequestId::generate();
         if (!RequestId::isValid(id))
         {
-            LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec
+            LOG_ERROR << "[seed=0x" << seedHex(kSeed)
                       << "] generate() produced invalid id: " << escapeForLog(id);
         }
         CHECK(RequestId::isValid(id) == true);
@@ -275,7 +286,7 @@ DROGON_TEST(Unit_P0_RequestId_Property10_ResolveAndGenerate)
     // Every generated id must be mutually distinct: no collisions in the set.
     if (generatedIds.size() != generatedCount)
     {
-        LOG_ERROR << "[seed=0x" << std::hex << kSeed << std::dec
+        LOG_ERROR << "[seed=0x" << seedHex(kSeed)
                   << "] generated id collision: produced " << generatedCount << " ids but only "
                   << generatedIds.size() << " unique";
     }


### PR DESCRIPTION
## Summary / 摘要

Batch 5 of the professionalization plan: first-party compiler warning governance with a CI warnings-as-errors gate.

专业化计划批次5：一方代码编译警告治理 + CI 警告即错误门禁。

## Changes / 变更

### New: `cmake/Warnings.cmake`
- `oauth2_apply_warnings(target)` following the existing `oauth2_apply_compat` function pattern
- MSVC: `/W4` + `/external:anglebrackets /external:W0` (isolates Conan third-party headers)
- GCC/Clang: `-Wall -Wextra` (third-party headers already exempt via SYSTEM includes)
- `AUTHFORGE_WERROR` option (**default OFF**) escalates to `/WX` / `-Werror`
- All flags **PRIVATE** — nothing leaks into the `install(EXPORT)` interface of the 8 SDK packages

### Applied to 10 first-party targets
8 SDK libs (common, common-testing, oauth2, identity, storage-postgres, storage-memory, storage-redis, drogon) + `authforge-server` + `authforge-tests`, each behind the same standalone-build guard used for `Compatibility.cmake`.

### ORM model exemption
`drogon_ctl`-generated models (`libs/storage-postgres/src/models/*.cc`, must not be hand-edited) get a source-file-level `/wd4100` / `-Wno-unused-parameter`. Hand-written sources keep full warning level.

### CI gate
`-DAUTHFORGE_WERROR=ON` injected via `configure_extra_args` on all three platform workflows. Local developer builds (README Quick Start presets) are unaffected — default stays OFF.

### Warning fixes (zero new warnings under /W4 + /WX)
~24 fixes across storage/drogon/test layers: unused parameters commented out per project convention (`const T & /*name/`), dead locals removed, `(void)TEST_CTX;` added to assert-free DROGON_TESTs.

## Verification / 验证

- Local: `cmake --preset windows-msvc -DAUTHFORGE_WERROR=ON` + full build → **BUILD_EXIT=0, zero warnings** (4 iterative build rounds to surface and clear all layers)
- CI on this PR exercises the gate on Linux GCC / macOS Clang / Windows MSVC — `-Wextra` may surface platform-specific findings not visible to MSVC; will fix in follow-up commits on this branch if any appear