### PR TITLE
fix(storage-postgres): acquire saveTokenPair transaction asynchronously to avoid DbLoop deadlock

### DIFF
--- a/libs/storage-postgres/src/PostgresTokenRepository.cc
+++ b/libs/storage-postgres/src/PostgresTokenRepository.cc
@@ -108,7 +108,7 @@ void PostgresTokenRepository::saveTokenPair(
     // reproduced under some CI runners/timings and not deterministically
     // in every environment.
     //
-    // Fix: install a commit callback via newTransaction() and fire the
+    // Fix: install a commit callback on the transaction and fire the
     // caller's callback from there (guaranteed to run only after COMMIT
     // completes). The insert error paths still invoke the caller's
     // callback directly, because Drogon automatically rolls back on error
@@ -124,70 +124,93 @@ void PostgresTokenRepository::saveTokenPair(
         }
     };
 
-    // Use a transaction to ensure both tokens are saved atomically
-    auto transPtr = dbClientMaster_->newTransaction([invokeOnce](bool committed) {
-        if (!committed)
-            LOG_ERROR << "saveTokenPair: transaction commit failed";
-        invokeOnce();
-    });
-
-    auto refreshInsertErrorCb = [invokeOnce](const DrogonDbException &e) {
-        LOG_ERROR << "saveTokenPair (refresh) failed: " << e.base().what();
-        invokeOnce();
-    };
-
-    transPtr->execSqlAsync(
-      "INSERT INTO oauth2_access_tokens (token, client_id, user_id, scope, expires_at, revoked) "
-      "VALUES ($1, $2, $3, $4, $5, $6)",
-      [transPtr, rt, refreshInsertErrorCb](const ::drogon::orm::Result &) {
-          // Access token saved, now save refresh token. The caller's
-          // callback fires from the commit callback above, not here.
-          if (rt.familyId.empty())
+    // Deadlock fix: the transaction must be acquired asynchronously.
+    // saveTokenPair is reached from inside DB result callbacks (e.g. the
+    // token endpoint's device-code flow issues tokens from within
+    // PgConnection::handleRead on a DbLoop thread). The blocking
+    // newTransaction() overload waits on a future that is only fulfilled by
+    // the DB event loops themselves, so calling it there stalls the loop it
+    // runs on; with every DbLoop blocked this way (two concurrent
+    // redemptions), BEGIN can never be sent and the whole process
+    // deadlocks. newTransactionAsync() delivers the transaction via
+    // callback without ever blocking the calling loop.
+    dbClientMaster_->newTransactionAsync(
+      [invokeOnce, at, rt](const std::shared_ptr<Transaction> &transPtr) {
+          if (!transPtr)
           {
-              transPtr->execSqlAsync(
-                "INSERT INTO oauth2_refresh_tokens "
-                "(token, access_token, client_id, user_id, scope, expires_at, revoked) "
-                "VALUES ($1, $2, $3, $4, $5, $6, $7)",
-                [](const ::drogon::orm::Result &) {},
-                refreshInsertErrorCb,
-                rt.token,
-                rt.accessToken,
-                rt.clientId,
-                rt.userId,
-                rt.scope,
-                rt.expiresAt,
-                rt.revoked
-              );
+              LOG_ERROR << "saveTokenPair: failed to acquire transaction (timeout)";
+              invokeOnce();
+              return;
           }
-          else
-          {
-              transPtr->execSqlAsync(
-                "INSERT INTO oauth2_refresh_tokens "
-                "(token, access_token, client_id, user_id, scope, expires_at, revoked, family_id) "
-                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-                [](const ::drogon::orm::Result &) {},
-                refreshInsertErrorCb,
-                rt.token,
-                rt.accessToken,
-                rt.clientId,
-                rt.userId,
-                rt.scope,
-                rt.expiresAt,
-                rt.revoked,
-                rt.familyId
-              );
-          }
-      },
-      [invokeOnce](const DrogonDbException &e) {
-          LOG_ERROR << "saveTokenPair (access) failed: " << e.base().what();
-          invokeOnce();
-      },
-      at.token,
-      at.clientId,
-      at.userId,
-      at.scope,
-      at.expiresAt,
-      at.revoked
+
+          // Use a transaction to ensure both tokens are saved atomically
+          transPtr->setCommitCallback([invokeOnce](bool committed) {
+              if (!committed)
+                  LOG_ERROR << "saveTokenPair: transaction commit failed";
+              invokeOnce();
+          });
+
+          auto refreshInsertErrorCb = [invokeOnce](const DrogonDbException &e) {
+              LOG_ERROR << "saveTokenPair (refresh) failed: " << e.base().what();
+              invokeOnce();
+          };
+
+          transPtr->execSqlAsync(
+            "INSERT INTO oauth2_access_tokens (token, client_id, user_id, scope, expires_at, "
+            "revoked) "
+            "VALUES ($1, $2, $3, $4, $5, $6)",
+            [transPtr, rt, refreshInsertErrorCb](const ::drogon::orm::Result &) {
+                // Access token saved, now save refresh token. The caller's
+                // callback fires from the commit callback above, not here.
+                if (rt.familyId.empty())
+                {
+                    transPtr->execSqlAsync(
+                      "INSERT INTO oauth2_refresh_tokens "
+                      "(token, access_token, client_id, user_id, scope, expires_at, revoked) "
+                      "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                      [](const ::drogon::orm::Result &) {},
+                      refreshInsertErrorCb,
+                      rt.token,
+                      rt.accessToken,
+                      rt.clientId,
+                      rt.userId,
+                      rt.scope,
+                      rt.expiresAt,
+                      rt.revoked
+                    );
+                }
+                else
+                {
+                    transPtr->execSqlAsync(
+                      "INSERT INTO oauth2_refresh_tokens "
+                      "(token, access_token, client_id, user_id, scope, expires_at, revoked, "
+                      "family_id) "
+                      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                      [](const ::drogon::orm::Result &) {},
+                      refreshInsertErrorCb,
+                      rt.token,
+                      rt.accessToken,
+                      rt.clientId,
+                      rt.userId,
+                      rt.scope,
+                      rt.expiresAt,
+                      rt.revoked,
+                      rt.familyId
+                    );
+                }
+            },
+            [invokeOnce](const DrogonDbException &e) {
+                LOG_ERROR << "saveTokenPair (access) failed: " << e.base().what();
+                invokeOnce();
+            },
+            at.token,
+            at.clientId,
+            at.userId,
+            at.scope,
+            at.expiresAt,
+            at.revoked
+          );
+      }
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a hard deadlock that made local test runs (`test.sh` on WSL/Linux) hang forever at CTest #248 `OAuth2Tests`, right after `Start 248` with no further output.

## Root cause

`PostgresTokenRepository::saveTokenPair()` used the **blocking** `DbClient::newTransaction()` overload, but it is reached from **inside DB result callbacks** — the token endpoint's device-code flow issues tokens from within `PgConnection::handleRead()` on a DbLoop thread.

The blocking overload waits on a future that only the DB event loops themselves can fulfill, so calling it on a DbLoop thread stalls that very loop. When `Integration_P1_DeviceCode_ConcurrentRedemption_OnlyOneSucceeds` fires two concurrent device-code redemptions, **both** DbLoop threads enter this path simultaneously, `BEGIN` can never be sent to Postgres, and every subsequent DB operation in the process blocks forever. Since the `OAuth2Tests` ctest entry has no `TIMEOUT` property, ctest waits indefinitely.

Confirmed with a GDB thread dump of the hung process: both `DbLoop` threads futex-waiting inside `DbClientImpl::newTransaction()` under `saveTokenPair`, main thread stuck in the next test case's `execSql()` future wait.

## Fix

Switch to `newTransactionAsync()` and install the commit callback via `Transaction::setCommitCallback()`. Original semantics are fully preserved:

- Both INSERTs remain in a single transaction (atomicity unchanged).
- The caller's callback still fires only **after COMMIT** (the earlier MVCC race fix is untouched).
- The `invokeOnce` reentrancy guard is unchanged.
- New: transaction-acquisition timeout (`transPtr == nullptr`) logs an error and invokes the callback instead of waiting forever.

Other blocking `newTransaction()` call sites were audited and left alone — `SchemaManager.cc` (startup migration, main thread) and `ClientManagementService.cc` (HTTP IO thread) never run on a DbLoop thread, so they cannot self-deadlock.

## Verification

Full `authforge-tests` binary on WSL (linux-release preset, live PostgreSQL + Redis):

```
All tests passed (56609 assertions in 290 tests cases)
test::run() completed with status: 0
```

Previously the run always hung at the device-code concurrency test; now the whole suite completes and exits normally.

## Follow-up (not in this PR)

- Add a ctest `TIMEOUT` property to the `OAuth2Tests` entry so any future in-process hang fails fast instead of blocking `test.sh` indefinitely.
