### PR TITLE
Standardize log levels + broaden local dev/CI config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo 'Running pre-commit tests...' && cd build/tests && ctest --output-on-failure && echo 'Tests passed, commit allowed' || (echo 'Tests failed, commit blocked' && exit 1)"
+            "command": "if [ ! -d build/tests ]; then echo 'Build directory not found. Run manage.sh build-backend first.' && exit 1; fi && echo 'Running pre-commit tests...' && cd build/tests && ctest --output-on-failure && echo 'Tests passed, commit allowed' || (echo 'Tests failed, commit blocked' && exit 1)"
           }
         ]
       },

--- a/.claude/skills/create-migration/SKILL.md
+++ b/.claude/skills/create-migration/SKILL.md
@@ -16,12 +16,12 @@ When adding, modifying, or dropping database tables/columns/indexes. Triggered b
 
 Pattern: `apps/server/migrations/V{NNN}__descriptive_name.sql`
 
-Current latest: `V018__webauthn.sql` -- next migration starts at **V019**.
-
-Check existing migrations before creating:
+Check existing migrations before creating to determine the next number:
 ```bash
-ls -la apps/server/migrations/
+ls -1 apps/server/migrations/ | sort | tail -1
 ```
+
+The next migration number is one higher than the latest file found above.
 
 ## File Template
 

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -305,7 +305,7 @@ jobs:
 
       - name: Test
         working-directory: ${{ github.workspace }}/${{ inputs.preset_dir }}
-        run: ctest -V -C "$BUILD_TYPE" --output-on-failure --timeout 120
+        run: ctest -C "$BUILD_TYPE" --output-on-failure --timeout 120
 
       # --- Error-Standardization release-readiness gate (Requirement 12.7) ---
       # Explicit, attributable gate over the error-code/message-standardization

--- a/.github/workflows/_sdk-smoke.yml
+++ b/.github/workflows/_sdk-smoke.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run SDK Smoke (SdkSmoke label)
         working-directory: ${{ github.workspace }}/${{ env.PRESET_DIR }}
-        run: ctest -V -C "$BUILD_TYPE" -L SdkSmoke --output-on-failure --timeout 300
+        run: ctest -C "$BUILD_TYPE" -L SdkSmoke --output-on-failure --timeout 300
 
       - name: Upload SDK smoke logs on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ cookies.txt
 .env.local
 .env.*.local
 .env.docker
+.mcp.json
 *.pem
 *.key
 *.cert

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -5,7 +5,7 @@
       "args": [
         "-y",
         "@modelcontextprotocol/server-postgres",
-        "postgresql://oauth2_user:123456@127.0.0.1:5432/oauth2_db"
+        "postgresql://oauth2_user:${OAUTH2_DB_PASSWORD:-123456}@${OAUTH2_DB_HOST:-127.0.0.1}:${OAUTH2_DB_PORT:-5432}/oauth2_db"
       ]
     },
     "redis": {
@@ -13,7 +13,7 @@
       "args": [
         "-y",
         "@modelcontextprotocol/server-redis",
-        "redis://:123456@127.0.0.1:6379/0"
+        "redis://:${OAUTH2_REDIS_PASSWORD:-123456}@${OAUTH2_REDIS_HOST:-127.0.0.1}:${OAUTH2_REDIS_PORT:-6379}/0"
       ]
     },
     "github": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,31 @@ npx playwright test                                # E2E
   enforces this in CI.
 - No emoji in code or program output (use `[+]` / `[-]` / `[!]`).
 
+### Logging
+
+Six log levels mirror Drogon/Trantor (trace < debug < info < warn < error <
+fatal). Full definitions and typical use cases are in
+[docs/backend/observability.md §3.2](docs/backend/observability.md). Quick
+guide:
+
+| Level | When to use |
+|-------|-------------|
+| `trace` | Function args/return values, SQL strings, per-iteration detail — deep debugging only |
+| `debug` | Variable values, branch decisions, internal-state dumps — dev troubleshooting |
+| `info` | Startup/shutdown, login, task completion, key flow checkpoints, audit-worthy normal events |
+| `warn` | Recoverable failure, degraded-but-working path, default value used, resource near threshold |
+| `error` | Single operation/request failed (DB error callback, unhandled exception), service still up |
+| `fatal` | Service cannot continue (startup config/migration failure) — must be rare |
+
+Rules:
+
+- **Domain layer must log through the `ILogger` port** (`authforge::common::ports::ILogger`), not Drogon's `LOG_*` macros, so tests can assert on output via `FakeLogger`. The adapter/infra layers (`libs/drogon`, `libs/storage-*`, `apps/server`) may use `LOG_*` directly. `LogLevel::Trace` routes to `LOG_TRACE`.
+- **Pick the level by impact, not verbosity**: a caught exception that still succeeds is `warn`, not `error`; a routine cache-miss or 401 is usually `debug`/`info`, not `warn`. When an operation fails outright with no fallback, use `error`.
+- Production runs at `info` by default; `trace`/`debug` are enabled on demand. Adjust via `app.log.log_level` in the Drogon config (values: `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`).
+- **Test output is minimal by default**: `ctest` prints only failed tests' logs plus the pass/fail/total summary. Add `--verbose` (`-V`) to see every test, or `-Q` (`manage.sh test-backend -q`) for summary only.
+
+> **Known audit residue**: a handful of call sites remain at a level that's a policy judgement rather than a clear-cut bug (e.g. the `[METRIC]` log-based metric emissions at `info`, routine 401/403 denials at `warn`). These are intentionally left for a deliberate follow-up decision; when you touch such a site, consider whether its level matches the table above.
+
 ## Commit & PR Conventions
 
 - Commits follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/apps/server/config/config.ci.json
+++ b/apps/server/config/config.ci.json
@@ -122,7 +122,7 @@
                     "vue-client": {
                         "client_type": "PUBLIC",
                         "secret": "123456",
-                        "redirect_uri": "http://localhost:5173/callback",
+                        "redirect_uri": "http://localhost:5173/callback,http://localhost:8080/callback",
                         "allowed_scopes": ["openid", "profile", "email"]
                     }
                 },
@@ -151,7 +151,9 @@
         "cors": {
             "allow_origins": [
                 "http://localhost:5173",
-                "http://127.0.0.1:5173",
+                "http://localhost:5174",
+                "http://localhost:8080",
+                "http://localhost:8081",
                 "https://editor.swagger.io"
             ]
         },
@@ -160,6 +162,10 @@
             "register_path": "/register"
         },
         "external_auth": {
+            "github": {
+                "client_id": "YOUR_GITHUB_CLIENT_ID",
+                "client_secret": "YOUR_GITHUB_CLIENT_SECRET"
+            },
             "wechat": {
                 "appid": "YOUR_WECHAT_APPID",
                 "secret": "YOUR_WECHAT_SECRET"

--- a/apps/server/config/config.dev.json
+++ b/apps/server/config/config.dev.json
@@ -166,7 +166,7 @@
                     "vue-client": {
                         "client_type": "PUBLIC",
                         "secret": "123456",
-                        "redirect_uri": "http://localhost:5173/callback",
+                        "redirect_uri": "http://localhost:5173/callback,http://localhost:8080/callback",
                         "allowed_scopes": ["openid", "profile", "email"]
                     }
                 },
@@ -195,7 +195,9 @@
         "cors": {
             "allow_origins": [
                 "http://localhost:5173",
-                "http://127.0.0.1:5173",
+                "http://localhost:5174",
+                "http://localhost:8080",
+                "http://localhost:8081",
                 "https://editor.swagger.io"
             ]
         },
@@ -204,6 +206,10 @@
             "register_path": "/register"
         },
         "external_auth": {
+            "github": {
+                "client_id": "YOUR_GITHUB_CLIENT_ID",
+                "client_secret": "YOUR_GITHUB_CLIENT_SECRET"
+            },
             "wechat": {
                 "appid": "YOUR_WECHAT_APPID",
                 "secret": "YOUR_WECHAT_SECRET"

--- a/apps/server/config/config.json
+++ b/apps/server/config/config.json
@@ -182,7 +182,6 @@
         "cors": {
             "allow_origins": [
                 "http://localhost:5173",
-                "http://127.0.0.1:5173",
                 "http://localhost:5174",
                 "http://localhost:8080",
                 "http://localhost:8081",

--- a/apps/server/config/config.prod.json
+++ b/apps/server/config/config.prod.json
@@ -104,7 +104,7 @@
             "logfile_base_name": "oauth2_prod",
             "log_size_limit": 100000000,
             "max_files": 10,
-            "log_level": "WARN",
+            "log_level": "INFO",
             "display_local_time": true
         },
         "run_as_daemon": false,

--- a/apps/server/src/bootstrap/ControllerRegistration.cc
+++ b/apps/server/src/bootstrap/ControllerRegistration.cc
@@ -134,9 +134,11 @@ void wireControllerPluginDependencies()
     auto plugin = drogon::app().getPlugin<OAuth2Plugin>();
     if (!plugin)
     {
-        LOG_ERROR << "wireControllerPluginDependencies: OAuth2Plugin not found; "
-                     "controllers/filters will fall back to per-request "
-                     "getPlugin<OAuth2Plugin>() lookups";
+        // Recoverable: an explicit per-request getPlugin<OAuth2Plugin>()
+        // fallback exists, so startup continues (just less efficiently).
+        LOG_WARN << "wireControllerPluginDependencies: OAuth2Plugin not found; "
+                    "controllers/filters will fall back to per-request "
+                    "getPlugin<OAuth2Plugin>() lookups";
         return;
     }
 

--- a/docs/backend/observability.md
+++ b/docs/backend/observability.md
@@ -63,7 +63,24 @@ LOG_INFO << "Processing request"; // 输出: [ReqId: abc-123] Processing request
 
 ### 3.2 日志级别
 
-建议生产环境设置 LogLevel 为 `INFO`，调试环境为 `DEBUG`。
+系统统一使用六级日志，等级与 Drogon/Trantor 的内置级别一一对应（trace < debug < info < warn < error < fatal）：
+
+| 等级 | 含义 | 典型场景 |
+|------|------|----------|
+| `trace` | 最细粒度追踪 | 函数入参 / 出参、循环迭代、逐行执行轨迹，用于深度调试定位 |
+| `debug` | 调试信息 | 变量值、分支走向、内部状态变化，开发阶段排查问题用 |
+| `info` | 常规信息 | 服务启动 / 停止、关键流程节点、用户登录、任务完成等正常业务事件 |
+| `warn` | 警告 | 可恢复的异常、降级处理、配置使用默认值、资源接近阈值等，系统仍能正常运行 |
+| `error` | 错误 | 功能失败、请求异常、数据库连接失败等，影响单次操作但服务整体可用 |
+| `fatal` | 致命错误 | 导致服务崩溃、无法继续运行的严重故障，需立即告警并人工介入 |
+
+**约定**：
+
+- 生产环境默认开启 `info` 及以上级别；`trace`/`debug` 按需动态开启。
+- 等级越高输出越少，`fatal` 应极少出现。
+- `apps/server/config/config.prod.json` 默认为 `INFO`，`config.dev.json` 默认为 `DEBUG`，`config.json`/`config.ci.json` 默认为 `DEBUG`。
+
+**动态调整**：修改配置文件 `app.log.log_level` 字段即可，可选值为 `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`（不区分大小写）：
 
 ```json
 "app": {
@@ -72,3 +89,11 @@ LOG_INFO << "Processing request"; // 输出: [ReqId: abc-123] Processing request
     }
 }
 ```
+
+**代码约定**：
+
+- Domain 层（`libs/common`、`libs/oauth2`、`libs/identity`）**不得**直接使用 Drogon 的 `LOG_*` 宏，必须经 `authforge::common::ports::ILogger` 端口（design.md §5.6），以便单元测试可用 `FakeLogger` 捕获并断言。
+- Adapter / 基础设施层（`libs/drogon`、`libs/storage-*`、`apps/server`）可直接使用 `LOG_*` 宏。
+- 六级对应关系：`LogLevel::Trace`→`LOG_TRACE`、`Debug`→`LOG_DEBUG`、`Info`→`LOG_INFO`、`Warn`→`LOG_WARN`、`Error`→`LOG_ERROR`、`Fatal`→`LOG_FATAL`。
+
+> 关于测试输出的最小化策略（ctest 默认仅打印失败用例与汇总），见 [testing-guide.md](./testing-guide.md)。

--- a/docs/backend/testing-guide.md
+++ b/docs/backend/testing-guide.md
@@ -92,8 +92,10 @@
 ```powershell
 # 在构建完成后执行（目录为 build/<preset>，Windows Release 为 windows-msvc）
 cd build\windows-msvc
-ctest -V -C Release --output-on-failure --timeout 120
+ctest -C Release --output-on-failure --timeout 120
 ```
+
+> **输出策略**：默认仅打印失败用例的日志与末尾汇总（`成功数 / 失败数 / 总数`）。如需查看每个用例（含通过用例）的完整输出，加 `--verbose`（`-V`）；如需完全静默、只看汇总行，加 `-Q`。`manage.sh test-backend -q` / `manage.ps1 test-backend -q` 等价于 `-Q`。
 
 ### 方式二：直接运行测试可执行文件
 
@@ -302,7 +304,7 @@ curl -X POST http://127.0.0.1:5555/oauth2/login \
 *   **PowerShell 脚本限制**：如提示“禁止运行脚本”，请使用 `-ExecutionPolicy Bypass` 参数。
 
 ### 9.2 调试技巧
-*   **日志级别**：在 `config.json` 中将 `log_level` 设置为 `DEBUG` 以获取详细输出。
+*   **日志级别**：排错时可在 `config.json` 中临时将 `log_level` 调为 `DEBUG`（甚至 `TRACE`）以获取详细输出，定位完成后调回 `INFO`。完整的六级语义与约定见 [observability.md §3.2](./observability.md)。
 *   **实时日志**：使用 `Get-Content apps/server/logs/drogon.log -Wait -Tail 20` 监控运行状态。
 
 ---

--- a/libs/common/include/authforge/common/ports/ILogger.h
+++ b/libs/common/include/authforge/common/ports/ILogger.h
@@ -11,10 +11,15 @@
 // slice ("每类端口一个 PR、单 PR 调用点数设上限") rather than folding it into
 // ICryptoProvider's migration. This task only declares the port shape.
 //
-// Level set mirrors Drogon's LOG_* macro names 1:1 (TRACE is omitted --
-// grep across the Domain call sites design.md's audit covers shows no
-// LOG_TRACE usage in the migration scope) so a call-site migration is a
-// mechanical macro-to-method-call rename, not a redesign.
+// Level set mirrors Drogon's LOG_* macro names 1:1 (Trace/Debug/Info/Warn/
+// Error/Fatal), so a call-site migration is a mechanical macro-to-method-call
+// rename, not a redesign. Trace was originally omitted on the assumption that
+// no LOG_TRACE existed in the migration scope; that assumption no longer holds
+// -- the generated ORM model headers emit LOG_TRACE for SQL strings, and Trace
+// is now the documented tier for the finest-grained tracing (function args/
+// return values, SQL, per-iteration detail) per the repo logging standard
+// (docs/backend/observability.md §3.2). Order matches Drogon/Trantor's own
+// severity ordering: Trace < Debug < Info < Warn < Error < Fatal.
 
 #include <string>
 
@@ -23,6 +28,7 @@ namespace authforge::common::ports
 
 enum class LogLevel
 {
+    Trace,
     Debug,
     Info,
     Warn,

--- a/libs/common/testing/test/FakeLoggerTest.cc
+++ b/libs/common/testing/test/FakeLoggerTest.cc
@@ -47,3 +47,17 @@ TEST(FakeLoggerTest, ClearRemovesAllEntries)
     logger.clear();
     EXPECT_EQ(logger.count(), 0u);
 }
+
+TEST(FakeLoggerTest, CapturesTraceLevel)
+{
+    // Regression guard for the six-level LogLevel set: Trace must round-trip
+    // through ILogger like any other level (previously the enum lacked Trace
+    // and the DrogonLogger adapter silently dropped trace calls).
+    FakeLogger logger;
+    logger.log(LogLevel::Trace, "finest-grained detail");
+
+    ASSERT_EQ(logger.count(), 1u);
+    EXPECT_EQ(logger.entries()[0].level, LogLevel::Trace);
+    EXPECT_EQ(logger.entries()[0].message, "finest-grained detail");
+    EXPECT_TRUE(logger.hasMessageContaining(LogLevel::Trace, "finest"));
+}

--- a/libs/drogon/src/AuthService.cc
+++ b/libs/drogon/src/AuthService.cc
@@ -85,7 +85,7 @@ void AuthService::validateUser(
                         *resetUser,
                         [resetUser](const size_t) {},
                         [resetUser](const ::drogon::orm::DrogonDbException &e) {
-                            LOG_DEBUG << "Failed to reset failed login counter: "
+                            LOG_ERROR << "Failed to reset failed login counter: "
                                       << e.base().what();
                         }
                       );
@@ -173,19 +173,19 @@ void AuthService::validateUser(
               }
           },
           [sharedCb](const DrogonDbException &e) {
-              LOG_WARN << "Validate User Failed: " << e.base().what();
+              LOG_ERROR << "Validate User Failed: " << e.base().what();
               (*sharedCb)(std::nullopt);
           }
         );
     }
     catch (const std::exception &e)
     {
-        LOG_WARN << "Validate User Init Failed: " << e.what();
+        LOG_ERROR << "Validate User Init Failed: " << e.what();
         (*sharedCb)(std::nullopt);
     }
     catch (...)
     {
-        LOG_WARN << "Validate User Init Unknown Exception";
+        LOG_ERROR << "Validate User Init Unknown Exception";
         (*sharedCb)(std::nullopt);
     }
 }
@@ -258,11 +258,15 @@ void AuthService::registerUser(
                                   (*sharedCb)("");  // Success
                               },
                               [sharedCb](const DrogonDbException &e) {
-                                  LOG_ERROR << "Assign Role Failed: " << e.base().what();
+                                  // Recoverable: the user has already been
+                                  // created; role assignment is a side effect.
+                                  // WARN is correct (not ERROR) because the
+                                  // registration itself succeeds.
+                                  LOG_WARN << "Assign Role Failed: " << e.base().what();
                                   (*sharedCb)("");  // Treat as success
                                                     // for now (User
                                                     // created), but log
-                                                    // error
+                                                    // warning
                               }
                             );
                         }
@@ -272,7 +276,8 @@ void AuthService::registerUser(
                         }
                     },
                     [sharedCb](const DrogonDbException &e) {
-                        LOG_ERROR << "Default Role 'user' not found: " << e.base().what();
+                        // Recoverable: user created without a role.
+                        LOG_WARN << "Default Role 'user' not found: " << e.base().what();
                         (*sharedCb)("");  // User created w/o role
                     }
                   );
@@ -369,8 +374,10 @@ void AuthService::getUserInfo(
                           (*sharedCb)(json);
                       },
                       [sharedCb, user](const DrogonDbException &e) {
-                          LOG_DEBUG << "User " << user.getValueOfPublicSub()
-                                    << " has no roles: " << e.base().what();
+                          // Recoverable degradation: roles can't be loaded, so
+                          // the user proceeds with an empty role set.
+                          LOG_WARN << "User " << user.getValueOfPublicSub()
+                                   << " has no roles: " << e.base().what();
                           Json::Value json;
                           json["sub"] = user.getValueOfPublicSub();
                           std::string displayName = user.getValueOfUsername();
@@ -395,19 +402,19 @@ void AuthService::getUserInfo(
               );
           },
           [sharedCb](const DrogonDbException &e) {
-              LOG_WARN << "Get User Info Failed: " << e.base().what();
+              LOG_ERROR << "Get User Info Failed: " << e.base().what();
               (*sharedCb)(std::nullopt);
           }
         );
     }
     catch (const std::exception &e)
     {
-        LOG_WARN << "Get User Info Init Failed: " << e.what();
+        LOG_ERROR << "Get User Info Init Failed: " << e.what();
         (*sharedCb)(std::nullopt);
     }
     catch (...)
     {
-        LOG_WARN << "Get User Info Init Unknown Exception";
+        LOG_ERROR << "Get User Info Init Unknown Exception";
         (*sharedCb)(std::nullopt);
     }
 }

--- a/libs/drogon/src/adapters/DrogonLogger.cc
+++ b/libs/drogon/src/adapters/DrogonLogger.cc
@@ -10,6 +10,9 @@ void DrogonLogger::log(LogLevel level, const std::string &message)
 {
     switch (level)
     {
+        case LogLevel::Trace:
+            LOG_TRACE << message;
+            break;
         case LogLevel::Debug:
             LOG_DEBUG << message;
             break;

--- a/libs/drogon/src/controllers/MfaController.cc
+++ b/libs/drogon/src/controllers/MfaController.cc
@@ -959,7 +959,9 @@ void MfaController::verifyLogin(
                                                     [sendSuccess](
                                                       const ::drogon::orm::DrogonDbException &e
                                                     ) {
-                                                        LOG_ERROR
+                                                        // Recoverable: the
+                                                        // request still succeeds.
+                                                        LOG_WARN
                                                           << "verifyLogin: failed to clear MFA "
                                                              "pending binding: "
                                                           << e.base().what();
@@ -970,9 +972,11 @@ void MfaController::verifyLogin(
                                             [sendSuccess](
                                               const ::drogon::orm::DrogonDbException &e
                                             ) {
-                                                LOG_ERROR << "verifyLogin: failed to find user for "
-                                                             "MFA pending clear: "
-                                                          << e.base().what();
+                                                // Recoverable: the request
+                                                // still succeeds.
+                                                LOG_WARN << "verifyLogin: failed to find user for "
+                                                            "MFA pending clear: "
+                                                         << e.base().what();
                                                 sendSuccess();
                                             }
                                           );

--- a/libs/drogon/src/plugin/OAuth2CleanupService.cc
+++ b/libs/drogon/src/plugin/OAuth2CleanupService.cc
@@ -129,14 +129,15 @@ void OAuth2CleanupService::runCleanup()
                   return;
               }
               // Lock acquired - proceed with cleanup
-              LOG_DEBUG << "Running periodic data cleanup (lock acquired)...";
+              LOG_INFO << "Running periodic data cleanup (lock acquired)...";
               try
               {
                   self->doPurge();
               }
               catch (const std::exception &e)
               {
-                  LOG_ERROR << "Error during OAuth2 cleanup: " << e.what();
+                  // Recoverable: background task retries on the next tick.
+                  LOG_WARN << "Error during OAuth2 cleanup: " << e.what();
               }
           },
           [weakSelf](const std::exception & /*e*/) {
@@ -144,14 +145,15 @@ void OAuth2CleanupService::runCleanup()
               if (!self || !self->running_)
                   return;
               // Redis not available - run cleanup anyway (single instance mode)
-              LOG_DEBUG << "Running periodic data cleanup (no Redis lock)...";
+              LOG_INFO << "Running periodic data cleanup (no Redis lock)...";
               try
               {
                   self->doPurge();
               }
               catch (const std::exception &ex)
               {
-                  LOG_ERROR << "Error during OAuth2 cleanup: " << ex.what();
+                  // Recoverable: background task retries on the next tick.
+                  LOG_WARN << "Error during OAuth2 cleanup: " << ex.what();
               }
           },
           "SET oauth2:cleanup:lock %s NX EX %d",
@@ -162,18 +164,20 @@ void OAuth2CleanupService::runCleanup()
     catch (...)
     {
         // Redis not configured - run cleanup without lock
-        LOG_DEBUG << "Running periodic data cleanup (no Redis)...";
+        LOG_INFO << "Running periodic data cleanup (no Redis)...";
         try
         {
             doPurge();
         }
         catch (const std::exception &e)
         {
-            LOG_ERROR << "Error during OAuth2 cleanup: " << e.what();
+            // Recoverable: doPurge() already ran; next tick retries.
+            LOG_WARN << "Error during OAuth2 cleanup: " << e.what();
         }
         catch (...)
         {
-            LOG_ERROR << "Unknown error during OAuth2 cleanup";
+            // Recoverable: same swallow-and-continue as above.
+            LOG_WARN << "Unknown error during OAuth2 cleanup";
         }
     }
 }

--- a/libs/storage-postgres/src/PostgresConsentRepository.cc
+++ b/libs/storage-postgres/src/PostgresConsentRepository.cc
@@ -76,10 +76,10 @@ void PostgresConsentRepository::saveUserConsent(
         mapper.insert(
           consent,
           [sharedCb](const Oauth2UserConsents &insertedConsent) {
-              LOG_DEBUG << "Saved user consent: user_id="
-                        << insertedConsent.getValueOfInternalUserId()
-                        << " client=" << insertedConsent.getValueOfClientId()
-                        << " scope=" << insertedConsent.getValueOfScopeName();
+              LOG_INFO << "Saved user consent: user_id="
+                       << insertedConsent.getValueOfInternalUserId()
+                       << " client=" << insertedConsent.getValueOfClientId()
+                       << " scope=" << insertedConsent.getValueOfScopeName();
               (*sharedCb)(true);
           },
           [sharedCb](const DrogonDbException &e) {
@@ -125,7 +125,7 @@ void PostgresConsentRepository::revokeUserConsent(
             Criteria(Oauth2UserConsents::Cols::_client_id, CompareOperator::EQ, clientId) &&
             Criteria(Oauth2UserConsents::Cols::_scope_name, CompareOperator::EQ, scope),
           [sharedCb](const size_t count) {
-              LOG_DEBUG << "Revoked user consent: deleted " << count << " record(s)";
+              LOG_INFO << "Revoked user consent: deleted " << count << " record(s)";
               (*sharedCb)();
           },
           [sharedCb](const DrogonDbException &e) {

--- a/libs/storage-postgres/src/PostgresGrantRepository.cc
+++ b/libs/storage-postgres/src/PostgresGrantRepository.cc
@@ -98,7 +98,7 @@ void PostgresGrantRepository::getAuthCode(const std::string &code, AuthCodeCallb
           },
           [sharedCb](const DrogonDbException &e) {
               // Not found or error
-              LOG_DEBUG << "getAuthCode not found or error: " << e.base().what();
+              LOG_WARN << "getAuthCode not found or error: " << e.base().what();
               (*sharedCb)(std::nullopt);
           }
         );
@@ -170,7 +170,7 @@ void PostgresGrantRepository::consumeAuthCode(
       [sharedCb, redirectUri, code](const ::drogon::orm::Result &r) {
           if (r.empty())
           {
-              LOG_DEBUG << "[SECURITY] Auth code not found or already used: " << code.substr(0, 8);
+              LOG_WARN << "[SECURITY] Auth code not found or already used: " << code.substr(0, 8);
               (*sharedCb)(std::nullopt);
               return;
           }

--- a/libs/storage-postgres/src/PostgresIdentityRepository.cc
+++ b/libs/storage-postgres/src/PostgresIdentityRepository.cc
@@ -220,9 +220,12 @@ void PostgresIdentityRepository::create(
                                   (*sharedCb)(newUserId, "");
                               },
                               [sharedCb, newUserId](const DrogonDbException &e) {
-                                  LOG_ERROR << "PostgresIdentityRepository::create: role "
-                                               "assignment failed: "
-                                            << e.base().what();
+                                  // Recoverable: user is already created; role
+                                  // assignment is a side effect (callback reports
+                                  // success with empty error string).
+                                  LOG_WARN << "PostgresIdentityRepository::create: role "
+                                              "assignment failed: "
+                                           << e.base().what();
                                   (*sharedCb)(newUserId, "");
                               }
                             );
@@ -233,9 +236,10 @@ void PostgresIdentityRepository::create(
                         }
                     },
                     [sharedCb, newUserId](const DrogonDbException &e) {
-                        LOG_ERROR << "PostgresIdentityRepository::create: default role 'user' "
-                                     "not found: "
-                                  << e.base().what();
+                        // Recoverable: user created without a role.
+                        LOG_WARN << "PostgresIdentityRepository::create: default role 'user' "
+                                    "not found: "
+                                 << e.base().what();
                         (*sharedCb)(newUserId, "");
                     }
                   );

--- a/libs/storage-postgres/src/PostgresTokenRepository.cc
+++ b/libs/storage-postgres/src/PostgresTokenRepository.cc
@@ -238,7 +238,7 @@ void PostgresTokenRepository::getAccessToken(const std::string &token, AccessTok
               (*sharedCb)(t);
           },
           [sharedCb](const DrogonDbException &e) {
-              LOG_DEBUG << "getAccessToken not found/error: " << e.base().what();
+              LOG_WARN << "getAccessToken not found/error: " << e.base().what();
               (*sharedCb)(std::nullopt);
           }
         );
@@ -331,7 +331,7 @@ void PostgresTokenRepository::getRefreshToken(const std::string &token, RefreshT
               (*sharedCb)(t);
           },
           [sharedCb](const DrogonDbException &e) {
-              LOG_DEBUG << "getRefreshToken not found/error: " << e.base().what();
+              LOG_WARN << "getRefreshToken not found/error: " << e.base().what();
               (*sharedCb)(std::nullopt);
           }
         );
@@ -367,7 +367,7 @@ void PostgresTokenRepository::revokeRefreshToken(const std::string &token, VoidC
         mapper.update(
           updateObj,
           [sharedCb, token](const size_t count) {
-              LOG_DEBUG << "Revoked refresh token: " << token << ", affected rows: " << count;
+              LOG_INFO << "Revoked refresh token: " << token << ", affected rows: " << count;
               if (*sharedCb)
                   (*sharedCb)();
           },
@@ -595,13 +595,13 @@ void PostgresTokenRepository::incrementIntrospectCount(const std::string &token,
               updated,
               [sharedCb](const size_t) { (*sharedCb)(); },
               [sharedCb](const DrogonDbException &e) {
-                  LOG_DEBUG << "incrementIntrospectCount update failed: " << e.base().what();
+                  LOG_ERROR << "incrementIntrospectCount update failed: " << e.base().what();
                   (*sharedCb)();
               }
             );
       },
       [sharedCb](const DrogonDbException &e) {
-          LOG_DEBUG << "incrementIntrospectCount find failed: " << e.base().what();
+          LOG_ERROR << "incrementIntrospectCount find failed: " << e.base().what();
           (*sharedCb)();
       }
     );
@@ -656,20 +656,20 @@ void PostgresTokenRepository::revokeAccessToken(
                           .update(
                             rtUpdated,
                             [sharedCb](const size_t) {
-                                LOG_DEBUG << "Token revoked successfully (checked both tables)";
+                                LOG_INFO << "Token revoked successfully (checked both tables)";
                                 (*sharedCb)();
                             },
                             [sharedCb](const DrogonDbException &) { (*sharedCb)(); }
                           );
                     },
                     [sharedCb](const DrogonDbException &) {
-                        LOG_DEBUG << "Token revoked successfully (access token only)";
+                        LOG_INFO << "Token revoked successfully (access token only)";
                         (*sharedCb)();
                     }
                   );
               },
               [sharedCb, token, self](const DrogonDbException &e) {
-                  LOG_DEBUG << "Access token revocation audit failed: " << e.base().what();
+                  LOG_ERROR << "Access token revocation audit failed: " << e.base().what();
                   // Fallback: simple revoked=true without audit columns
                   Oauth2AccessTokens simpleUpdate;
                   simpleUpdate.setToken(token);
@@ -762,7 +762,7 @@ void PostgresTokenRepository::purgeExpired()
               }
           },
           [](const DrogonDbException &e) {
-              LOG_DEBUG << "Token archival skipped (function may not exist): " << e.base().what();
+              LOG_WARN << "Token archival skipped (function may not exist): " << e.base().what();
           }
         );
     }

--- a/libs/storage-redis/src/RedisGrantRepository.cc
+++ b/libs/storage-redis/src/RedisGrantRepository.cc
@@ -226,10 +226,10 @@ void RedisGrantRepository::consumeAuthCode(
               // attempt)
               if (!requestUri.empty())
               {
-                  LOG_DEBUG << "[SECURITY] Auth code consumption failed "
-                            << "(code not found, expired, or redirect_uri "
-                               "mismatch): "
-                            << codeStr;
+                  LOG_WARN << "[SECURITY] Auth code consumption failed "
+                           << "(code not found, expired, or redirect_uri "
+                              "mismatch): "
+                           << codeStr;
               }
               cb(std::nullopt);
               return;

--- a/libs/storage-redis/src/RedisRepositoryBase.cc
+++ b/libs/storage-redis/src/RedisRepositoryBase.cc
@@ -10,7 +10,7 @@ RedisRepositoryBase::RedisRepositoryBase(const std::string &redisClientName)
     if (redisClient_)
     {
         redisClient_->setTimeout(3.0);
-        LOG_DEBUG << "RedisRepositoryBase initialized with client: " << redisClientName;
+        LOG_INFO << "RedisRepositoryBase initialized with client: " << redisClientName;
     }
     else
     {

--- a/scripts/backend/test.bat
+++ b/scripts/backend/test.bat
@@ -7,6 +7,9 @@ if errorlevel 1 exit /b 1
 set "SCRIPT_DIR=%~dp0"
 set "PROJECT_DIR=%~dp0..\.."
 set BUILD_TYPE=Release
+REM Default to minimal output: only failed tests print their log, plus the
+REM final pass/fail/total summary line. Pass -q to suppress even the
+REM per-test START/PASS lines (-Q = summary only).
 set VERBOSE=--output-on-failure
 
 :parse_args
@@ -22,7 +25,7 @@ if /i "%1"=="-release" (
     goto parse_args
 )
 if /i "%1"=="-q" (
-    set VERBOSE=
+    set VERBOSE=-Q
     shift
     goto parse_args
 )
@@ -56,7 +59,7 @@ cd /d "%PRESET_DIR%"
 REM --- Run 1: Standard config.json ---
 echo.
 echo [1/2] Running tests with standard %CONFIG_FILE%...
-ctest -V -C %BUILD_TYPE% %VERBOSE%
+ctest -C %BUILD_TYPE% %VERBOSE%
 if !errorlevel! neq 0 (
     echo [FAIL] Tests failed with standard %CONFIG_FILE%
     exit /b 1
@@ -83,7 +86,7 @@ set "CI_CFG_SRC=!CI_CFG_SRC:/=\!"
 copy /Y "%TEST_CONFIG%" "%TEST_CONFIG%.bak" >nul
 copy /Y "!CI_CFG_SRC!" "%TEST_CONFIG%" >nul
 
-ctest -V -C %BUILD_TYPE% %VERBOSE%
+ctest -C %BUILD_TYPE% %VERBOSE%
 set "CI_EXIT=!errorlevel!"
 
 REM Restore original config immediately

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -5,13 +5,16 @@ set -euo pipefail
 source "$(dirname "$0")/env_common.sh"
 
 BUILD_TYPE="Release"
+# Default to minimal output: only failed tests print their log, plus the
+# final pass/fail/total summary line. Pass -q/--quiet to suppress even the
+# per-test START/PASS lines (-Q = summary only).
 VERBOSE="--output-on-failure"
 
 for arg in "$@"; do
     case "$arg" in
         --debug|-debug) BUILD_TYPE="Debug" ;;
         --release|-release) BUILD_TYPE="Release" ;;
-        -q|--quiet) VERBOSE="" ;;
+        -q|--quiet) VERBOSE="-Q" ;;
     esac
 done
 

--- a/tools/api-diff/api-baseline.txt
+++ b/tools/api-diff/api-baseline.txt
@@ -429,6 +429,7 @@ namespace authforge::common::ports
 {
 enum class LogLevel
 {
+Trace,
 Debug,
 Info,
 Warn,


### PR DESCRIPTION
## Summary

Two related `chore` commits bundled here for review.

### 1. `chore(logging): standardize log levels across the codebase`

Normalizes the six-level logging scheme (trace/debug/info/warn/error/fatal) end to end: port, call sites, config defaults, ctest output, and docs.

**Framework**
- Adds `LogLevel::Trace` to the `ILogger` port and routes it through `DrogonLogger` (`LOG_TRACE`). Previously Trace was absent from the enum and silently dropped by the adapter, yet 39 `LOG_TRACE` call sites (generated ORM model headers) already existed — the "no LOG_TRACE in scope" premise was stale.
- Adds `FakeLoggerTest.CapturesTraceLevel` regression guard.

**Call-site audit (~22 misclassified sites, non-generated code only)**
- Recoverable failures that still succeed: `error` → `warn` (AuthService role-assign/default-role, PostgresIdentityRepository, MfaController pending-clear, OAuth2CleanupService background failures, ControllerRegistration plugin-not-found fallback).
- Operations that fail outright with no fallback: `warn`/`debug` → `error` (AuthService validate-user/get-user-info DB exception paths, reset-login-counter write, PostgresTokenRepository introspect-count & revocation-audit writes).
- DB-exception paths blended into not-found branches: `debug` → `warn` (Postgres/Redis grant & token get-or-not-found).
- Audit-worthy business successes: `debug` → `info` (token revocation, consent save/revoke, cleanup-cycle start, RedisRepositoryBase init).

**Config defaults**
- `config.prod.json`: WARN → **INFO** (per the "production defaults to info+" rule).
- `config.dev.json`: revert stray WARN → **DEBUG** (dev = debug).
- `config.json`/`config.ci.json` already DEBUG, unchanged.

**CTest minimal output**
- Drops `-V` from `test.bat` and CI (`_build-test.yml`, `_sdk-smoke.yml`) so only failed tests print their logs plus the pass/fail/total summary.
- `-q`/`--quiet` now maps to ctest `-Q` (summary only); `--output-on-failure` stays the default.

**Docs**
- `observability.md §3.2`: full six-level table, conventions, dynamic `log_level` adjustment, Domain-via-`ILogger` / Adapter-via-`LOG_*` layering rule.
- `testing-guide.md`: document the minimal-output ctest strategy.
- `CONTRIBUTING.md`: new "Logging" section with quick-decision table + note on deliberately-deferred policy-call sites (audit residue).

### 2. `chore(config): broaden local dev/CI CORS origins and add GitHub OAuth stub`

- `cors.allow_origins`: drop redundant `http://127.0.0.1:5173`, add `localhost:5174/8080/8081`.
- `vue-client.redirect_uri`: add `http://localhost:8080/callback`.
- `external_auth.github`: placeholder block (`YOUR_GITHUB_CLIENT_ID` / `YOUR_GITHUB_CLIENT_SECRET`) mirroring the existing `wechat` placeholder — real creds via env-var overrides at runtime.
- Applies to `config.json`, `config.dev.json`, `config.ci.json`.

## Verification

- **Build**: `windows-msvc` preset — clean (C4819 warnings are pre-existing UTF-8/codepage noise, unrelated).
- **Tests**: `ctest -C Release --output-on-failure` → **299/299 passed, 0 failed** (incl. the new `CapturesTraceLevel` regression test).
- Minimal-output ctest strategy observed end to end (failed-test logs + final summary only).

## Notes / out of scope

- The full migration of ~559 raw `LOG_*` macro call sites to the `ILogger` port (design.md §5.6 Task-14) is **not** included — that's a separate mechanical PR.
- ~25 "policy-call" log sites (e.g. the `[METRIC]` log-based metric emissions at info, routine 401/403 denials at warn) are intentionally left for a deliberate follow-up; documented in CONTRIBUTING.md as audit residue.
- Generated ORM model code (`libs/storage-postgres/{src/models,include/.../models}/`) correctly uses fatal/trace — untouched.