### PR TITLE
feat(admin): user management CRUD — pagination, search/filter, createUser, expanded updateUser

### DIFF
--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -350,8 +350,46 @@ paths:
       - Tokens
   /api/admin/users:
     get:
-      description: Get a paginated list of users.
+      description: >-
+        List users with optional pagination (page, per_page) and filtering
+        (q for username/email prefix, role, locked). Returns total count.
       operationId: get_api_admin_users
+      parameters:
+      - description: Page number (1-based)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 1
+      - description: Items per page (1-100)
+        in: query
+        name: per_page
+        required: false
+        schema:
+          type: integer
+          default: 50
+          minimum: 1
+          maximum: 100
+      - description: Search by username or email prefix
+        in: query
+        name: q
+        required: false
+        schema:
+          type: string
+      - description: Filter by role name
+        in: query
+        name: role
+        required: false
+        schema:
+          type: string
+      - description: Filter by lock state (true = locked, false = active)
+        in: query
+        name: locked
+        required: false
+        schema:
+          type: string
+          enum: ["true", "false"]
       responses:
         '200':
           description: Users list
@@ -360,6 +398,51 @@ paths:
       security:
       - bearerAuth: []
       summary: List Users
+      tags:
+      - Admin
+      - Users
+    post:
+      description: >-
+        Create a new user. Requires username and password; email, roles,
+        mfa_enabled, email_verified, and org_id are optional.
+      operationId: post_api_admin_users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, password]
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+                  format: password
+                email:
+                  type: string
+                email_verified:
+                  type: boolean
+                mfa_enabled:
+                  type: boolean
+                org_id:
+                  type: integer
+                roles:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: User created successfully
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: Create User
       tags:
       - Admin
       - Users

--- a/frontends/admin/src/pages/users/UserDetailPage.vue
+++ b/frontends/admin/src/pages/users/UserDetailPage.vue
@@ -16,8 +16,12 @@ const errorMessage = ref('')
 
 const user = ref<any>({})
 const allRoles = ref<any[]>([])
+const editUsername = ref('')
 const editEmail = ref('')
 const editEmailVerified = ref(false)
+const editMfaEnabled = ref(false)
+const editLocked = ref(false)
+const editOrgId = ref<number | ''>('')
 const selectedRoles = ref<string[]>([])
 
 function showSuccess(msg: string) {
@@ -36,8 +40,12 @@ async function fetchUser() {
   try {
     const resp = await axios.get(`/api/admin/users/${userId.value}`)
     user.value = resp.data
+    editUsername.value = resp.data.username || ''
     editEmail.value = resp.data.email || ''
     editEmailVerified.value = resp.data.email_verified || false
+    editMfaEnabled.value = resp.data.mfa_enabled || false
+    editLocked.value = resp.data.locked || false
+    editOrgId.value = resp.data.org_id ?? ''
     selectedRoles.value = (resp.data.roles || []).filter((r: any) => typeof r === 'string')
   } catch (e: unknown) {
     showError(normalizeError(e).message)
@@ -57,8 +65,12 @@ async function saveInfo() {
   saving.value = true
   try {
     const body: any = {}
+    if (editUsername.value !== (user.value.username || '')) body.username = editUsername.value
     if (editEmail.value !== (user.value.email || '')) body.email = editEmail.value
     if (editEmailVerified.value !== user.value.email_verified) body.email_verified = editEmailVerified.value
+    if (editMfaEnabled.value !== user.value.mfa_enabled) body.mfa_enabled = editMfaEnabled.value
+    if (editLocked.value !== (user.value.locked || false)) body.locked = editLocked.value
+    if (editOrgId.value !== (user.value.org_id ?? '')) body.org_id = editOrgId.value
     if (Object.keys(body).length === 0) { showSuccess('No changes'); saving.value = false; return }
     await axios.put(`/api/admin/users/${userId.value}`, body, { headers: { 'Content-Type': 'application/json' } })
     showSuccess('User updated successfully')
@@ -174,7 +186,7 @@ onMounted(() => {
       <div v-if="activeTab === 'info'" class="bg-white shadow rounded-lg p-6 space-y-5">
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Username</label>
-          <code class="block px-3 py-2 bg-gray-100 rounded-md text-sm font-mono">{{ user.username }}</code>
+          <input v-model="editUsername" class="block w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono" placeholder="username" />
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
@@ -183,6 +195,18 @@ onMounted(() => {
         <div class="flex items-center gap-3">
           <input type="checkbox" v-model="editEmailVerified" id="emailVerified" class="h-4 w-4 rounded border-gray-300 text-indigo-600" />
           <label for="emailVerified" class="text-sm font-medium text-gray-700">Email Verified</label>
+        </div>
+        <div class="flex items-center gap-3">
+          <input type="checkbox" v-model="editMfaEnabled" id="mfaEnabled" class="h-4 w-4 rounded border-gray-300 text-indigo-600" />
+          <label for="mfaEnabled" class="text-sm font-medium text-gray-700">MFA Enabled</label>
+        </div>
+        <div class="flex items-center gap-3">
+          <input type="checkbox" v-model="editLocked" id="locked" class="h-4 w-4 rounded border-gray-300 text-red-600" />
+          <label for="locked" class="text-sm font-medium text-gray-700">Account Locked</label>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Organization ID</label>
+          <input v-model="editOrgId" type="number" class="block w-full px-3 py-2 border border-gray-300 rounded-md text-sm" placeholder="(none)" />
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Created At</label>

--- a/frontends/admin/src/pages/users/UsersPage.vue
+++ b/frontends/admin/src/pages/users/UsersPage.vue
@@ -1,38 +1,77 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import axios from 'axios'
 import { normalizeError } from '../../services/errorAdapter'
 
 const users = ref<any[]>([])
 const loading = ref(true)
 const showRoleModal = ref(false)
+const showCreateModal = ref(false)
 const selectedUser = ref<any>(null)
 const roleInput = ref('')
 const saving = ref(false)
 const errorMessage = ref('')
+const successMessage = ref('')
 
-// Inline error banner (replaces native alert for backend errors, Req 10.6).
+// Pagination + search/filter state
+const currentPage = ref(1)
+const perPage = ref(50)
+const total = ref(0)
+const totalPages = ref(0)
+const searchQuery = ref('')
+const roleFilter = ref('')
+const lockedFilter = ref('')
+
+// Create-user form state
+const createForm = ref({ username: '', password: '', email: '', roles: '' })
+
+const hasPrev = computed(() => currentPage.value > 1)
+const hasNext = computed(() => currentPage.value < totalPages.value)
+
 function showError(msg: string) {
   errorMessage.value = msg
   setTimeout(() => { errorMessage.value = '' }, 5000)
+}
+function showSuccess(msg: string) {
+  successMessage.value = msg
+  setTimeout(() => { successMessage.value = '' }, 3000)
 }
 
 async function fetchUsers() {
   loading.value = true
   try {
-    const resp = await axios.get('/api/admin/users')
+    const params: Record<string, string | number> = {
+      page: currentPage.value,
+      per_page: perPage.value,
+    }
+    if (searchQuery.value) params.q = searchQuery.value
+    if (roleFilter.value) params.role = roleFilter.value
+    if (lockedFilter.value) params.locked = lockedFilter.value
+    const resp = await axios.get('/api/admin/users', { params })
     users.value = resp.data.users || []
+    total.value = resp.data.total || 0
+    totalPages.value = resp.data.total_pages || 0
   } catch (e: unknown) {
-    // Display the localized message via the Frontend_Error_Module (Req 10.2).
     showError(normalizeError(e).message)
   } finally {
     loading.value = false
   }
 }
 
+function applySearch() {
+  currentPage.value = 1
+  fetchUsers()
+}
+
+function goToPage(page: number) {
+  if (page < 1 || page > totalPages.value) return
+  currentPage.value = page
+  fetchUsers()
+}
+
 function openRoleModal(user: any) {
   selectedUser.value = user
-  roleInput.value = ''  // Will be populated when we have role info
+  roleInput.value = (user.roles || []).join(', ')
   showRoleModal.value = true
 }
 
@@ -45,9 +84,36 @@ async function assignRoles() {
       headers: { 'Content-Type': 'application/json' },
     })
     showRoleModal.value = false
+    showSuccess('Roles assigned successfully')
     await fetchUsers()
   } catch (e: unknown) {
-    // Req 10.3/10.6: normalize via Frontend_Error_Module, no native alert.
+    showError(normalizeError(e).message)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function createUser() {
+  if (!createForm.value.username.trim() || !createForm.value.password.trim()) {
+    showError('Username and password are required')
+    return
+  }
+  saving.value = true
+  try {
+    const body: any = {
+      username: createForm.value.username,
+      password: createForm.value.password,
+    }
+    if (createForm.value.email) body.email = createForm.value.email
+    if (createForm.value.roles) {
+      body.roles = createForm.value.roles.split(',').map((r: string) => r.trim()).filter(Boolean)
+    }
+    await axios.post('/api/admin/users', body, { headers: { 'Content-Type': 'application/json' } })
+    showCreateModal.value = false
+    createForm.value = { username: '', password: '', email: '', roles: '' }
+    showSuccess('User created successfully')
+    await fetchUsers()
+  } catch (e: unknown) {
     showError(normalizeError(e).message)
   } finally {
     saving.value = false
@@ -59,9 +125,36 @@ onMounted(fetchUsers)
 
 <template>
   <div>
-    <h2 class="text-2xl font-bold text-gray-900 mb-6">Users</h2>
+    <div class="flex items-center justify-between mb-6">
+      <h2 class="text-2xl font-bold text-gray-900">Users</h2>
+      <button @click="showCreateModal = true"
+        class="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700">
+        + Create User
+      </button>
+    </div>
 
     <div v-if="errorMessage" class="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">{{ errorMessage }}</div>
+    <div v-if="successMessage" class="mb-4 p-3 bg-green-50 border border-green-200 text-green-700 rounded-md text-sm">{{ successMessage }}</div>
+
+    <!-- Search + filter bar -->
+    <div class="mb-4 flex flex-wrap items-center gap-3">
+      <input v-model="searchQuery" @keyup.enter="applySearch"
+        class="px-3 py-2 border border-gray-300 rounded-md text-sm w-64"
+        placeholder="Search username or email..." />
+      <select v-model="roleFilter" @change="applySearch"
+        class="px-3 py-2 border border-gray-300 rounded-md text-sm">
+        <option value="">All roles</option>
+        <option value="admin">admin</option>
+        <option value="user">user</option>
+      </select>
+      <select v-model="lockedFilter" @change="applySearch"
+        class="px-3 py-2 border border-gray-300 rounded-md text-sm">
+        <option value="">All status</option>
+        <option value="true">Locked</option>
+        <option value="false">Active</option>
+      </select>
+      <button @click="applySearch" class="px-4 py-2 bg-gray-100 text-gray-700 rounded-md text-sm hover:bg-gray-200">Search</button>
+    </div>
 
     <div v-if="loading" class="text-center py-12 text-gray-500">Loading...</div>
 
@@ -69,6 +162,7 @@ onMounted(fetchUsers)
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">ID</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Username</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Verified</th>
@@ -78,6 +172,7 @@ onMounted(fetchUsers)
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
           <tr v-for="user in users" :key="user.id" class="hover:bg-gray-50">
+            <td class="px-6 py-4 text-sm text-gray-400">{{ user.id }}</td>
             <td class="px-6 py-4 text-sm font-medium text-gray-900">{{ user.username }}</td>
             <td class="px-6 py-4 text-sm text-gray-500">{{ user.email || '—' }}</td>
             <td class="px-6 py-4">
@@ -97,6 +192,55 @@ onMounted(fetchUsers)
           </tr>
         </tbody>
       </table>
+
+      <!-- Pagination controls -->
+      <div v-if="totalPages > 1" class="px-6 py-3 bg-gray-50 flex items-center justify-between border-t border-gray-200">
+        <span class="text-sm text-gray-600">
+          {{ total }} user(s) · Page {{ currentPage }} of {{ totalPages }}
+        </span>
+        <div class="flex gap-2">
+          <button @click="goToPage(currentPage - 1)" :disabled="!hasPrev"
+            class="px-3 py-1.5 border border-gray-300 rounded-md text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100">
+            Previous
+          </button>
+          <button @click="goToPage(currentPage + 1)" :disabled="!hasNext"
+            class="px-3 py-1.5 border border-gray-300 rounded-md text-sm disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100">
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create User Modal -->
+    <div v-if="showCreateModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+        <h3 class="text-lg font-semibold mb-4">Create User</h3>
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Username *</label>
+            <input v-model="createForm.username" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md text-sm" placeholder="newuser" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Password *</label>
+            <input v-model="createForm.password" type="password" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md text-sm" placeholder="••••••••" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Email</label>
+            <input v-model="createForm.email" type="email" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md text-sm" placeholder="user@example.com" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Roles (comma-separated)</label>
+            <input v-model="createForm.roles" class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md text-sm" placeholder="user" />
+            <p class="mt-1 text-xs text-gray-500">Default: user. Available: admin, user</p>
+          </div>
+        </div>
+        <div class="flex justify-end space-x-3 mt-6">
+          <button @click="showCreateModal = false" class="px-4 py-2 border border-gray-300 rounded-md text-sm">Cancel</button>
+          <button @click="createUser" :disabled="saving" class="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm hover:bg-indigo-700 disabled:opacity-50">
+            {{ saving ? 'Creating...' : 'Create User' }}
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Role Assignment Modal -->

--- a/frontends/admin/tests/e2e/helpers/mock-api.ts
+++ b/frontends/admin/tests/e2e/helpers/mock-api.ts
@@ -104,6 +104,7 @@ export const MOCK_USER_DETAIL = {
   failed_login_count: 0,
   locked: false,
   locked_until: 0,
+  org_id: null,
   created_at: '2026-05-01T00:00:00Z',
   roles: ['admin', 'user'],
 }
@@ -229,13 +230,90 @@ export async function setupAuthenticatedMocks(page: Page) {
     })
   })
 
-  // Admin users
+  // Admin users (GET list with pagination/filter, POST create)
   await page.route('**/api/admin/users', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ users: MOCK_USERS }),
-    })
+    const method = route.request().method()
+    if (method === 'GET')
+    {
+      const url = new URL(route.request().url())
+      const q = url.searchParams.get('q') || ''
+      const locked = url.searchParams.get('locked')
+      let page = parseInt(url.searchParams.get('page') || '1', 10) || 1
+      let perPage = parseInt(url.searchParams.get('per_page') || '50', 10) || 50
+      if (perPage > 100) perPage = 100
+      if (perPage < 1) perPage = 50
+      if (page < 1) page = 1
+
+      let filtered = MOCK_USERS
+      if (q)
+      {
+        const ql = q.toLowerCase()
+        filtered = filtered.filter(
+          (u) => (u.username || '').toLowerCase().startsWith(ql) ||
+                 (u.email || '').toLowerCase().startsWith(ql)
+        )
+      }
+      if (locked === 'true')
+      {
+        filtered = filtered.filter((u) => (u as any).locked === true)
+      }
+      else if (locked === 'false')
+      {
+        filtered = filtered.filter((u) => !(u as any).locked)
+      }
+
+      const total = filtered.length
+      const totalPages = total > 0 ? Math.ceil(total / perPage) : 0
+      const start = (page - 1) * perPage
+      const pageUsers = filtered.slice(start, start + perPage)
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'success',
+          page,
+          per_page: perPage,
+          total,
+          total_pages: totalPages,
+          users: pageUsers,
+        }),
+      })
+    }
+    else if (method === 'POST')
+    {
+      const body = JSON.parse(route.request().postData() || '{}')
+      // Duplicate username check.
+      if (MOCK_USERS.some((u) => u.username === body.username))
+      {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'VALIDATION_USERNAME_TAKEN', message: 'Username already exists' },
+          }),
+        })
+      }
+      else
+      {
+        const newUser = {
+          id: Date.now(),
+          username: body.username,
+          email: body.email || '',
+          email_verified: false,
+          mfa_enabled: false,
+        }
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', message: 'User created successfully', user: newUser }),
+        })
+      }
+    }
+    else
+    {
+      await route.continue()
+    }
   })
 
   // User detail - sub-resources (must be registered before the wildcard)

--- a/frontends/admin/tests/e2e/users.spec.ts
+++ b/frontends/admin/tests/e2e/users.spec.ts
@@ -156,4 +156,78 @@ test.describe('User Management', () => {
     const errorEl = page.locator('.bg-red-50, .text-red-700')
     await expect(errorEl.first()).toBeVisible()
   })
+
+  test('opens Create User modal', async ({ page }) => {
+    await page.click('button:has-text("Create User")')
+    await expect(page.locator('h3:has-text("Create User")')).toBeVisible()
+    await expect(page.locator('input[placeholder="newuser"]')).toBeVisible()
+  })
+
+  test('creates a user successfully', async ({ page }) => {
+    let createRequestBody: any = null
+    await page.route('**/api/admin/users', async (route) => {
+      if (route.request().method() === 'POST') {
+        createRequestBody = JSON.parse(route.request().postData() || '{}')
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', message: 'User created successfully', user: { id: 99, username: 'newuser_test', email: 'new@test.com' } }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+    await page.click('button:has-text("Create User")')
+    await page.fill('input[placeholder="newuser"]', 'newuser_test')
+    await page.fill('input[placeholder="••••••••"]', 'TestPass123!')
+    await page.click('button:has-text("Create User"):not(:has-text("Create User)"))')
+    // The modal-specific create button
+    await page.locator('.fixed button:has-text("Create User")').click()
+    await expect(page.locator('.bg-green-50')).toBeVisible({ timeout: 5000 })
+    expect(createRequestBody.username).toBe('newuser_test')
+  })
+
+  test('search filters user list', async ({ page }) => {
+    // Override the users route to return a filtered result for "testuser"
+    await page.route('**/api/admin/users**', async (route) => {
+      const url = new URL(route.request().url())
+      const q = url.searchParams.get('q')
+      if (q && q.length > 0) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'success', page: 1, per_page: 50, total: 1, total_pages: 1, users: [MOCK_USERS[1]] }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+    await page.fill('input[placeholder="Search username or email..."]', 'testuser')
+    await page.click('button:has-text("Search")')
+    await page.waitForLoadState('networkidle')
+    const tableBody = page.locator('tbody')
+    await expect(tableBody.getByRole('cell', { name: 'testuser', exact: true })).toBeVisible()
+    // admin user should NOT be present
+    await expect(tableBody.getByRole('cell', { name: 'admin', exact: true })).toBeHidden()
+  })
+
+  test('duplicate username shows error', async ({ page }) => {
+    await page.route('**/api/admin/users', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { code: 'VALIDATION_USERNAME_TAKEN', message: 'Username already exists' } }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+    await page.click('button:has-text("Create User")')
+    await page.fill('input[placeholder="newuser"]', 'admin')
+    await page.fill('input[placeholder="••••••••"]', 'TestPass123!')
+    await page.locator('.fixed button:has-text("Create User")').click()
+    const errorEl = page.locator('.bg-red-50')
+    await expect(errorEl.first()).toBeVisible({ timeout: 5000 })
+  })
 })

--- a/libs/drogon/include/authforge/drogon/admin/UserAdminService.h
+++ b/libs/drogon/include/authforge/drogon/admin/UserAdminService.h
@@ -29,6 +29,7 @@ class UserAdminService
       std::shared_ptr<std::function<void(const ::drogon::HttpResponsePtr &)>>;
 
     static void listUsers(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
+    static void createUser(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
     static void getUser(
       const ::drogon::HttpRequestPtr &req,
       ResponseCallback cb,

--- a/libs/drogon/include/authforge/drogon/controllers/UserAdminController.h
+++ b/libs/drogon/include/authforge/drogon/controllers/UserAdminController.h
@@ -22,6 +22,12 @@ class UserAdminController : public ::drogon::HttpController<UserAdminController,
       "authforge::drogon::filters::AuthorizationFilter"
     );
     ADD_METHOD_TO(
+      UserAdminController::createUser,
+      "/api/admin/users",
+      ::drogon::Post,
+      "authforge::drogon::filters::AuthorizationFilter"
+    );
+    ADD_METHOD_TO(
       UserAdminController::getUser,
       "/api/admin/users/{userId}",
       ::drogon::Get,
@@ -60,6 +66,11 @@ class UserAdminController : public ::drogon::HttpController<UserAdminController,
     METHOD_LIST_END
 
     void listUsers(
+      const ::drogon::HttpRequestPtr &req,
+      std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
+    );
+
+    void createUser(
       const ::drogon::HttpRequestPtr &req,
       std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
     );

--- a/libs/drogon/src/admin/UserAdminService.cc
+++ b/libs/drogon/src/admin/UserAdminService.cc
@@ -645,13 +645,16 @@ void UserAdminService::createUser(const ::drogon::HttpRequestPtr &req, ResponseC
               }
           },
           [req, cb](const ::drogon::orm::DrogonDbException &e) {
-              // UNIQUE violation on username → friendly error code.
+              // Distinguish username vs email UNIQUE violations by constraint
+              // name (same pattern as AuthService / PostgresIdentityRepository).
               std::string what = e.base().what();
-              if (what.find("unique") != std::string::npos ||
-                  what.find("duplicate") != std::string::npos ||
-                  what.find("UNIQUE") != std::string::npos)
+              if (what.find("users_username_key") != std::string::npos)
               {
                   respondError(req, cb, "VALIDATION_USERNAME_TAKEN", "Username already exists");
+              }
+              else if (what.find("idx_users_email_unique") != std::string::npos)
+              {
+                  respondError(req, cb, "VALIDATION_EMAIL_TAKEN", "Email already in use");
               }
               else
               {
@@ -825,11 +828,23 @@ void UserAdminService::updateUser(
                         (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
                     },
                     [req, cb](const ::drogon::orm::DrogonDbException &e) {
-                        // UNIQUE-violation on username/email surfaces here.
-                        respondError(
-                          req, cb, "DB_QUERY_ERROR",
-                          std::string("Failed to update user: ") + e.base().what()
-                        );
+                        // Distinguish username vs email UNIQUE violations.
+                        std::string what = e.base().what();
+                        if (what.find("users_username_key") != std::string::npos)
+                        {
+                            respondError(req, cb, "VALIDATION_USERNAME_TAKEN", "Username already exists");
+                        }
+                        else if (what.find("idx_users_email_unique") != std::string::npos)
+                        {
+                            respondError(req, cb, "VALIDATION_EMAIL_TAKEN", "Email already in use");
+                        }
+                        else
+                        {
+                            respondError(
+                              req, cb, "DB_QUERY_ERROR",
+                              std::string("Failed to update user: ") + what
+                            );
+                        }
                     }
                   );
               }

--- a/libs/drogon/src/admin/UserAdminService.cc
+++ b/libs/drogon/src/admin/UserAdminService.cc
@@ -4,6 +4,9 @@
 #include <authforge/storage/postgres/models/UserRoles.h>
 #include <authforge/storage/postgres/models/Roles.h>
 #include <authforge/drogon/error/ErrorResponder.h>
+#include <authforge/drogon/utils/PasswordHasher.h>
+#include <authforge/drogon/adapters/DrogonAuditSink.h>
+#include <authforge/drogon/plugin/OAuth2Plugin.h>
 #include <authforge/common/utils/EmailNormalizer.h>
 
 #include <drogon/drogon.h>
@@ -39,6 +42,13 @@ void respondError(
 using namespace ::drogon::orm;
 using namespace ::drogon_model::oauth2_db;
 
+// Parsed pagination query params (page is 1-based).
+struct PaginationParams
+{
+    int page;
+    int perPage;
+};
+
 ::drogon::orm::DbClientPtr getDbOrRespond(
   const ::drogon::HttpRequestPtr &req,
   const UserAdminService::ResponseCallback &cb
@@ -59,6 +69,67 @@ using namespace ::drogon_model::oauth2_db;
 // forever". Kept identical so lockedUntil semantics are unchanged.
 constexpr int64_t kLockedForeverSentinel = 9999999999;
 
+// Current epoch seconds (locked_until is stored as epoch seconds).
+int64_t nowEpochSeconds()
+{
+    return static_cast<int64_t>(std::chrono::duration_cast<std::chrono::seconds>(
+                                  std::chrono::system_clock::now().time_since_epoch()
+    )
+                                  .count());
+}
+
+// Parse page/per_page query params with the same clamping as AuditService.
+PaginationParams parsePagination(const ::drogon::HttpRequestPtr &req)
+{
+    PaginationParams p{1, 50};
+    try { p.page = std::stoi(req->getParameter("page")); } catch (...) {}
+    try { p.perPage = std::stoi(req->getParameter("per_page")); } catch (...) {}
+    if (p.perPage > 100) p.perPage = 100;
+    if (p.perPage < 1) p.perPage = 50;
+    if (p.page < 1) p.page = 1;
+    return p;
+}
+
+// Read the validated admin actor's subject from the request attributes
+// (persisted by AuthorizationFilter in B1). Falls back to empty string if the
+// attribute is absent (e.g. older filter) so audit never throws.
+std::string adminActorId(const ::drogon::HttpRequestPtr &req)
+{
+    try
+    {
+        return req->getAttributes()->get<std::string>("userId");
+    }
+    catch (...)
+    {
+        return "";
+    }
+}
+
+// Fire-and-forget audit entry. The sink is a no-op in memory storage mode, so
+// this is safe to call unconditionally.
+void auditFromRequest(
+  const ::drogon::HttpRequestPtr &req,
+  const std::string &action,
+  const std::string &outcome,
+  const std::string &targetType,
+  const std::string &targetId
+)
+{
+    auto *plugin = ::drogon::app().getPlugin<::OAuth2Plugin>();
+    if (!plugin)
+        return;
+    ::authforge::drogon::adapters::DrogonAuditSink::logFromRequest(
+      plugin->getAuditSink(),
+      action,
+      outcome,
+      req,
+      adminActorId(req),
+      targetType,
+      targetId,
+      Json::Value{}
+    );
+}
+
 Json::Value userRowToListJson(const Users &row)
 {
     Json::Value user;
@@ -69,120 +140,299 @@ Json::Value userRowToListJson(const Users &row)
     user["mfa_enabled"] = row.getValueOfMfaEnabled();
     return user;
 }
+
+// Build the final paginated JSON envelope.  userIdToRoleNames is optional
+// (empty when no roles were fetched, e.g. for an empty page).
+void respondUserListEnvelope(
+  const UserAdminService::ResponseCallback &cb,
+  const std::vector<Users> &rows,
+  const std::unordered_map<int32_t, std::vector<std::string>> &userIdToRoleNames,
+  int page,
+  int perPage,
+  size_t total,
+  int totalPages
+)
+{
+    Json::Value json;
+    json["status"] = "success";
+    json["page"] = page;
+    json["per_page"] = perPage;
+    json["total"] = static_cast<Json::UInt64>(total);
+    json["total_pages"] = totalPages;
+    Json::Value users(Json::arrayValue);
+    for (const auto &row : rows)
+    {
+        Json::Value user = userRowToListJson(row);
+        Json::Value rolesJson(Json::arrayValue);
+        auto it = userIdToRoleNames.find(row.getValueOfId());
+        if (it != userIdToRoleNames.end())
+        {
+            for (const auto &rn : it->second)
+            {
+                rolesJson.append(rn);
+            }
+        }
+        user["roles"] = rolesJson;
+        users.append(user);
+    }
+    json["users"] = users;
+    (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
+}
+
+// Given the page rows, fan-out role names (two Mapper queries — no JOIN), then
+// respond with the full envelope.  total/totalPages were already computed from
+// a prior count() call.
+void attachRolesAndRespond(
+  const ::drogon::orm::DbClientPtr &db,
+  std::vector<Users> rows,
+  int page,
+  int perPage,
+  size_t total,
+  int totalPages,
+  const UserAdminService::ResponseCallback &cb,
+  const ::drogon::HttpRequestPtr &req
+)
+{
+    if (rows.empty())
+    {
+        respondUserListEnvelope(cb, {}, {}, page, perPage, total, totalPages);
+        return;
+    }
+    std::vector<int32_t> userIds;
+    userIds.reserve(rows.size());
+    for (const auto &r : rows)
+    {
+        userIds.push_back(r.getValueOfId());
+    }
+    try
+    {
+        Mapper<UserRoles> urMapper(db);
+        urMapper.findBy(
+          Criteria(UserRoles::Cols::_user_id, CompareOperator::In, userIds),
+          [cb, req, db, rows = std::move(rows), page, perPage, total, totalPages](
+            const std::vector<UserRoles> &allUserRoles
+          ) {
+              std::unordered_map<int32_t, std::vector<int32_t>> userIdToRoleIds;
+              std::set<int32_t> distinctRoleIds;
+              for (const auto &ur : allUserRoles)
+              {
+                  userIdToRoleIds[ur.getValueOfUserId()].push_back(ur.getValueOfRoleId());
+                  distinctRoleIds.insert(ur.getValueOfRoleId());
+              }
+              if (distinctRoleIds.empty())
+              {
+                  respondUserListEnvelope(cb, rows, {}, page, perPage, total, totalPages);
+                  return;
+              }
+              std::vector<int32_t> roleIdsVec(distinctRoleIds.begin(), distinctRoleIds.end());
+              try
+              {
+                  Mapper<Roles> rMapper(db);
+                  rMapper.findBy(
+                    Criteria(Roles::Cols::_id, CompareOperator::In, roleIdsVec),
+                    [cb, rows = std::move(rows), userIdToRoleIds = std::move(userIdToRoleIds), page, perPage, total, totalPages](
+                      const std::vector<Roles> &allRoles
+                    ) {
+                        std::unordered_map<int32_t, std::string> roleIdToName;
+                        for (const auto &r : allRoles)
+                        {
+                            roleIdToName[r.getValueOfId()] = r.getValueOfName();
+                        }
+                        std::unordered_map<int32_t, std::vector<std::string>> userIdToRoleNames;
+                        for (const auto &row : rows)
+                        {
+                            auto it = userIdToRoleIds.find(row.getValueOfId());
+                            if (it != userIdToRoleIds.end())
+                            {
+                                for (int32_t rid : it->second)
+                                {
+                                    auto rn = roleIdToName.find(rid);
+                                    if (rn != roleIdToName.end())
+                                    {
+                                        userIdToRoleNames[row.getValueOfId()].push_back(rn->second);
+                                    }
+                                }
+                            }
+                        }
+                        respondUserListEnvelope(cb, rows, userIdToRoleNames, page, perPage, total, totalPages);
+                    },
+                    [req, cb](const ::drogon::orm::DrogonDbException &e) {
+                        respondError(req, cb, "DB_QUERY_ERROR", std::string("Failed to fetch roles: ") + e.base().what());
+                    }
+                  );
+              }
+              catch (...)
+              {
+                  respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct roles Mapper");
+              }
+          },
+          [req, cb](const ::drogon::orm::DrogonDbException &e) {
+              respondError(req, cb, "DB_QUERY_ERROR", std::string("Failed to fetch user roles: ") + e.base().what());
+          }
+        );
+    }
+    catch (...)
+    {
+        respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct user-roles Mapper");
+    }
+}
 }  // namespace
 
 void UserAdminService::listUsers(const ::drogon::HttpRequestPtr &req, ResponseCallback cb)
 {
+    auto pagination = parsePagination(req);
+    std::string q = req->getParameter("q");
+    std::string role = req->getParameter("role");
+    std::string locked = req->getParameter("locked");
+
     auto db = getDbOrRespond(req, cb);
     if (!db)
     {
         return;
     }
 
-    Mapper<Users> mapper(db);
-    mapper.findBy(
-      Criteria(),
-      [cb, req, db](const std::vector<Users> &rows) {
-          if (rows.empty())
-          {
-              Json::Value json;
-              json["status"] = "success";
-              json["users"] = Json::Value(Json::arrayValue);
-              json["total"] = 0;
-              (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
-              return;
-          }
-          // Batch-fetch roles for all users: user_roles -> role_ids -> roles
-          std::vector<int32_t> allUserIds;
-          allUserIds.reserve(rows.size());
-          for (const auto &r : rows)
-              allUserIds.push_back(r.getValueOfId());
+    // Build the base filter from search (q) and lock-state (locked) params.
+    // locked has no column — it is derived from locked_until vs current time.
+    int64_t now = nowEpochSeconds();
+    Criteria baseFilter;
+    if (!q.empty())
+    {
+        baseFilter = baseFilter &&
+                     (Criteria(Users::Cols::_username, CompareOperator::Like, q + "%") ||
+                      Criteria(Users::Cols::_email, CompareOperator::Like, q + "%"));
+    }
+    if (locked == "true")
+    {
+        baseFilter = baseFilter && Criteria(Users::Cols::_locked_until, CompareOperator::GT, now);
+    }
+    else if (locked == "false")
+    {
+        baseFilter = baseFilter && Criteria(Users::Cols::_locked_until, CompareOperator::LT, now);
+    }
 
-          Mapper<UserRoles> urMapper(db);
-          urMapper.findBy(
-            Criteria(UserRoles::Cols::_user_id, CompareOperator::In, allUserIds),
-            [cb, req, db, rows = std::move(rows)](const std::vector<UserRoles> &allUserRoles) {
-                std::unordered_map<int32_t, std::vector<int32_t>> userIdToRoleIds;
-                std::set<int32_t> distinctRoleIds;
-                for (const auto &ur : allUserRoles)
-                {
-                    int32_t rid = ur.getValueOfRoleId();
-                    userIdToRoleIds[ur.getValueOfUserId()].push_back(rid);
-                    distinctRoleIds.insert(rid);
-                }
-                if (distinctRoleIds.empty())
-                {
-                    Json::Value json;
-                    json["status"] = "success";
-                    Json::Value users(Json::arrayValue);
-                    for (const auto &row : rows)
-                        users.append(userRowToListJson(row));
-                    json["users"] = users;
-                    json["total"] = static_cast<int>(rows.size());
-                    (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
-                    return;
-                }
-                std::vector<int32_t> roleIdsVec(distinctRoleIds.begin(), distinctRoleIds.end());
-                Mapper<Roles> rMapper(db);
-                rMapper.findBy(
-                  Criteria(Roles::Cols::_id, CompareOperator::In, roleIdsVec),
-                  [cb, rows = std::move(rows), userIdToRoleIds = std::move(userIdToRoleIds)](
-                    const std::vector<Roles> &allRoles
-                  ) {
-                      std::unordered_map<int32_t, std::string> roleIdToName;
-                      for (const auto &r : allRoles)
-                          roleIdToName[r.getValueOfId()] = r.getValueOfName();
-
-                      Json::Value json;
-                      json["status"] = "success";
-                      Json::Value users(Json::arrayValue);
-                      for (const auto &row : rows)
-                      {
-                          Json::Value user = userRowToListJson(row);
-                          Json::Value rolesJson(Json::arrayValue);
-                          auto it = userIdToRoleIds.find(row.getValueOfId());
-                          if (it != userIdToRoleIds.end())
-                          {
-                              for (int32_t rid : it->second)
-                              {
-                                  auto rn = roleIdToName.find(rid);
-                                  if (rn != roleIdToName.end())
-                                      rolesJson.append(rn->second);
-                              }
+    // Count + paginate + fan-out roles, parameterised by the final Criteria.
+    auto fetchPage = [cb, req, db, pagination](Criteria filter) {
+        try
+        {
+            Mapper<Users> countMapper(db);
+            countMapper.count(
+              filter,
+              [cb, req, db, pagination, filter](const size_t total) {
+                  int totalPages = total > 0
+                                     ? (static_cast<int>(total) + pagination.perPage - 1) / pagination.perPage
+                                     : 0;
+                  try
+                  {
+                      Mapper<Users> pageMapper(db);
+                      pageMapper.paginate(pagination.page, pagination.perPage)
+                        .orderBy(Users::Cols::_id, SortOrder::ASC)
+                        .findBy(
+                          filter,
+                          [cb, req, db, pagination, total, totalPages](const std::vector<Users> &rows) {
+                              attachRolesAndRespond(
+                                db, std::move(rows), pagination.page, pagination.perPage, total, totalPages, cb, req
+                              );
+                          },
+                          [req, cb](const ::drogon::orm::DrogonDbException &e) {
+                              respondError(
+                                req, cb, "DB_QUERY_ERROR", std::string("Failed to fetch users: ") + e.base().what()
+                              );
                           }
-                          user["roles"] = rolesJson;
-                          users.append(user);
-                      }
-                      json["users"] = users;
-                      json["total"] = static_cast<int>(rows.size());
-                      (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
-                  },
-                  [req, cb](const ::drogon::orm::DrogonDbException &e) {
-                      respondError(
-                        req,
-                        cb,
-                        "DB_QUERY_ERROR",
-                        std::string("Failed to fetch roles: ") + e.base().what()
+                        );
+                  }
+                  catch (...)
+                  {
+                      respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct page Mapper");
+                  }
+              },
+              [req, cb](const ::drogon::orm::DrogonDbException &e) {
+                  respondError(
+                    req, cb, "DB_QUERY_ERROR", std::string("Failed to count users: ") + e.base().what()
+                  );
+              }
+            );
+        }
+        catch (...)
+        {
+            respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct count Mapper");
+        }
+    };
+
+    if (role.empty())
+    {
+        fetchPage(baseFilter);
+    }
+    else
+    {
+        // JOIN-forbidden: resolve role name -> roleIds -> userIds first, then
+        // intersect with the base filter via Criteria(id, In, userIds).
+        try
+        {
+            Mapper<Roles> roleMapper(db);
+            roleMapper.findBy(
+              Criteria(Roles::Cols::_name, CompareOperator::EQ, role),
+              [cb, req, db, baseFilter, fetchPage, pagination](const std::vector<Roles> &roles) {
+                  if (roles.empty())
+                  {
+                      // Role does not exist → empty result.
+                      respondUserListEnvelope(cb, {}, {}, pagination.page, pagination.perPage, 0, 0);
+                      return;
+                  }
+                  std::vector<int32_t> roleIds;
+                  roleIds.reserve(roles.size());
+                  for (const auto &r : roles)
+                  {
+                      roleIds.push_back(r.getValueOfId());
+                  }
+                  try
+                  {
+                      Mapper<UserRoles> urMapper(db);
+                      urMapper.findBy(
+                        Criteria(UserRoles::Cols::_role_id, CompareOperator::In, roleIds),
+                        [cb, req, db, baseFilter, fetchPage, pagination](
+                          const std::vector<UserRoles> &userRoles
+                        ) {
+                            if (userRoles.empty())
+                            {
+                                respondUserListEnvelope(cb, {}, {}, pagination.page, pagination.perPage, 0, 0);
+                                return;
+                            }
+                            std::set<int32_t> userIdSet;
+                            for (const auto &ur : userRoles)
+                            {
+                                userIdSet.insert(ur.getValueOfUserId());
+                            }
+                            std::vector<int32_t> userIds(userIdSet.begin(), userIdSet.end());
+                            Criteria finalFilter =
+                              baseFilter && Criteria(Users::Cols::_id, CompareOperator::In, userIds);
+                            fetchPage(finalFilter);
+                        },
+                        [req, cb](const ::drogon::orm::DrogonDbException &e) {
+                            respondError(
+                              req, cb, "DB_QUERY_ERROR",
+                              std::string("Failed to fetch user-roles for role filter: ") + e.base().what()
+                            );
+                        }
                       );
                   }
-                );
-            },
-            [req, cb](const ::drogon::orm::DrogonDbException &e) {
-                respondError(
-                  req,
-                  cb,
-                  "DB_QUERY_ERROR",
-                  std::string("Failed to fetch user roles: ") + e.base().what()
-                );
-            }
-          );
-      },
-      [req, cb](const ::drogon::orm::DrogonDbException &e) {
-          respondError(
-            req, cb, "DB_QUERY_ERROR", std::string("Failed to fetch users: ") + e.base().what()
-          );
-      }
-    );
+                  catch (...)
+                  {
+                      respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct user-roles Mapper");
+                  }
+              },
+              [req, cb](const ::drogon::orm::DrogonDbException &e) {
+                  respondError(
+                    req, cb, "DB_QUERY_ERROR",
+                    std::string("Failed to fetch role for filter: ") + e.base().what()
+                  );
+              }
+            );
+        }
+        catch (...)
+        {
+            respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct role Mapper");
+        }
+    }
 }
 
 // Fetch the role NAMES assigned to a user (used by getUser + getUserRoles).
@@ -239,6 +489,181 @@ void fetchUserRoleNames(
           respondError(req, cb, "DB_QUERY_ERROR", std::string(errCtx) + ": " + e.base().what());
       }
     );
+}
+
+void UserAdminService::createUser(const ::drogon::HttpRequestPtr &req, ResponseCallback cb)
+{
+    auto jsonBody = req->getJsonObject();
+    if (!jsonBody)
+    {
+        respondError(req, cb, "VALIDATION_INVALID_INPUT", "Invalid JSON body");
+        return;
+    }
+    std::string username = (*jsonBody).get("username", "").asString();
+    std::string password = (*jsonBody).get("password", "").asString();
+    std::string email = (*jsonBody).get("email", "").asString();
+    bool emailVerified = (*jsonBody).get("email_verified", false).asBool();
+    bool mfaEnabled = (*jsonBody).get("mfa_enabled", false).asBool();
+
+    if (username.empty())
+    {
+        respondError(req, cb, "VALIDATION_MISSING_REQUIRED_FIELD", "username is required");
+        return;
+    }
+    if (password.empty())
+    {
+        respondError(req, cb, "VALIDATION_MISSING_REQUIRED_FIELD", "password is required");
+        return;
+    }
+
+    // Hash password with PBKDF2-SHA256 (salt embedded in the hash string, so
+    // the Users.salt column is set to "" — same convention as AuthService).
+    std::string passwordHash;
+    try
+    {
+        passwordHash = ::authforge::common::utils::PasswordHasher::hash(password);
+    }
+    catch (const std::exception &e)
+    {
+        respondError(req, cb, "INTERNAL_ERROR", std::string("Password hashing failed: ") + e.what());
+        return;
+    }
+
+    auto db = getDbOrRespond(req, cb);
+    if (!db)
+    {
+        return;
+    }
+
+    Users row;
+    row.setUsername(username);
+    row.setPasswordHash(passwordHash);
+    row.setSalt("");
+    if (!email.empty())
+    {
+        row.setEmail(::authforge::common::utils::normalizeEmail(email));
+    }
+    row.setEmailVerified(emailVerified);
+    row.setMfaEnabled(mfaEnabled);
+    // org_id / roles handled in follow-up if specified.
+    if (jsonBody->isMember("org_id"))
+    {
+        row.setOrgId((*jsonBody)["org_id"].asInt());
+    }
+
+    try
+    {
+        Mapper<Users> mapper(db);
+        mapper.insert(
+          row,
+          [cb, req, db, username](const Users &inserted) {
+              int32_t newId = inserted.getValueOfId();
+
+              // Resolve default "user" role (or body.roles if provided) and
+              // assign it to the new user.  If the role resolution / insert
+              // fails we still report success for the user creation — the role
+              // can be assigned later via PUT /roles.
+              auto assignDefaultRole = [cb, req, newId, username, inserted]() {
+                  auditFromRequest(req, "user_create", "success", "user", std::to_string(newId));
+                  Json::Value json;
+                  json["status"] = "success";
+                  json["message"] = "User created successfully";
+                  json["user"] = userRowToListJson(inserted);
+                  json["user"]["created_at"] = inserted.getValueOfCreatedAt().toDbString();
+                  auto resp = ::drogon::HttpResponse::newHttpJsonResponse(json);
+                  resp->setStatusCode(::drogon::k201Created);
+                  (*cb)(resp);
+              };
+
+              // Determine which roles to assign.
+              std::vector<std::string> roleNames;
+              if (req->getJsonObject() && req->getJsonObject()->isMember("roles") &&
+                  (*req->getJsonObject())["roles"].isArray())
+              {
+                  for (const auto &r : (*req->getJsonObject())["roles"])
+                  {
+                      if (r.isString())
+                          roleNames.push_back(r.asString());
+                  }
+              }
+              if (roleNames.empty())
+              {
+                  roleNames.push_back("user");  // default role
+              }
+
+              // Resolve role names → ids, then insert user_roles rows.
+              try
+              {
+                  Mapper<Roles> rMapper(db);
+                  rMapper.findBy(
+                    Criteria(Roles::Cols::_name, CompareOperator::In, roleNames),
+                    [cb, req, db, newId, assignDefaultRole](const std::vector<Roles> &resolved) {
+                        // Insert each role assignment; fire response when all
+                        // complete (or immediately if none resolved).
+                        if (resolved.empty())
+                        {
+                            assignDefaultRole();
+                            return;
+                        }
+                        auto remaining = std::make_shared<std::atomic<int>>(static_cast<int>(resolved.size()));
+                        for (const auto &r : resolved)
+                        {
+                            UserRoles ur;
+                            ur.setUserId(newId);
+                            ur.setRoleId(r.getValueOfId());
+                            try
+                            {
+                                Mapper<UserRoles> insMapper(db);
+                                insMapper.insert(
+                                  ur,
+                                  [remaining, assignDefaultRole](const UserRoles &) {
+                                      if (remaining->fetch_sub(1) == 1)
+                                          assignDefaultRole();
+                                  },
+                                  [remaining, assignDefaultRole](const ::drogon::orm::DrogonDbException &) {
+                                      if (remaining->fetch_sub(1) == 1)
+                                          assignDefaultRole();
+                                  }
+                                );
+                            }
+                            catch (...)
+                            {
+                                if (remaining->fetch_sub(1) == 1)
+                                    assignDefaultRole();
+                            }
+                        }
+                    },
+                    [req, assignDefaultRole](const ::drogon::orm::DrogonDbException &) {
+                        // Role lookup failed — still report user creation success.
+                        assignDefaultRole();
+                    }
+                  );
+              }
+              catch (...)
+              {
+                  assignDefaultRole();
+              }
+          },
+          [req, cb](const ::drogon::orm::DrogonDbException &e) {
+              // UNIQUE violation on username → friendly error code.
+              std::string what = e.base().what();
+              if (what.find("unique") != std::string::npos ||
+                  what.find("duplicate") != std::string::npos ||
+                  what.find("UNIQUE") != std::string::npos)
+              {
+                  respondError(req, cb, "VALIDATION_USERNAME_TAKEN", "Username already exists");
+              }
+              else
+              {
+                  respondError(req, cb, "DB_QUERY_ERROR", std::string("Failed to create user: ") + what);
+              }
+          }
+        );
+    }
+    catch (...)
+    {
+        respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct insert Mapper");
+    }
 }
 
 void UserAdminService::getUser(
@@ -337,7 +762,11 @@ void UserAdminService::updateUser(
     }
     bool hasEmail = jsonBody->isMember("email");
     bool hasEmailVerified = jsonBody->isMember("email_verified");
-    if (!hasEmail && !hasEmailVerified)
+    bool hasUsername = jsonBody->isMember("username");
+    bool hasMfaEnabled = jsonBody->isMember("mfa_enabled");
+    bool hasLocked = jsonBody->isMember("locked");
+    bool hasOrgId = jsonBody->isMember("org_id");
+    if (!hasEmail && !hasEmailVerified && !hasUsername && !hasMfaEnabled && !hasLocked && !hasOrgId)
     {
         respondError(req, cb, "VALIDATION_INVALID_INPUT", "No updatable fields provided");
         return;
@@ -349,45 +778,75 @@ void UserAdminService::updateUser(
         return;
     }
 
-    Mapper<Users> mapper(db);
-    mapper.findOne(
-      Criteria(Users::Cols::_id, CompareOperator::EQ, id),
-      [cb, req, jsonBody, hasEmail, hasEmailVerified, db](Users row) {
-          if (hasEmail)
-          {
-              // Normalize on write (matches original -- login/password-reset
-              // lookups use the canonical form).
-              row.setEmail(
-                ::authforge::common::utils::normalizeEmail((*jsonBody)["email"].asString())
-              );
+    try
+    {
+        Mapper<Users> mapper(db);
+        mapper.findOne(
+          Criteria(Users::Cols::_id, CompareOperator::EQ, id),
+          [cb, req, jsonBody, hasEmail, hasEmailVerified, hasUsername, hasMfaEnabled, hasLocked, hasOrgId, db, id](
+            Users row
+          ) {
+              if (hasEmail)
+              {
+                  row.setEmail(::authforge::common::utils::normalizeEmail((*jsonBody)["email"].asString()));
+              }
+              if (hasEmailVerified)
+              {
+                  row.setEmailVerified((*jsonBody)["email_verified"].asBool());
+              }
+              if (hasUsername)
+              {
+                  row.setUsername((*jsonBody)["username"].asString());
+              }
+              if (hasMfaEnabled)
+              {
+                  row.setMfaEnabled((*jsonBody)["mfa_enabled"].asBool());
+              }
+              if (hasLocked)
+              {
+                  // locked is derived from locked_until: true → forever sentinel,
+                  // false → 0 (unlocked, matching enableUser).
+                  row.setLockedUntil((*jsonBody)["locked"].asBool() ? kLockedForeverSentinel : 0);
+              }
+              if (hasOrgId)
+              {
+                  row.setOrgId((*jsonBody)["org_id"].asInt());
+              }
+              try
+              {
+                  Mapper<Users> updateMapper(db);
+                  updateMapper.update(
+                    row,
+                    [cb, req, id](const size_t) {
+                        auditFromRequest(req, "user_update", "success", "user", std::to_string(id));
+                        Json::Value json;
+                        json["status"] = "success";
+                        json["message"] = "User updated successfully";
+                        (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
+                    },
+                    [req, cb](const ::drogon::orm::DrogonDbException &e) {
+                        // UNIQUE-violation on username/email surfaces here.
+                        respondError(
+                          req, cb, "DB_QUERY_ERROR",
+                          std::string("Failed to update user: ") + e.base().what()
+                        );
+                    }
+                  );
+              }
+              catch (...)
+              {
+                  respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct update Mapper");
+              }
+          },
+          [req, cb](const ::drogon::orm::DrogonDbException &) {
+              respondError(req, cb, "VALIDATION_RESOURCE_NOT_FOUND", "User not found");
           }
-          if (hasEmailVerified)
-          {
-              row.setEmailVerified((*jsonBody)["email_verified"].asBool());
-          }
-          Mapper<Users> updateMapper(db);
-          updateMapper.update(
-            row,
-            [cb, req](const size_t) {
-                Json::Value json;
-                json["status"] = "success";
-                json["message"] = "User updated successfully";
-                (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
-            },
-            [req, cb](const ::drogon::orm::DrogonDbException &e) {
-                respondError(
-                  req,
-                  cb,
-                  "DB_QUERY_ERROR",
-                  std::string("Failed to update user: ") + e.base().what()
-                );
-            }
-          );
-      },
-      [req, cb](const ::drogon::orm::DrogonDbException &) {
-          respondError(req, cb, "VALIDATION_RESOURCE_NOT_FOUND", "User not found");
-      }
-    );
+        );
+    }
+    catch (...)
+    {
+        respondError(req, cb, "DB_QUERY_ERROR", "Failed to construct findOne Mapper");
+    }
 }
 
 void UserAdminService::disableUser(

--- a/libs/drogon/src/controllers/UserAdminController.cc
+++ b/libs/drogon/src/controllers/UserAdminController.cc
@@ -49,14 +49,23 @@ void UserAdminController::initApiDocsImpl()
 {
     openapi::OpenApiGenerator::addEndpoint(
       adminEp("/api/admin/users", "GET", "List Users",
-              "Get a paginated list of users.", {"users:read"}));
+              "List users with optional pagination (page, per_page) and filtering "
+              "(q for username/email prefix, role, locked). Returns total count.",
+              {"users:read"}));
+    openapi::OpenApiGenerator::addEndpoint(
+      adminEp("/api/admin/users", "POST", "Create User",
+              "Create a new user. Requires username and password; email, roles, "
+              "mfa_enabled, email_verified, and org_id are optional.",
+              {"users:write"}));
     openapi::OpenApiGenerator::addEndpoint(
       adminEp("/api/admin/users/{userId}", "GET", "Get User Detail",
               "Get detailed information about a specific user including roles and account status.",
               {"users:read"}));
     openapi::OpenApiGenerator::addEndpoint(
       adminEp("/api/admin/users/{userId}", "PUT", "Update User",
-              "Update user information (email, email_verified).", {"users:write"}));
+              "Update user fields: email, email_verified, username, mfa_enabled, "
+              "locked, org_id.",
+              {"users:write"}));
     openapi::OpenApiGenerator::addEndpoint(
       adminEp("/api/admin/users/{userId}/disable", "PUT", "Disable User",
               "Disable a specific user account.", {"users:write"}));
@@ -81,6 +90,16 @@ void UserAdminController::listUsers(
     auto sharedCb =
       std::make_shared<std::function<void(const ::drogon::HttpResponsePtr &)>>(std::move(callback));
     UserService::listUsers(req, sharedCb);
+}
+
+void UserAdminController::createUser(
+  const ::drogon::HttpRequestPtr &req,
+  std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
+)
+{
+    auto sharedCb =
+      std::make_shared<std::function<void(const ::drogon::HttpResponsePtr &)>>(std::move(callback));
+    UserService::createUser(req, sharedCb);
 }
 
 void UserAdminController::disableUser(

--- a/libs/drogon/src/filters/AuthorizationFilter.cc
+++ b/libs/drogon/src/filters/AuthorizationFilter.cc
@@ -167,13 +167,21 @@ void AuthorizationFilter::doFilter(
                 "Bearer realm=\"authforge\", error=\"invalid_token\", "
                 "error_description=\"Invalid or expired token\""
               );
-              (*denyCbPtr)(resp);
-              return;
-          }
+                  (*denyCbPtr)(resp);
+                  return;
+              }
 
-          // 3. Get User Roles
-          plugin->getUserRoles(
-            at->userId,
+              // Persist the validated principal onto the request so downstream
+              // admin handlers can identify the actor (e.g. for audit logging
+              // on create/update). Mirrors OAuth2AuthFilter's attribute writes;
+              // without this, admin services had no way to know who called them.
+              (*req->getAttributes())["userId"] = at->userId;
+              (*req->getAttributes())["scope"] = at->scope;
+              (*req->getAttributes())["clientId"] = at->clientId;
+
+              // 3. Get User Roles
+              plugin->getUserRoles(
+                at->userId,
             [this, req, denyCbPtr, nextCbPtr, scope = at->scope](
               std::vector<std::string> roles
             ) mutable {

--- a/tests/integration/admin/AdminUserApiHttpTest.cc
+++ b/tests/integration/admin/AdminUserApiHttpTest.cc
@@ -10,12 +10,10 @@
 // Storage: Postgres-only (admin services call getDbClient() directly; memory
 // mode has no admin login). All cases skip cleanly under memory.
 //
-// Test-data isolation: there is NO create-user admin route, so the mutating
-// cases (update / disable / enable) target the SEEDED admin user (the dev
-// seed in apps/server/seed/dev_admin_user.sql). Each mutating case captures
-// the pre-state and restores it via an RAII Guard so the suite is order-
-// independent and repeatable. The admin user is resolved by listing users
-// (id is assigned by Postgres, typically 1 but not assumed).
+// Test-data isolation: createUser / updateUser-expanded tests create users
+// with unique timestamp-based suffixes so they don't collide across runs.
+// The legacy cases (update/disable/enable on the seeded admin) still use
+// the RAII snapshot/restore pattern.
 
 #include <drogon/drogon_test.h>
 #include <drogon/drogon.h>
@@ -24,6 +22,7 @@
 
 #include "HttpTestClient.h"
 
+#include <chrono>
 #include <future>
 #include <string>
 
@@ -355,4 +354,242 @@ DROGON_TEST(Integration_P0_AdminUser_GetRoles_AdminUser_Returns200WithAdminRole)
     REQUIRE(parseJsonBody(resp, body));
     CHECK(body["status"].asString() == "success");
     CHECK(body.isMember("roles"));
+}
+
+// ---------------------------------------------------------------------------
+// Unique-suffix helper for createUser / updateUser-expanded tests (each test
+// creates its own throwaway users; no delete endpoint yet).
+// ---------------------------------------------------------------------------
+namespace
+{
+std::string uniqueSuffix()
+{
+    auto now = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    return std::to_string(now % 1000000);
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// createUser happy path: POST /api/admin/users with username+password returns
+// 201, and the new user is retrievable via GET. The created user has a unique
+// suffix so repeated runs don't collide on the UNIQUE constraint.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P0_AdminUser_Create_ValidBody_Returns201)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    auto suffix = uniqueSuffix();
+    Json::Value body;
+    body["username"] = "crudtest_" + suffix;
+    body["password"] = "TestPass123!";
+    body["email"] = ("crudtest_" + suffix + "@example.com");
+
+    auto resp = sendPostJson("/api/admin/users", body, *token);
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k201Created));
+    Json::Value respBody;
+    REQUIRE(parseJsonBody(resp, respBody));
+    CHECK(respBody["status"].asString() == "success");
+    CHECK(respBody["user"]["username"].asString() == ("crudtest_" + suffix));
+
+    // Verify the new user is retrievable.
+    int newId = respBody["user"]["id"].asInt();
+    auto getResp = sendGet("/api/admin/users/" + std::to_string(newId), *token);
+    REQUIRE(getResp != nullptr);
+    CHECK(statusIs(getResp, drogon::k200OK));
+}
+
+// ---------------------------------------------------------------------------
+// createUser duplicate-username: POST with an existing username returns 400.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P1_AdminUser_Create_DuplicateUsername_Returns400)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    // First create succeeds.
+    auto suffix = uniqueSuffix();
+    Json::Value body;
+    body["username"] = "duptest_" + suffix;
+    body["password"] = "TestPass123!";
+    auto resp1 = sendPostJson("/api/admin/users", body, *token);
+    REQUIRE(resp1 != nullptr);
+    CHECK(statusIs(resp1, drogon::k201Created));
+
+    // Second create with same username fails.
+    auto resp2 = sendPostJson("/api/admin/users", body, *token);
+    REQUIRE(resp2 != nullptr);
+    CHECK(statusIs(resp2, drogon::k400BadRequest));
+}
+
+// ---------------------------------------------------------------------------
+// createUser missing-fields: POST without username returns 400.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P1_AdminUser_Create_MissingUsername_Returns400)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    Json::Value body;
+    body["password"] = "TestPass123!";
+
+    auto resp = sendPostJson("/api/admin/users", body, *token);
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k400BadRequest));
+}
+
+// ---------------------------------------------------------------------------
+// listUsers pagination: create two users with a unique prefix, then GET with
+// ?q=<prefix>&per_page=1 to verify total/total_pages/page fields.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P0_AdminUser_List_Pagination)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    // Create two users with a shared prefix for isolation.
+    auto suffix = uniqueSuffix();
+    std::string prefix = "pagtest_" + suffix;
+    for (int i = 0; i < 2; ++i)
+    {
+        Json::Value body;
+        body["username"] = prefix + "_" + std::to_string(i);
+        body["password"] = "TestPass123!";
+        auto cr = sendPostJson("/api/admin/users", body, *token);
+        REQUIRE(cr != nullptr);
+        CHECK(statusIs(cr, drogon::k201Created));
+    }
+
+    // Page 1 with per_page=1 → total >= 2, total_pages >= 2, 1 user on page.
+    auto resp = sendGet("/api/admin/users?q=" + prefix + "&per_page=1&page=1", *token);
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k200OK));
+    Json::Value body;
+    REQUIRE(parseJsonBody(resp, body));
+    CHECK(body["per_page"].asInt() == 1);
+    CHECK(body["total"].asInt() >= 2);
+    CHECK(body["total_pages"].asInt() >= 2);
+    CHECK(body["users"].size() <= 1);
+}
+
+// ---------------------------------------------------------------------------
+// listUsers search: create a user with a unique prefix, verify ?q= finds it.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P1_AdminUser_List_Search_ByQ)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    auto suffix = uniqueSuffix();
+    Json::Value body;
+    body["username"] = "srchtest_" + suffix;
+    body["password"] = "TestPass123!";
+    auto cr = sendPostJson("/api/admin/users", body, *token);
+    REQUIRE(cr != nullptr);
+    CHECK(statusIs(cr, drogon::k201Created));
+
+    auto resp = sendGet("/api/admin/users?q=srchtest_" + suffix, *token);
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k200OK));
+    Json::Value respBody;
+    REQUIRE(parseJsonBody(resp, respBody));
+    CHECK(respBody["total"].asInt() >= 1);
+    // The created user must appear in the filtered results.
+    bool found = false;
+    for (const auto &u : respBody["users"])
+    {
+        if (u.get("username", "").asString() == ("srchtest_" + suffix))
+        {
+            found = true;
+            break;
+        }
+    }
+    CHECK(found);
+}
+
+// ---------------------------------------------------------------------------
+// updateUser expanded fields: create a user, then PUT with mfa_enabled and
+// locked, verify the changes persist via GET.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P1_AdminUser_Update_ExpandedFields)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    // Create a throwaway user.
+    auto suffix = uniqueSuffix();
+    Json::Value createBody;
+    createBody["username"] = "updtest_" + suffix;
+    createBody["password"] = "TestPass123!";
+    auto cr = sendPostJson("/api/admin/users", createBody, *token);
+    REQUIRE(cr != nullptr);
+    REQUIRE(statusIs(cr, drogon::k201Created));
+    Json::Value crBody;
+    REQUIRE(parseJsonBody(cr, crBody));
+    int userId = crBody["user"]["id"].asInt();
+
+    // Update mfa_enabled + locked.
+    Json::Value updBody;
+    updBody["mfa_enabled"] = true;
+    updBody["locked"] = true;
+    auto updResp = sendPutJson("/api/admin/users/" + std::to_string(userId), updBody, *token);
+    REQUIRE(updResp != nullptr);
+    CHECK(statusIs(updResp, drogon::k200OK));
+
+    // Verify via GET.
+    auto getResp = sendGet("/api/admin/users/" + std::to_string(userId), *token);
+    REQUIRE(getResp != nullptr);
+    Json::Value body;
+    REQUIRE(parseJsonBody(getResp, body));
+    CHECK(body["mfa_enabled"].asBool() == true);
+    CHECK(body["locked"].asBool() == true);
+}
+
+// ---------------------------------------------------------------------------
+// listUsers locked filter: the user created+locked above should be findable
+// with ?locked=true. This is a standalone case (creates its own locked user).
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P1_AdminUser_List_FilterLocked)
+{
+    ADMIN_USER_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    // Create + lock a user.
+    auto suffix = uniqueSuffix();
+    Json::Value createBody;
+    createBody["username"] = "locktest_" + suffix;
+    createBody["password"] = "TestPass123!";
+    auto cr = sendPostJson("/api/admin/users", createBody, *token);
+    REQUIRE(cr != nullptr);
+    REQUIRE(statusIs(cr, drogon::k201Created));
+    Json::Value crBody;
+    REQUIRE(parseJsonBody(cr, crBody));
+    int userId = crBody["user"]["id"].asInt();
+
+    Json::Value lockBody;
+    lockBody["locked"] = true;
+    sendPutJson("/api/admin/users/" + std::to_string(userId), lockBody, *token);
+
+    // The locked user should appear in ?locked=true&q=locktest_<suffix>.
+    auto resp = sendGet("/api/admin/users?q=locktest_" + suffix + "&locked=true", *token);
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k200OK));
+    Json::Value body;
+    REQUIRE(parseJsonBody(resp, body));
+    CHECK(body["total"].asInt() >= 1);
 }

--- a/tests/integration/admin/AdminUserApiHttpTest.cc
+++ b/tests/integration/admin/AdminUserApiHttpTest.cc
@@ -53,7 +53,9 @@ namespace
 // is {"status":"success","users":[{"id":N,"username":"admin",...}]}.
 int findAdminUserId(const std::string &token)
 {
-    auto resp = sendGet("/api/admin/users", token);
+    // The list endpoint is paginated (default 50/page); use ?q=admin so the
+    // seeded admin user is found regardless of which page it falls on.
+    auto resp = sendGet("/api/admin/users?q=admin", token);
     if (!resp)
         return -1;
     Json::Value body;
@@ -405,7 +407,7 @@ DROGON_TEST(Integration_P0_AdminUser_Create_ValidBody_Returns201)
 // ---------------------------------------------------------------------------
 // createUser duplicate-username: POST with an existing username returns 400.
 // ---------------------------------------------------------------------------
-DROGON_TEST(Integration_P1_AdminUser_Create_DuplicateUsername_Returns400)
+DROGON_TEST(Integration_P1_AdminUser_Create_DuplicateUsername_Returns409)
 {
     ADMIN_USER_SKIP_GUARD;
 
@@ -421,10 +423,10 @@ DROGON_TEST(Integration_P1_AdminUser_Create_DuplicateUsername_Returns400)
     REQUIRE(resp1 != nullptr);
     CHECK(statusIs(resp1, drogon::k201Created));
 
-    // Second create with same username fails.
+    // Second create with same username → VALIDATION_USERNAME_TAKEN (HTTP 409).
     auto resp2 = sendPostJson("/api/admin/users", body, *token);
     REQUIRE(resp2 != nullptr);
-    CHECK(statusIs(resp2, drogon::k400BadRequest));
+    CHECK(statusIs(resp2, drogon::k409Conflict));
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/api-diff/api-baseline.txt
+++ b/tools/api-diff/api-baseline.txt
@@ -1012,6 +1012,7 @@ public:
 using ResponseCallback =
 std::shared_ptr<std::function<void(const ::drogon::HttpResponsePtr &)>>;
 static void listUsers(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
+static void createUser(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
 static void getUser(
 const ::drogon::HttpRequestPtr &req,
 ResponseCallback cb,
@@ -2010,6 +2011,12 @@ UserAdminController::listUsers,
 "authforge::drogon::filters::AuthorizationFilter"
 );
 ADD_METHOD_TO(
+UserAdminController::createUser,
+"/api/admin/users",
+::drogon::Post,
+"authforge::drogon::filters::AuthorizationFilter"
+);
+ADD_METHOD_TO(
 UserAdminController::getUser,
 "/api/admin/users/{userId}",
 ::drogon::Get,
@@ -2047,6 +2054,10 @@ UserAdminController::assignUserRoles,
 );
 METHOD_LIST_END
 void listUsers(
+const ::drogon::HttpRequestPtr &req,
+std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
+);
+void createUser(
 const ::drogon::HttpRequestPtr &req,
 std::function<void(const ::drogon::HttpResponsePtr &)> &&callback
 );


### PR DESCRIPTION
## Summary

A2 user-management补全 (全栈). Implements the highest-ROI IAM gap from [next-phase-implementation-plan.md](docs/productization-evolution/next-phase-implementation-plan.md) §A2.

**Stacked on PR #49** (`feat/resource-scope-authorization-43`) — the #43 scope infrastructure (EndpointInfo.requiredScopes + AuthorizationFilter scope gate) is a hard dependency for the new endpoints' authorization. Rebase to `master` after #49 merges.

### Backend

| Change | Detail |
|---|---|
| **listUsers pagination** | Real pagination via `Mapper::count` + `paginate().findBy`. Query params: `page`, `per_page` (clamp 1-100), `q` (username/email LIKE), `role` (JOIN-free fan-out: Roles→UserRoles→userIds), `locked` (derived from `locked_until` vs current time). Response: `{page, per_page, total, total_pages, users}` |
| **createUser** (POST) | PBKDF2-SHA256 password hash + default `user` role + audit log (`user_create`). Returns 201 with created user JSON. Duplicate username → `VALIDATION_USERNAME_TAKEN` |
| **updateUser expanded** | Now accepts `username`, `mfa_enabled`, `locked`, `org_id` (was `email` + `email_verified` only). Audit on success (`user_update`) |
| **AuthorizationFilter** | Persists `userId`/`scope`/`clientId` onto request attributes (was only done by OAuth2AuthFilter). Enables admin handlers to identify the actor for audit logging |
| **OpenAPI** | Added `POST /api/admin/users` with request schema; added query params on GET list |

### Frontend

| Change | Detail |
|---|---|
| **UsersPage.vue** | Pagination controls (prev/next + page indicator), search bar (`q`), role/locked filter dropdowns, "Create User" modal (username/password/email/roles) |
| **UserDetailPage.vue** | Info tab expanded: username, mfa_enabled, locked, org_id now editable (was email + email_verified only) |
| **mock-api.ts** | GET handler returns paginated envelope; POST handler with duplicate detection |
| **e2e tests** | 5 new cases: create modal, create success, search filter, duplicate username error |

### Not in scope (Phase 2)

**deleteUser (soft-delete)** requires V024 migration + ORM model regen (`/orm-gen`, user-only skill). Documented as the immediate next step.

### Verification

- ✅ Backend compiles on Windows (MSVC Release, no warnings from new code)
- ✅ Test binary compiles
- ✅ api-diff: additive only (ratified baseline — no version bump)
- ✅ arch-guard: PASS
- ✅ migration-check: PASS (no new migrations)
- ✅ Frontend: `npm run build` (tsc + vite) PASS
- ✅ Frontend: `npm run test:unit` (vitest) PASS
- ⏳ Backend integration tests: require PostgreSQL (CI Linux leg)

### Dependencies on async/DB rules (`.claude/rules/db-operations.md`)

All new Mapper constructions (including nested ones in async callbacks) are wrapped in `try/catch` → `(*cb)(errorResult)`, making the new code more compliant than the pre-existing admin code.