### PR TITLE
feat(openapi): spec governance M0 — 3-layer reconciliation, P0 schemas, consistency + breaking-change gates

### DIFF
--- a/.claude/skills/openapi-update/SKILL.md
+++ b/.claude/skills/openapi-update/SKILL.md
@@ -21,7 +21,7 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - `SessionController.cc` — `/oauth2/login`、`/oauth2/consent`、`/oauth2/end_session`、`/login`、`/api/register`
    - `ClientRegistrationController.cc` — `/oauth2/register`
    - `DiscoveryController.cc` — `/.well-known/openid-configuration`、`/.well-known/jwks.json`
-   - `MfaController.cc` — `/oauth2/mfa/*`
+   - `MfaController.cc` — `/api/me/mfa/*`（自服务，Bearer 保护）+ `/oauth2/mfa/verify`（登录补全）
    - `DeviceAuthController.cc` — `/oauth2/device_*`
    - `WebAuthnController.cc` — `/oauth2/webauthn/*`、`/api/me/webauthn/*`
    - `UserSelfServiceController.cc` — `/api/me*`
@@ -36,8 +36,8 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 识别所有路由端点和参数（以各控制器头文件的 `ADD_METHOD_TO` 宏为权威来源）
 
 2. **比较现有OpenAPI规范**
-   - 读取`apps/server/openapi.yaml`（手工维护的源文档，当前 `info.version: 1.0.0`）
-   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI。**修改 `openapi.yaml` 后需重新运行服务器（或构建）以再生 `openapi.json`**，否则 Swagger UI 与校验脚本看到的仍是旧 JSON。
+   - 读取`apps/server/openapi.yaml`（手工维护的**唯一契约源**；`info.version` 与 `cmake/Version.cmake` 联动，由治理门强制一致）
+   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI（**generated JSON 是派生产物，仅用于 Swagger UI，不是契约源**）。修改 C++ 文档注册后需重新构建/运行服务器以再生 `openapi.json`
    - 检查是否有新的端点、参数变更、响应格式变更
 
 3. **更新OpenAPI规范**
@@ -45,11 +45,19 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 更新现有端点的参数
    - 更新响应模型
    - 确保符合OpenAPI 3.0规范
+   - **C++ 文档注册（`OpenApiGenerator::addEndpoint`）与 `apps/server/openapi.yaml` 必须同步改**——三层（路由宏 `ADD_METHOD_TO` / 文档注册 / YAML）由治理门强制一致
 
-4. **验证规范**
-   - 使用验证脚本检查YAML语法
-   - 验证所有引用是否有效
-   - 确保端点路径与代码一致
+4. **验证规范（治理门）**
+   ```bash
+   # 权威校验：三层一致性 + 版本同步（改完必须跑，CI 也会跑）
+   python3 tools/openapi-governance/check_spec_governance.py --selftest
+   python3 tools/openapi-governance/check_spec_governance.py
+
+   # 结构校验（OpenAPI schema 合法性）
+   python -m openapi_spec_validator apps/server/openapi.yaml
+   ```
+   - 破坏性变更（删端点/收窄请求/收紧安全声明）会被 `.github/workflows/openapi-governance.yml` 的 oasdiff 门拦截：要么升 major 版本，要么在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 加豁免条目（必须带理由）
+   - 改了指纹测试基线（`tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc` 的 `kFingerprint`）时，重新跑治理门确认解析正常
 
 ### 验证脚本集成
 
@@ -97,11 +105,12 @@ foreach ($field in $requiredFields) {
 - `POST /oauth2/introspect` - 令牌内省（RFC 7662）
 - `POST /oauth2/consent` - 授权同意
 - `GET|POST /oauth2/end_session` - 注销
+- `POST /oauth2/logout` - 登出（Bearer 保护）
 - `POST /oauth2/register` - 动态客户端注册（RFC 7591）
-- MFA：`/oauth2/mfa/setup`、`/oauth2/mfa/setup/verify`、`/oauth2/mfa/disable`、`/oauth2/mfa/verify`
-- Device：`/oauth2/device_authorization`、`/oauth2/device/verify`、`/oauth2/device/approve`
+- MFA：`POST /api/me/mfa/setup`、`POST /api/me/mfa/verify`、`POST /api/me/mfa/disable`（自服务）、`POST /oauth2/mfa/verify`（登录补全）
+- Device：`/oauth2/device_authorization`、`/oauth2/device/approve`（admin）（**无 `/oauth2/device/verify` 路由**——验证页由前端渲染）
 - WebAuthn：`/oauth2/webauthn/authenticate/begin`、`/oauth2/webauthn/authenticate/finish`
-- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`
+- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`、`/.well-known/oauth-authorization-server`（RFC 8414）
 - 健康检查：`/health`、`/health/live`、`/health/ready`
 
 ### 社交登录端点（`#ifdef WITH_SOCIAL`）
@@ -142,10 +151,11 @@ foreach ($field in $requiredFields) {
 # 更新规范后提交到 Git
 git add apps/server/openapi.yaml
 git commit -m "docs: update OpenAPI specification for endpoint changes"
-
-# 如果有重大变更，更新 API 版本号
-# 在 openapi.yaml 的 info.version 字段中递增版本
 ```
+
+版本号规则（治理门 + release version-check 强制）：
+- `info.version` **必须**与 `cmake/Version.cmake` 的 `OAUTH2_PROJECT_VERSION` 一致（改版本就两边一起改）
+- 破坏性变更要求升 major（oasdiff 门拦截；豁免需在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 带理由登记）
 
 ## 文档同步
 

--- a/.codebuddy/skills/openapi-update/SKILL.md
+++ b/.codebuddy/skills/openapi-update/SKILL.md
@@ -21,7 +21,7 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - `SessionController.cc` — `/oauth2/login`、`/oauth2/consent`、`/oauth2/end_session`、`/login`、`/api/register`
    - `ClientRegistrationController.cc` — `/oauth2/register`
    - `DiscoveryController.cc` — `/.well-known/openid-configuration`、`/.well-known/jwks.json`
-   - `MfaController.cc` — `/oauth2/mfa/*`
+   - `MfaController.cc` — `/api/me/mfa/*`（自服务，Bearer 保护）+ `/oauth2/mfa/verify`（登录补全）
    - `DeviceAuthController.cc` — `/oauth2/device_*`
    - `WebAuthnController.cc` — `/oauth2/webauthn/*`、`/api/me/webauthn/*`
    - `UserSelfServiceController.cc` — `/api/me*`
@@ -36,8 +36,8 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 识别所有路由端点和参数（以各控制器头文件的 `ADD_METHOD_TO` 宏为权威来源）
 
 2. **比较现有OpenAPI规范**
-   - 读取`apps/server/openapi.yaml`（手工维护的源文档，当前 `info.version: 1.0.0`）
-   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI。**修改 `openapi.yaml` 后需重新运行服务器（或构建）以再生 `openapi.json`**，否则 Swagger UI 与校验脚本看到的仍是旧 JSON。
+   - 读取`apps/server/openapi.yaml`（手工维护的**唯一契约源**；`info.version` 与 `cmake/Version.cmake` 联动，由治理门强制一致）
+   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI（**generated JSON 是派生产物，仅用于 Swagger UI，不是契约源**）。修改 C++ 文档注册后需重新构建/运行服务器以再生 `openapi.json`
    - 检查是否有新的端点、参数变更、响应格式变更
 
 3. **更新OpenAPI规范**
@@ -45,11 +45,19 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 更新现有端点的参数
    - 更新响应模型
    - 确保符合OpenAPI 3.0规范
+   - **C++ 文档注册（`OpenApiGenerator::addEndpoint`）与 `apps/server/openapi.yaml` 必须同步改**——三层（路由宏 `ADD_METHOD_TO` / 文档注册 / YAML）由治理门强制一致
 
-4. **验证规范**
-   - 使用验证脚本检查YAML语法
-   - 验证所有引用是否有效
-   - 确保端点路径与代码一致
+4. **验证规范（治理门）**
+   ```bash
+   # 权威校验：三层一致性 + 版本同步（改完必须跑，CI 也会跑）
+   python3 tools/openapi-governance/check_spec_governance.py --selftest
+   python3 tools/openapi-governance/check_spec_governance.py
+
+   # 结构校验（OpenAPI schema 合法性）
+   python -m openapi_spec_validator apps/server/openapi.yaml
+   ```
+   - 破坏性变更（删端点/收窄请求/收紧安全声明）会被 `.github/workflows/openapi-governance.yml` 的 oasdiff 门拦截：要么升 major 版本，要么在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 加豁免条目（必须带理由）
+   - 改了指纹测试基线（`tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc` 的 `kFingerprint`）时，重新跑治理门确认解析正常
 
 ### 验证脚本集成
 
@@ -97,11 +105,12 @@ foreach ($field in $requiredFields) {
 - `POST /oauth2/introspect` - 令牌内省（RFC 7662）
 - `POST /oauth2/consent` - 授权同意
 - `GET|POST /oauth2/end_session` - 注销
+- `POST /oauth2/logout` - 登出（Bearer 保护）
 - `POST /oauth2/register` - 动态客户端注册（RFC 7591）
-- MFA：`/oauth2/mfa/setup`、`/oauth2/mfa/setup/verify`、`/oauth2/mfa/disable`、`/oauth2/mfa/verify`
-- Device：`/oauth2/device_authorization`、`/oauth2/device/verify`、`/oauth2/device/approve`
+- MFA：`POST /api/me/mfa/setup`、`POST /api/me/mfa/verify`、`POST /api/me/mfa/disable`（自服务）、`POST /oauth2/mfa/verify`（登录补全）
+- Device：`/oauth2/device_authorization`、`/oauth2/device/approve`（admin）（**无 `/oauth2/device/verify` 路由**——验证页由前端渲染）
 - WebAuthn：`/oauth2/webauthn/authenticate/begin`、`/oauth2/webauthn/authenticate/finish`
-- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`
+- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`、`/.well-known/oauth-authorization-server`（RFC 8414）
 - 健康检查：`/health`、`/health/live`、`/health/ready`
 
 ### 社交登录端点（`#ifdef WITH_SOCIAL`）
@@ -142,10 +151,11 @@ foreach ($field in $requiredFields) {
 # 更新规范后提交到 Git
 git add apps/server/openapi.yaml
 git commit -m "docs: update OpenAPI specification for endpoint changes"
-
-# 如果有重大变更，更新 API 版本号
-# 在 openapi.yaml 的 info.version 字段中递增版本
 ```
+
+版本号规则（治理门 + release version-check 强制）：
+- `info.version` **必须**与 `cmake/Version.cmake` 的 `OAUTH2_PROJECT_VERSION` 一致（改版本就两边一起改）
+- 破坏性变更要求升 major（oasdiff 门拦截；豁免需在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 带理由登记）
 
 ## 文档同步
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,16 @@ jobs:
 
       - name: Validate OpenAPI Spec
         run: |
-          pip install openapi-spec-validator
+          pip install openapi-spec-validator pyyaml
           python -m openapi_spec_validator apps/server/openapi.yaml
+
+      - name: Check OpenAPI Spec Governance (3-layer consistency + version sync)
+        # Spec governance gate (M0): Drogon routes == doc registrations ==
+        # openapi.yaml operations (modulo documented exclusions), and
+        # info.version == cmake/Version.cmake. Pure source scan.
+        run: |
+          python3 tools/openapi-governance/check_spec_governance.py --selftest
+          python3 tools/openapi-governance/check_spec_governance.py
 
   frontend:
     name: Frontend Property Tests

--- a/.github/workflows/openapi-governance.yml
+++ b/.github/workflows/openapi-governance.yml
@@ -1,0 +1,58 @@
+name: OpenAPI Governance
+
+# Breaking-change gate over the HTTP API contract (spec-governance M0,
+# design: docs/productization-evolution/todo/client-sdk-facility-design.md §D4).
+#
+# Compares apps/server/openapi.yaml (the single source of truth) against the
+# base branch. Any breaking change (path removal, request-body tightening,
+# response narrowing, ...) fails the gate unless:
+#   - the change ships with a major version bump, or
+#   - it is explicitly exempted (with justification) in
+#     tools/openapi-governance/oasdiff-breaking-ignore.md.
+#
+# oasdiff is downloaded as a pinned release binary (single Go binary, no JVM)
+# so the exact same command can be reproduced locally:
+#   oasdiff breaking base.yaml apps/server/openapi.yaml \
+#     --err-ignore tools/openapi-governance/oasdiff-breaking-ignore.md -o ERR
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths:
+      - "apps/server/openapi.yaml"
+      - "tools/openapi-governance/**"
+      - ".github/workflows/openapi-governance.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: openapi-governance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  breaking-change:
+    name: oasdiff breaking (base vs PR)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need origin/master for the base spec
+
+      - name: Extract base-branch spec
+        run: |
+          git show origin/master:apps/server/openapi.yaml > /tmp/base_openapi.yaml
+          echo "Base spec lines: $(wc -l < /tmp/base_openapi.yaml)"
+
+      - name: Install oasdiff (pinned v1.29.1)
+        run: |
+          curl -sSfL -o oasdiff.tgz \
+            https://github.com/Tufin/oasdiff/releases/download/v1.29.1/oasdiff_1.29.1_linux_amd64.tar.gz
+          tar -xzf oasdiff.tgz
+          sudo install -m 755 oasdiff /usr/local/bin/oasdiff
+          oasdiff --help > /dev/null && echo "oasdiff installed"
+
+      - name: Breaking-change gate
+        run: |
+          oasdiff breaking /tmp/base_openapi.yaml apps/server/openapi.yaml \
+            --err-ignore tools/openapi-governance/oasdiff-breaking-ignore.md \
+            -f githubactions -o ERR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,16 +68,12 @@ jobs:
             exit 1
           fi
 
-      - name: OpenAPI info.version must match the repo version
+      - name: OpenAPI spec governance check (version sync + 3-layer consistency)
         # Spec-governance M0 backstop: the published spec must carry the
-        # released version (PR-side gate: tools/openapi-governance/
-        # check_spec_governance.py).
-        run: |
-          yaml_version=$(python3 -c "import yaml; print(yaml.safe_load(open('apps/server/openapi.yaml'))['info']['version'])")
-          if [ "$yaml_version" != "${{ steps.ver.outputs.version }}" ]; then
-            echo "::error::apps/server/openapi.yaml info.version ($yaml_version) != cmake/Version.cmake (${{ steps.ver.outputs.version }})"
-            exit 1
-          fi
+        # released version. Uses the PyYAML-optional gate script (no hard
+        # dependency on runner-image Python packages) and re-validates the
+        # full routes/docs/yaml consistency on the release ref.
+        run: python3 tools/openapi-governance/check_spec_governance.py
 
       - name: API surface frozen at this version (api-diff)
         # Also cross-checks cmake/Version.cmake vs CMakeLists.txt vs conanfile.py.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,17 @@ jobs:
             exit 1
           fi
 
+      - name: OpenAPI info.version must match the repo version
+        # Spec-governance M0 backstop: the published spec must carry the
+        # released version (PR-side gate: tools/openapi-governance/
+        # check_spec_governance.py).
+        run: |
+          yaml_version=$(python3 -c "import yaml; print(yaml.safe_load(open('apps/server/openapi.yaml'))['info']['version'])")
+          if [ "$yaml_version" != "${{ steps.ver.outputs.version }}" ]; then
+            echo "::error::apps/server/openapi.yaml info.version ($yaml_version) != cmake/Version.cmake (${{ steps.ver.outputs.version }})"
+            exit 1
+          fi
+
       - name: API surface frozen at this version (api-diff)
         # Also cross-checks cmake/Version.cmake vs CMakeLists.txt vs conanfile.py.
         run: python3 tools/api-diff/api_diff.py

--- a/.qoder/skills/openapi-update/SKILL.md
+++ b/.qoder/skills/openapi-update/SKILL.md
@@ -21,7 +21,7 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - `SessionController.cc` — `/oauth2/login`、`/oauth2/consent`、`/oauth2/end_session`、`/login`、`/api/register`
    - `ClientRegistrationController.cc` — `/oauth2/register`
    - `DiscoveryController.cc` — `/.well-known/openid-configuration`、`/.well-known/jwks.json`
-   - `MfaController.cc` — `/oauth2/mfa/*`
+   - `MfaController.cc` — `/api/me/mfa/*`（自服务，Bearer 保护）+ `/oauth2/mfa/verify`（登录补全）
    - `DeviceAuthController.cc` — `/oauth2/device_*`
    - `WebAuthnController.cc` — `/oauth2/webauthn/*`、`/api/me/webauthn/*`
    - `UserSelfServiceController.cc` — `/api/me*`
@@ -36,8 +36,8 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 识别所有路由端点和参数（以各控制器头文件的 `ADD_METHOD_TO` 宏为权威来源）
 
 2. **比较现有OpenAPI规范**
-   - 读取`apps/server/openapi.yaml`（手工维护的源文档，当前 `info.version: 1.0.0`）
-   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI。**修改 `openapi.yaml` 后需重新运行服务器（或构建）以再生 `openapi.json`**，否则 Swagger UI 与校验脚本看到的仍是旧 JSON。
+   - 读取`apps/server/openapi.yaml`（手工维护的**唯一契约源**；`info.version` 与 `cmake/Version.cmake` 联动，由治理门强制一致）
+   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI（**generated JSON 是派生产物，仅用于 Swagger UI，不是契约源**）。修改 C++ 文档注册后需重新构建/运行服务器以再生 `openapi.json`
    - 检查是否有新的端点、参数变更、响应格式变更
 
 3. **更新OpenAPI规范**
@@ -45,11 +45,19 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 更新现有端点的参数
    - 更新响应模型
    - 确保符合OpenAPI 3.0规范
+   - **C++ 文档注册（`OpenApiGenerator::addEndpoint`）与 `apps/server/openapi.yaml` 必须同步改**——三层（路由宏 `ADD_METHOD_TO` / 文档注册 / YAML）由治理门强制一致
 
-4. **验证规范**
-   - 使用验证脚本检查YAML语法
-   - 验证所有引用是否有效
-   - 确保端点路径与代码一致
+4. **验证规范（治理门）**
+   ```bash
+   # 权威校验：三层一致性 + 版本同步（改完必须跑，CI 也会跑）
+   python3 tools/openapi-governance/check_spec_governance.py --selftest
+   python3 tools/openapi-governance/check_spec_governance.py
+
+   # 结构校验（OpenAPI schema 合法性）
+   python -m openapi_spec_validator apps/server/openapi.yaml
+   ```
+   - 破坏性变更（删端点/收窄请求/收紧安全声明）会被 `.github/workflows/openapi-governance.yml` 的 oasdiff 门拦截：要么升 major 版本，要么在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 加豁免条目（必须带理由）
+   - 改了指纹测试基线（`tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc` 的 `kFingerprint`）时，重新跑治理门确认解析正常
 
 ### 验证脚本集成
 
@@ -97,11 +105,12 @@ foreach ($field in $requiredFields) {
 - `POST /oauth2/introspect` - 令牌内省（RFC 7662）
 - `POST /oauth2/consent` - 授权同意
 - `GET|POST /oauth2/end_session` - 注销
+- `POST /oauth2/logout` - 登出（Bearer 保护）
 - `POST /oauth2/register` - 动态客户端注册（RFC 7591）
-- MFA：`/oauth2/mfa/setup`、`/oauth2/mfa/setup/verify`、`/oauth2/mfa/disable`、`/oauth2/mfa/verify`
-- Device：`/oauth2/device_authorization`、`/oauth2/device/verify`、`/oauth2/device/approve`
+- MFA：`POST /api/me/mfa/setup`、`POST /api/me/mfa/verify`、`POST /api/me/mfa/disable`（自服务）、`POST /oauth2/mfa/verify`（登录补全）
+- Device：`/oauth2/device_authorization`、`/oauth2/device/approve`（admin）（**无 `/oauth2/device/verify` 路由**——验证页由前端渲染）
 - WebAuthn：`/oauth2/webauthn/authenticate/begin`、`/oauth2/webauthn/authenticate/finish`
-- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`
+- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`、`/.well-known/oauth-authorization-server`（RFC 8414）
 - 健康检查：`/health`、`/health/live`、`/health/ready`
 
 ### 社交登录端点（`#ifdef WITH_SOCIAL`）
@@ -142,10 +151,11 @@ foreach ($field in $requiredFields) {
 # 更新规范后提交到 Git
 git add apps/server/openapi.yaml
 git commit -m "docs: update OpenAPI specification for endpoint changes"
-
-# 如果有重大变更，更新 API 版本号
-# 在 openapi.yaml 的 info.version 字段中递增版本
 ```
+
+版本号规则（治理门 + release version-check 强制）：
+- `info.version` **必须**与 `cmake/Version.cmake` 的 `OAUTH2_PROJECT_VERSION` 一致（改版本就两边一起改）
+- 破坏性变更要求升 major（oasdiff 门拦截；豁免需在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 带理由登记）
 
 ## 文档同步
 

--- a/.zcode/skills/openapi-update/SKILL.md
+++ b/.zcode/skills/openapi-update/SKILL.md
@@ -21,7 +21,7 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - `SessionController.cc` — `/oauth2/login`、`/oauth2/consent`、`/oauth2/end_session`、`/login`、`/api/register`
    - `ClientRegistrationController.cc` — `/oauth2/register`
    - `DiscoveryController.cc` — `/.well-known/openid-configuration`、`/.well-known/jwks.json`
-   - `MfaController.cc` — `/oauth2/mfa/*`
+   - `MfaController.cc` — `/api/me/mfa/*`（自服务，Bearer 保护）+ `/oauth2/mfa/verify`（登录补全）
    - `DeviceAuthController.cc` — `/oauth2/device_*`
    - `WebAuthnController.cc` — `/oauth2/webauthn/*`、`/api/me/webauthn/*`
    - `UserSelfServiceController.cc` — `/api/me*`
@@ -36,8 +36,8 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 识别所有路由端点和参数（以各控制器头文件的 `ADD_METHOD_TO` 宏为权威来源）
 
 2. **比较现有OpenAPI规范**
-   - 读取`apps/server/openapi.yaml`（手工维护的源文档，当前 `info.version: 1.0.0`）
-   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI。**修改 `openapi.yaml` 后需重新运行服务器（或构建）以再生 `openapi.json`**，否则 Swagger UI 与校验脚本看到的仍是旧 JSON。
+   - 读取`apps/server/openapi.yaml`（手工维护的**唯一契约源**；`info.version` 与 `cmake/Version.cmake` 联动，由治理门强制一致）
+   - 运行时由 `apps/server/src/bootstrap/OpenApiSetup.cc` 生成 JSON 规范到 `apps/server/docs/api/openapi.json`，并由 `ApiDocController` 在 `/docs/api/openapi.json` 与 `/docs/api/` 提供 Swagger UI（**generated JSON 是派生产物，仅用于 Swagger UI，不是契约源**）。修改 C++ 文档注册后需重新构建/运行服务器以再生 `openapi.json`
    - 检查是否有新的端点、参数变更、响应格式变更
 
 3. **更新OpenAPI规范**
@@ -45,11 +45,19 @@ description: 当OAuth2端点发生变化时更新OpenAPI规范
    - 更新现有端点的参数
    - 更新响应模型
    - 确保符合OpenAPI 3.0规范
+   - **C++ 文档注册（`OpenApiGenerator::addEndpoint`）与 `apps/server/openapi.yaml` 必须同步改**——三层（路由宏 `ADD_METHOD_TO` / 文档注册 / YAML）由治理门强制一致
 
-4. **验证规范**
-   - 使用验证脚本检查YAML语法
-   - 验证所有引用是否有效
-   - 确保端点路径与代码一致
+4. **验证规范（治理门）**
+   ```bash
+   # 权威校验：三层一致性 + 版本同步（改完必须跑，CI 也会跑）
+   python3 tools/openapi-governance/check_spec_governance.py --selftest
+   python3 tools/openapi-governance/check_spec_governance.py
+
+   # 结构校验（OpenAPI schema 合法性）
+   python -m openapi_spec_validator apps/server/openapi.yaml
+   ```
+   - 破坏性变更（删端点/收窄请求/收紧安全声明）会被 `.github/workflows/openapi-governance.yml` 的 oasdiff 门拦截：要么升 major 版本，要么在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 加豁免条目（必须带理由）
+   - 改了指纹测试基线（`tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc` 的 `kFingerprint`）时，重新跑治理门确认解析正常
 
 ### 验证脚本集成
 
@@ -97,11 +105,12 @@ foreach ($field in $requiredFields) {
 - `POST /oauth2/introspect` - 令牌内省（RFC 7662）
 - `POST /oauth2/consent` - 授权同意
 - `GET|POST /oauth2/end_session` - 注销
+- `POST /oauth2/logout` - 登出（Bearer 保护）
 - `POST /oauth2/register` - 动态客户端注册（RFC 7591）
-- MFA：`/oauth2/mfa/setup`、`/oauth2/mfa/setup/verify`、`/oauth2/mfa/disable`、`/oauth2/mfa/verify`
-- Device：`/oauth2/device_authorization`、`/oauth2/device/verify`、`/oauth2/device/approve`
+- MFA：`POST /api/me/mfa/setup`、`POST /api/me/mfa/verify`、`POST /api/me/mfa/disable`（自服务）、`POST /oauth2/mfa/verify`（登录补全）
+- Device：`/oauth2/device_authorization`、`/oauth2/device/approve`（admin）（**无 `/oauth2/device/verify` 路由**——验证页由前端渲染）
 - WebAuthn：`/oauth2/webauthn/authenticate/begin`、`/oauth2/webauthn/authenticate/finish`
-- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`
+- 发现：`/.well-known/openid-configuration`、`/.well-known/jwks.json`、`/.well-known/oauth-authorization-server`（RFC 8414）
 - 健康检查：`/health`、`/health/live`、`/health/ready`
 
 ### 社交登录端点（`#ifdef WITH_SOCIAL`）
@@ -142,10 +151,11 @@ foreach ($field in $requiredFields) {
 # 更新规范后提交到 Git
 git add apps/server/openapi.yaml
 git commit -m "docs: update OpenAPI specification for endpoint changes"
-
-# 如果有重大变更，更新 API 版本号
-# 在 openapi.yaml 的 info.version 字段中递增版本
 ```
+
+版本号规则（治理门 + release version-check 强制）：
+- `info.version` **必须**与 `cmake/Version.cmake` 的 `OAUTH2_PROJECT_VERSION` 一致（改版本就两边一起改）
+- 破坏性变更要求升 major（oasdiff 门拦截；豁免需在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 带理由登记）
 
 ## 文档同步
 

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -8,7 +8,7 @@
 #     (modulo documented exclusions), and info.version == cmake/Version.cmake.
 #   - .github/workflows/openapi-governance.yml runs `oasdiff breaking` against
 #     the base branch; breaking changes require a major bump or an entry in
-#     tools/openapi-governance/oasdiff-breaking-ignore.yaml.
+#     tools/openapi-governance/oasdiff-breaking-ignore.md.
 #   - After editing controllers or this file, run:
 #       python tools/openapi-governance/check_spec_governance.py
 #       python -m openapi_spec_validator apps/server/openapi.yaml
@@ -2692,8 +2692,8 @@ paths:
                 success:
                   summary: Login succeeded (json=true)
                   value:
-                    status: success
-                    redirect_uri: http://127.0.0.1:5173/callback?code=xyz123
+                    code: xyz123
+                    location: http://127.0.0.1:5173/callback?code=xyz123&state=abc
                 mfa_required:
                   summary: MFA challenge required
                   value:

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -1,28 +1,551 @@
+# OpenAPI 3.0 specification of the AuthForge OAuth2/OIDC authorization server.
+#
+# Governance (2026-08, spec-governance M0):
+#   - This file is the SINGLE SOURCE OF TRUTH for the HTTP API contract
+#     (client SDK generation, endpoint consistency gate, breaking-change gate).
+#   - tools/openapi-governance/check_spec_governance.py (CI static-checks)
+#     asserts: METHOD+path set == C++ doc registrations == Drogon routes
+#     (modulo documented exclusions), and info.version == cmake/Version.cmake.
+#   - .github/workflows/openapi-governance.yml runs `oasdiff breaking` against
+#     the base branch; breaking changes require a major bump or an entry in
+#     tools/openapi-governance/oasdiff-breaking-ignore.yaml.
+#   - After editing controllers or this file, run:
+#       python tools/openapi-governance/check_spec_governance.py
+#       python -m openapi_spec_validator apps/server/openapi.yaml
 components:
   schemas:
     Error:
+      description: >-
+        The nested error object of the application error envelope. Application
+        (non-OAuth2-protocol) endpoints respond with {"error": {...}} on
+        failure; /oauth2/* and /.well-known/* endpoints use RFC 6749 §5.2
+        bodies instead (see OAuth2Error).
       properties:
         category:
           type: string
+          description: Error category, e.g. VALIDATION / AUTH / AUTHZ / DB / INTERNAL.
         code:
-          type: integer
-        details:
           type: string
+          description: Machine-readable error code, e.g. VALIDATION_INVALID_INPUT.
         message:
           type: string
         request_id:
           type: string
+        numeric_code:
+          type: integer
+          description: Numeric catalog code (present iff the code is registered, e.g. 3001).
+        details:
+          type: string
+          description: Extra context; only emitted when the server runs in non-production mode.
+      type: object
+    ErrorEnvelope:
+      description: Application-endpoint error wrapper.
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+      required:
+      - error
+      type: object
+    OAuth2Error:
+      description: >-
+        RFC 6749 §5.2 error body used by /oauth2/* and /.well-known/*
+        endpoints (with Cache-Control: no-store). HTTP status per code:
+        invalid_request 400, invalid_client 401, invalid_grant 400,
+        unauthorized_client 400, unsupported_grant_type 400, invalid_scope 400,
+        access_denied 403, authorization_pending 400, slow_down 400,
+        expired_token 400, server_error 500, temporarily_unavailable 503.
+      properties:
+        error:
+          type: string
+          enum:
+          - invalid_request
+          - invalid_client
+          - invalid_grant
+          - unauthorized_client
+          - unsupported_grant_type
+          - invalid_scope
+          - access_denied
+          - unsupported_token_type
+          - authorization_pending
+          - slow_down
+          - expired_token
+          - server_error
+          - temporarily_unavailable
+        error_description:
+          type: string
+        error_uri:
+          type: string
+      required:
+      - error
       type: object
     TokenResponse:
+      description: >-
+        Token endpoint success body (grant-dependent fields). authorization_code:
+        access_token/token_type/expires_in/refresh_token/roles + id_token iff
+        scope includes openid (no scope echo). refresh_token: rotated
+        refresh_token, no roles. client_credentials: scope echo, NO
+        refresh_token. device_code: refresh_token + optional scope/id_token.
+        Always carries Cache-Control: no-store / Pragma: no-cache.
       properties:
         access_token:
           type: string
+        token_type:
+          type: string
+          description: Always "Bearer".
         expires_in:
           type: integer
+          format: int64
+          description: Seconds until access_token expiry.
         refresh_token:
+          type: string
+          description: Present for grants that issue refresh tokens (rotated on refresh).
+        scope:
+          type: string
+          description: Space-separated scopes; echoed for client_credentials/device grants only.
+        roles:
+          type: array
+          items:
+            type: string
+          description: Role names; authorization_code grant only.
+        id_token:
+          type: string
+          description: OIDC ID token (JWT); present iff scope includes openid and signing keys are configured.
+      required:
+      - access_token
+      - token_type
+      - expires_in
+      type: object
+    IntrospectionResponse:
+      description: >-
+        RFC 7662 introspection body. Inactive tokens return {"active": false}
+        only. Active responses always carry iss (backfilled from config);
+        Cache-Control: no-store.
+      properties:
+        active:
+          type: boolean
+        client_id:
           type: string
         token_type:
           type: string
+          description: Always "Bearer" when active.
+        exp:
+          type: integer
+          format: int64
+        iat:
+          type: integer
+          format: int64
+        nbf:
+          type: integer
+          format: int64
+        sub:
+          type: string
+          description: Resource-owner subject; "client:<id>" for client_credentials tokens.
+        aud:
+          type: string
+        iss:
+          type: string
+        scope:
+          type: string
+          description: Space-separated scopes.
+      required:
+      - active
+      type: object
+    UserInfoResponse:
+      description: >-
+        OIDC Core §5.3 userinfo claims. email_verified present iff email
+        present; roles present iff non-empty.
+      properties:
+        sub:
+          type: string
+          description: Subject (public user id, stringified).
+        name:
+          type: string
+          description: 'Username (fallback: email, then sub).'
+        username:
+          type: string
+        email:
+          type: string
+        email_verified:
+          type: boolean
+        roles:
+          type: array
+          items:
+            type: string
+      required:
+      - sub
+      - name
+      type: object
+    OpenIDConfiguration:
+      description: OIDC Discovery 1.0 provider metadata.
+      properties:
+        issuer:
+          type: string
+        authorization_endpoint:
+          type: string
+        token_endpoint:
+          type: string
+        device_authorization_endpoint:
+          type: string
+        userinfo_endpoint:
+          type: string
+        jwks_uri:
+          type: string
+        introspection_endpoint:
+          type: string
+        revocation_endpoint:
+          type: string
+        registration_endpoint:
+          type: string
+        scopes_supported:
+          type: array
+          items:
+            type: string
+        response_types_supported:
+          type: array
+          items:
+            type: string
+        grant_types_supported:
+          type: array
+          items:
+            type: string
+        subject_types_supported:
+          type: array
+          items:
+            type: string
+        id_token_signing_alg_values_supported:
+          type: array
+          items:
+            type: string
+        token_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        code_challenge_methods_supported:
+          type: array
+          items:
+            type: string
+        prompt_values_supported:
+          type: array
+          items:
+            type: string
+        acr_values_supported:
+          type: array
+          items:
+            type: string
+        end_session_endpoint:
+          type: string
+        backchannel_logout_supported:
+          type: boolean
+        backchannel_logout_session_supported:
+          type: boolean
+        claims_supported:
+          type: array
+          items:
+            type: string
+      type: object
+    OAuthAuthorizationServerMetadata:
+      description: RFC 8414 authorization server metadata (no userinfo/jwks entries; OIDC discovery carries those).
+      properties:
+        issuer:
+          type: string
+        authorization_endpoint:
+          type: string
+        token_endpoint:
+          type: string
+        device_authorization_endpoint:
+          type: string
+        introspection_endpoint:
+          type: string
+        introspection_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        revocation_endpoint:
+          type: string
+        revocation_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        registration_endpoint:
+          type: string
+        scopes_supported:
+          type: array
+          items:
+            type: string
+        response_types_supported:
+          type: array
+          items:
+            type: string
+        response_modes_supported:
+          type: array
+          items:
+            type: string
+        grant_types_supported:
+          type: array
+          items:
+            type: string
+        subject_types_supported:
+          type: array
+          items:
+            type: string
+        code_challenge_methods_supported:
+          type: array
+          items:
+            type: string
+        token_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        service_documentation:
+          type: string
+        op_policy_uri:
+          type: string
+        op_tos_uri:
+          type: string
+      type: object
+    JWKSet:
+      description: 'RFC 7517 JSON Web Key Set (Cache-Control: public, max-age=3600).'
+      properties:
+        keys:
+          type: array
+          items:
+            type: object
+            properties:
+              kty:
+                type: string
+              kid:
+                type: string
+              use:
+                type: string
+              alg:
+                type: string
+              n:
+                type: string
+              e:
+                type: string
+              x5c:
+                type: array
+                items:
+                  type: string
+            required:
+            - kty
+      required:
+      - keys
+      type: object
+    LoginSuccessResponse:
+      description: /oauth2/login success when json=true (otherwise a 302 redirect with code+state query).
+      properties:
+        code:
+          type: string
+          description: The issued authorization code.
+        location:
+          type: string
+          description: Full redirect URI with code and state query parameters.
+      required:
+      - code
+      - location
+      type: object
+    MfaRequiredResponse:
+      description: /oauth2/login response when the account has MFA enabled; complete the flow at POST /oauth2/mfa/verify.
+      properties:
+        mfa_required:
+          type: boolean
+        mfa_token:
+          type: string
+          description: Pending-MFA token to submit to /oauth2/mfa/verify.
+        message:
+          type: string
+      required:
+      - mfa_required
+      - mfa_token
+      type: object
+    MessageResponse:
+      properties:
+        message:
+          type: string
+      required:
+      - message
+      type: object
+    DeviceAuthorizationResponse:
+      description: RFC 8628 device authorization response (no verification_uri_complete).
+      properties:
+        device_code:
+          type: string
+        user_code:
+          type: string
+          description: 8 characters from the A-Z2-9 alphabet (no 0/1/I/O).
+        verification_uri:
+          type: string
+        expires_in:
+          type: integer
+          description: Device code lifetime in seconds (600).
+        interval:
+          type: integer
+          description: Required polling interval in seconds (5).
+      required:
+      - device_code
+      - user_code
+      - verification_uri
+      - expires_in
+      - interval
+      type: object
+    HealthStatus:
+      properties:
+        status:
+          type: string
+          enum:
+          - ok
+          - degraded
+          - unhealthy
+        service:
+          type: string
+        timestamp:
+          type: integer
+          format: int64
+        storage_type:
+          type: string
+        database:
+          type: string
+          description: connected / disconnected / not_configured / unknown
+        redis:
+          type: string
+          description: connected / disconnected / not_configured
+      required:
+      - status
+      type: object
+    Organization:
+      properties:
+        id:
+          type: integer
+        slug:
+          type: string
+        name:
+          type: string
+        logo_uri:
+          type: string
+        primary_color:
+          type: string
+        issuer_override:
+          type: string
+      type: object
+    TokenRequest:
+      description: >-
+        RFC 6749 §4.1.3 token request (form-encoded). Field requirements are
+        grant-dependent: authorization_code needs code (+ redirect_uri +
+        code_verifier when PKCE was used); refresh_token needs refresh_token;
+        client_credentials may send scope; device_code needs device_code.
+        CONFIDENTIAL clients authenticate via HTTP Basic or client_id +
+        client_secret fields.
+      properties:
+        grant_type:
+          type: string
+          enum:
+          - authorization_code
+          - refresh_token
+          - client_credentials
+          - urn:ietf:params:oauth:grant-type:device_code
+        code:
+          type: string
+          description: Authorization code (required for grant_type=authorization_code).
+        redirect_uri:
+          type: string
+          description: Required for the authorization_code grant.
+        refresh_token:
+          type: string
+          description: Required for grant_type=refresh_token (rotated on use).
+        code_verifier:
+          type: string
+          description: 'PKCE code_verifier (RFC 7636): required for
+            authorization_code when the login/authorize request carried a
+            code_challenge.'
+        client_id:
+          type: string
+          description: Client identifier (alternative to HTTP Basic authentication).
+        client_secret:
+          type: string
+          description: Client secret for CONFIDENTIAL clients with
+            token_endpoint_auth_method=client_secret_post; FORBIDDEN for
+            PUBLIC clients whose method is 'none' (F-017).
+        scope:
+          type: string
+          description: Space-separated scopes (client_credentials grant only).
+        device_code:
+          type: string
+          description: Required for the device_code grant (from
+            /oauth2/device_authorization).
+      required:
+      - grant_type
+      type: object
+    LoginRequest:
+      description: /oauth2/login credentials (JSON body or form-encoded; query also accepted).
+      properties:
+        username:
+          type: string
+          description: Account username or email.
+        password:
+          type: string
+        client_id:
+          type: string
+          description: Matches the requesting app (required for code issuance).
+        redirect_uri:
+          type: string
+          description: Must match the registered client.
+        scope:
+          type: string
+          description: Space-separated (optional).
+        state:
+          type: string
+          description: Opaque value maintained between request and callback (recommended).
+        code_challenge:
+          type: string
+          description: PKCE code challenge (RFC 7636). REQUIRED for PUBLIC
+            clients (vue-client, admin-console) when
+            auth.require_pkce_for_public is enabled (default true, F-011 /
+            RFC 9700 §2.1.1). The matching code_verifier must be sent on the
+            /oauth2/token exchange.
+        code_challenge_method:
+          type: string
+          description: 'S256 (recommended) or plain.'
+        nonce:
+          type: string
+          description: OIDC nonce (anti-replay), echoed in the id_token.
+        json:
+          type: string
+          description: 'Set to "true" to receive a JSON body instead of a 302 redirect.'
+      required:
+      - username
+      - password
+      type: object
+    MfaVerifyRequest:
+      description: /oauth2/mfa/verify completion payload (JSON body or form-encoded).
+      properties:
+        mfa_token:
+          type: string
+          description: The MFA pending token returned by /oauth2/login when
+            mfa_required was true.
+        code:
+          type: string
+          description: The 6-digit TOTP code from the user's authenticator.
+        client_id:
+          type: string
+          description: Must match the first-factor login.
+        redirect_uri:
+          type: string
+          description: Must match the first-factor login.
+        scope:
+          type: string
+          description: Defaults to "openid profile email".
+        nonce:
+          type: string
+        code_verifier:
+          type: string
+          description: PKCE code_verifier matching the code_challenge sent on
+            the first-factor /oauth2/login step. Required for PUBLIC clients.
+      required:
+      - mfa_token
+      - code
+      - client_id
+      - redirect_uri
       type: object
   securitySchemes:
     bearerAuth:
@@ -36,7 +559,7 @@ components:
 info:
   description: OAuth2.0 authorization server with token management
   title: OAuth2 Authorization Server API
-  version: 1.0.0
+  version: 1.2.0
 openapi: 3.0.0
 paths:
   /.well-known/jwks.json:
@@ -48,12 +571,28 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/JWKSet'
           description: JSON Web Key Set
       summary: JSON Web Key Set
       tags:
       - OpenID Connect
       - Security
+  /.well-known/oauth-authorization-server:
+    get:
+      description: RFC 8414 OAuth 2.0 Authorization Server Metadata. Unlike the OIDC
+        discovery document this carries no userinfo/jwks entries.
+      operationId: get_.well-known_oauth-authorization-server
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthAuthorizationServerMetadata'
+          description: Authorization Server Metadata
+      summary: OAuth 2.0 Authorization Server Metadata
+      tags:
+      - OAuth2
+      - Discovery
   /.well-known/openid-configuration:
     get:
       description: Returns OIDC discovery metadata including endpoints and supported
@@ -64,7 +603,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/OpenIDConfiguration'
           description: OIDC Provider Metadata
       summary: OpenID Connect Discovery
       tags:
@@ -295,6 +834,65 @@ paths:
       tags:
       - Admin
       - Clients
+  /api/admin/dashboard:
+    get:
+      description: Static admin dashboard overview (welcome payload; live numbers
+        are on /api/admin/dashboard/stats).
+      operationId: get_api_admin_dashboard
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  status:
+                    type: string
+          description: Dashboard welcome payload
+        '401':
+          description: Unauthorized
+        '403':
+          description: 'insufficient permissions -- requires the admin role /
+            audit:read scope (F-010).'
+      security:
+      - bearerAuth: []
+      summary: Get Dashboard
+      tags:
+      - Admin
+      - Dashboard
+  /api/admin/dashboard/stats:
+    get:
+      description: Get dashboard statistics including user count, client count, active
+        tokens, and failure metrics.
+      operationId: get_api_admin_dashboard_stats
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  active_tokens:
+                    type: integer
+                  failures_today:
+                    type: integer
+                  logs_today:
+                    type: integer
+                  status:
+                    type: string
+                  total_clients:
+                    type: integer
+                  total_users:
+                    type: integer
+                type: object
+          description: Dashboard statistics
+      security:
+      - bearerAuth: []
+      summary: Get Dashboard Stats
+      tags:
+      - Admin
+      - Dashboard
   /api/admin/logs:
     get:
       description: Get a paginated list of system audit logs.
@@ -325,441 +923,115 @@ paths:
       tags:
       - Admin
       - OIDC
-  /api/admin/tokens:
+  /api/admin/organizations:
     get:
-      description: Get a list of active OAuth2 tokens.
-      operationId: get_api_admin_tokens
+      description: List all organizations (id, slug, name, branding fields; no created_at).
+      operationId: get_api_admin_organizations
       responses:
         '200':
-          description: Tokens list
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: List Tokens
-      tags:
-      - Admin
-      - Tokens
-  /api/admin/tokens/revoke-by-client:
-    post:
-      description: Revoke all tokens issued to a specific client.
-      operationId: post_api_admin_tokens_revoke-by-client
-      responses:
-        '200':
-          description: Tokens revoked successfully
-        '400':
-          description: Invalid request body
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: Revoke Tokens By Client
-      tags:
-      - Admin
-      - Tokens
-  /api/admin/tokens/revoke-by-user:
-    post:
-      description: Revoke all tokens issued for a specific user.
-      operationId: post_api_admin_tokens_revoke-by-user
-      responses:
-        '200':
-          description: Tokens revoked successfully
-        '400':
-          description: Invalid request body
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: Revoke Tokens By User
-      tags:
-      - Admin
-      - Tokens
-  /api/admin/tokens/{tokenPrefix}:
-    delete:
-      description: Revoke a specific token by its prefix.
-      operationId: delete_api_admin_tokens_{tokenPrefix}
-      parameters:
-      - description: Token prefix
-        in: path
-        name: tokenPrefix
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Token revoked successfully
-        '401':
-          description: Unauthorized
-        '404':
-          description: Token not found
-      security:
-      - bearerAuth: []
-      summary: Revoke Token
-      tags:
-      - Admin
-      - Tokens
-  /api/admin/users:
-    get:
-      description: >-
-        List users with optional pagination (page, per_page) and filtering
-        (q for username/email prefix, role, locked). Returns total count.
-      operationId: get_api_admin_users
-      parameters:
-      - description: Page number (1-based)
-        in: query
-        name: page
-        required: false
-        schema:
-          type: integer
-          default: 1
-      - description: Items per page (1-100)
-        in: query
-        name: per_page
-        required: false
-        schema:
-          type: integer
-          default: 50
-          minimum: 1
-          maximum: 100
-      - description: Search by username or email prefix
-        in: query
-        name: q
-        required: false
-        schema:
-          type: string
-      - description: Filter by role name
-        in: query
-        name: role
-        required: false
-        schema:
-          type: string
-      - description: Filter by lock state (true = locked, false = active)
-        in: query
-        name: locked
-        required: false
-        schema:
-          type: string
-          enum: ["true", "false"]
-      responses:
-        '200':
-          description: Users list
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: List Users
-      tags:
-      - Admin
-      - Users
-    post:
-      description: >-
-        Create a new user. Requires username and password; email, roles,
-        mfa_enabled, email_verified, and org_id are optional.
-      operationId: post_api_admin_users
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [username, password]
-              properties:
-                username:
-                  type: string
-                password:
-                  type: string
-                  format: password
-                email:
-                  type: string
-                email_verified:
-                  type: boolean
-                mfa_enabled:
-                  type: boolean
-                org_id:
-                  type: integer
-                  nullable: true
-                roles:
-                  type: array
-                  items:
-                    type: string
-      responses:
-        '201':
-          description: >-
-            User created successfully. The response body reports role
-            assignment outcome: roles_assigned (names landed), roles_failed
-            (requested names that did not land — unresolved or insert
-            failures), and a warning field when roles_failed is non-empty.
-        '400':
-          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  organizations:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Organization'
+                  total:
+                    type: integer
+          description: Organizations list
         '401':
           description: Unauthorized
         '403':
-          description: Forbidden
+          description: insufficient permissions (roles:read, implied by admin)
       security:
       - bearerAuth: []
-      summary: Create User
+      summary: List Organizations
       tags:
       - Admin
-      - Users
-  /api/admin/users/{userId}/disable:
-    put:
-      description: Disable a specific user account.
-      operationId: put_api_admin_users_{userId}_disable
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
+      - Organization
+    post:
+      description: Create an organization. Slug must be 3-50 chars of lowercase
+        alphanumeric + hyphens, starting/ending alphanumeric.
+      operationId: post_api_admin_organizations
+      requestBody:
         required: true
-        schema:
-          type: integer
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - slug
+              - name
+              properties:
+                slug:
+                  type: string
+                  pattern: '^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$'
+                name:
+                  type: string
+                logo_uri:
+                  type: string
+                primary_color:
+                  type: string
+                issuer_override:
+                  type: string
       responses:
         '200':
-          description: User disabled successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/Organization'
+                - type: object
+                  properties:
+                    message:
+                      type: string
+          description: Organization created
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: 'Validation error: missing/invalid JSON body, bad slug, or missing name'
+        '401':
+          description: Unauthorized
+        '409':
+          description: Organization slug already exists (or DB error)
+      security:
+      - bearerAuth: []
+      summary: Create Organization
+      tags:
+      - Admin
+      - Organization
+  /api/admin/organizations/{slug}:
+    get:
+      description: Get a single organization by its slug.
+      operationId: get_api_admin_organizations_{slug}
+      parameters:
+      - description: Organization slug
+        in: path
+        name: slug
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+          description: Organization details
         '401':
           description: Unauthorized
         '404':
-          description: User not found
-        '409':
-          description: The target is the last active admin
+          description: Organization not found
       security:
       - bearerAuth: []
-      summary: Disable User
+      summary: Get Organization
       tags:
       - Admin
-      - Users
-  /api/admin/users/{userId}/roles:
-    get:
-      description: Get the roles assigned to a specific user.
-      operationId: get_api_admin_users_{userId}_roles
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  roles:
-                    items:
-                      properties:
-                        description:
-                          type: string
-                        id:
-                          type: integer
-                        name:
-                          type: string
-                      type: object
-                    type: array
-                  status:
-                    type: string
-                type: object
-          description: User roles retrieved
-        '404':
-          description: User not found
-      security:
-      - bearerAuth: []
-      summary: Get User Roles
-      tags:
-      - Admin
-      - Users
-    put:
-      description: Assign roles to a specific user.
-      operationId: put_api_admin_users_{userId}_roles
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                roles:
-                  items:
-                    type: string
-                  type: array
-              required:
-              - roles
-              type: object
-      responses:
-        '200':
-          description: Roles assigned successfully
-        '400':
-          description: Invalid request body
-        '409':
-          description: >-
-            The change would remove the admin role from the last active admin
-      security:
-      - bearerAuth: []
-      summary: Assign User Roles
-      tags:
-      - Admin
-      - Users
-  /api/admin/users/{userId}:
-    get:
-      description: Get detailed information about a specific user including roles and
-        account status.
-      operationId: get_api_admin_users_{userId}
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  created_at:
-                    type: string
-                  email:
-                    type: string
-                  email_verified:
-                    type: boolean
-                  failed_login_count:
-                    type: integer
-                  id:
-                    type: integer
-                  locked:
-                    type: boolean
-                  locked_until:
-                    type: integer
-                  mfa_enabled:
-                    type: boolean
-                  org_id:
-                    type: integer
-                    nullable: true
-                  roles:
-                    items:
-                      type: string
-                    type: array
-                  status:
-                    type: string
-                  username:
-                    type: string
-                type: object
-          description: User details (org_id is null when the user has no org)
-        '404':
-          description: User not found
-      security:
-      - bearerAuth: []
-      summary: Get User Detail
-      tags:
-      - Admin
-      - Users
-    put:
-      description: >-
-        Update user information. Updatable fields: username, email,
-        email_verified, mfa_enabled, locked (true locks the account), and
-        org_id (integer sets it; JSON null clears it). Fields with a wrong
-        JSON type are rejected with 400 (never silently skipped).
-      operationId: put_api_admin_users_{userId}
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                username:
-                  type: string
-                email:
-                  type: string
-                email_verified:
-                  type: boolean
-                mfa_enabled:
-                  type: boolean
-                locked:
-                  type: boolean
-                org_id:
-                  type: integer
-                  nullable: true
-              type: object
-      responses:
-        '200':
-          description: User updated successfully
-        '400':
-          description: Invalid field type or no updatable fields provided
-        '404':
-          description: User not found
-        '409':
-          description: >-
-            Conflict — the target is the last active admin and the update
-            would lock them out of the management plane (e.g. locked=true)
-      security:
-      - bearerAuth: []
-      summary: Update User
-      tags:
-      - Admin
-      - Users
-    delete:
-      description: >-
-        Soft-delete a user account (sets deleted_at). The user is excluded
-        from all queries and can no longer log in. Outstanding access and
-        refresh tokens are revoked (matched on both the public subject and
-        the internal id) before the response is sent; the 200 body reports
-        tokens_revoked (false + warning on revocation failure).
-      operationId: delete_api_admin_users_{userId}
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: User deleted successfully (see tokens_revoked in the body)
-        '400':
-          description: Cannot delete your own account
-        '404':
-          description: User not found
-        '409':
-          description: The target is the last active admin
-      security:
-      - bearerAuth: []
-      summary: Delete User
-      tags:
-      - Admin
-      - Users
-  /api/admin/users/{userId}/enable:
-    post:
-      description: Enable a disabled user account by resetting lockout state.
-      operationId: post_api_admin_users_{userId}_enable
-      parameters:
-      - description: User ID
-        in: path
-        name: userId
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: User enabled successfully
-        '404':
-          description: User not found
-      security:
-      - bearerAuth: []
-      summary: Enable User
-      tags:
-      - Admin
-      - Users
+      - Organization
   /api/admin/roles:
     get:
       description: Get a list of all roles with user counts.
@@ -1007,37 +1279,477 @@ paths:
       tags:
       - Admin
       - Scopes
-  /api/admin/dashboard/stats:
+  /api/admin/scopes/resources:
     get:
-      description: Get dashboard statistics including user count, client count, active
-        tokens, and failure metrics.
-      operationId: get_api_admin_dashboard_stats
+      description: '#43 discovery -- the (path, method) -> required-scopes matrix
+        from the central ResourceScopeRegistry. Read-only, no DB access.'
+      operationId: get_api_admin_scopes_resources
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  resources:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                        method:
+                          type: string
+                        required_scopes:
+                          type: array
+                          items:
+                            type: string
+                        implied_by:
+                          type: array
+                          items:
+                            type: string
+          description: Scope-resource matrix
+      security:
+      - bearerAuth: []
+      summary: Scope-Resource Matrix
+      tags:
+      - Admin
+      - Scopes
+  /api/admin/tokens:
+    get:
+      description: Get a list of active OAuth2 tokens.
+      operationId: get_api_admin_tokens
+      responses:
+        '200':
+          description: Tokens list
+        '401':
+          description: Unauthorized
+      security:
+      - bearerAuth: []
+      summary: List Tokens
+      tags:
+      - Admin
+      - Tokens
+  /api/admin/tokens/revoke-by-client:
+    post:
+      description: Revoke all tokens issued to a specific client.
+      operationId: post_api_admin_tokens_revoke-by-client
+      responses:
+        '200':
+          description: Tokens revoked successfully
+        '400':
+          description: Invalid request body
+        '401':
+          description: Unauthorized
+      security:
+      - bearerAuth: []
+      summary: Revoke Tokens By Client
+      tags:
+      - Admin
+      - Tokens
+  /api/admin/tokens/revoke-by-user:
+    post:
+      description: Revoke all tokens issued for a specific user.
+      operationId: post_api_admin_tokens_revoke-by-user
+      responses:
+        '200':
+          description: Tokens revoked successfully
+        '400':
+          description: Invalid request body
+        '401':
+          description: Unauthorized
+      security:
+      - bearerAuth: []
+      summary: Revoke Tokens By User
+      tags:
+      - Admin
+      - Tokens
+  /api/admin/tokens/{tokenPrefix}:
+    delete:
+      description: Revoke a specific token by its prefix.
+      operationId: delete_api_admin_tokens_{tokenPrefix}
+      parameters:
+      - description: Token prefix
+        in: path
+        name: tokenPrefix
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Token revoked successfully
+        '401':
+          description: Unauthorized
+        '404':
+          description: Token not found
+      security:
+      - bearerAuth: []
+      summary: Revoke Token
+      tags:
+      - Admin
+      - Tokens
+  /api/admin/users:
+    get:
+      description: >-
+        List users with optional pagination (page, per_page) and filtering
+        (q for username/email prefix, role, locked). Returns total count.
+      operationId: get_api_admin_users
+      parameters:
+      - description: Page number (1-based)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 1
+      - description: Items per page (1-100)
+        in: query
+        name: per_page
+        required: false
+        schema:
+          type: integer
+          default: 50
+          minimum: 1
+          maximum: 100
+      - description: Search by username or email prefix
+        in: query
+        name: q
+        required: false
+        schema:
+          type: string
+      - description: Filter by role name
+        in: query
+        name: role
+        required: false
+        schema:
+          type: string
+      - description: Filter by lock state (true = locked, false = active)
+        in: query
+        name: locked
+        required: false
+        schema:
+          type: string
+          enum: ["true", "false"]
+      responses:
+        '200':
+          description: Users list
+        '401':
+          description: Unauthorized
+      security:
+      - bearerAuth: []
+      summary: List Users
+      tags:
+      - Admin
+      - Users
+    post:
+      description: >-
+        Create a new user. Requires username and password; email, roles,
+        mfa_enabled, email_verified, and org_id are optional.
+      operationId: post_api_admin_users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, password]
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+                  format: password
+                email:
+                  type: string
+                email_verified:
+                  type: boolean
+                mfa_enabled:
+                  type: boolean
+                org_id:
+                  type: integer
+                  nullable: true
+                roles:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: >-
+            User created successfully. The response body reports role
+            assignment outcome: roles_assigned (names landed), roles_failed
+            (requested names that did not land — unresolved or insert
+            failures), and a warning field when roles_failed is non-empty.
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: Create User
+      tags:
+      - Admin
+      - Users
+  /api/admin/users/{userId}:
+    delete:
+      description: >-
+        Soft-delete a user account (sets deleted_at). The user is excluded
+        from all queries and can no longer log in. Outstanding access and
+        refresh tokens are revoked (matched on both the public subject and
+        the internal id) before the response is sent; the 200 body reports
+        tokens_revoked (false + warning on revocation failure).
+      operationId: delete_api_admin_users_{userId}
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: User deleted successfully (see tokens_revoked in the body)
+        '400':
+          description: Cannot delete your own account
+        '404':
+          description: User not found
+        '409':
+          description: The target is the last active admin
+      security:
+      - bearerAuth: []
+      summary: Delete User
+      tags:
+      - Admin
+      - Users
+    get:
+      description: Get detailed information about a specific user including roles and
+        account status.
+      operationId: get_api_admin_users_{userId}
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
       responses:
         '200':
           content:
             application/json:
               schema:
                 properties:
-                  active_tokens:
+                  created_at:
+                    type: string
+                  email:
+                    type: string
+                  email_verified:
+                    type: boolean
+                  failed_login_count:
                     type: integer
-                  failures_today:
+                  id:
                     type: integer
-                  logs_today:
+                  locked:
+                    type: boolean
+                  locked_until:
                     type: integer
+                  mfa_enabled:
+                    type: boolean
+                  org_id:
+                    type: integer
+                    nullable: true
+                  roles:
+                    items:
+                      type: string
+                    type: array
                   status:
                     type: string
-                  total_clients:
-                    type: integer
-                  total_users:
-                    type: integer
+                  username:
+                    type: string
                 type: object
-          description: Dashboard statistics
+          description: User details (org_id is null when the user has no org)
+        '404':
+          description: User not found
       security:
       - bearerAuth: []
-      summary: Get Dashboard Stats
+      summary: Get User Detail
       tags:
       - Admin
-      - Dashboard
+      - Users
+    put:
+      description: >-
+        Update user information. Updatable fields: username, email,
+        email_verified, mfa_enabled, locked (true locks the account), and
+        org_id (integer sets it; JSON null clears it). Fields with a wrong
+        JSON type are rejected with 400 (never silently skipped).
+      operationId: put_api_admin_users_{userId}
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                username:
+                  type: string
+                email:
+                  type: string
+                email_verified:
+                  type: boolean
+                mfa_enabled:
+                  type: boolean
+                locked:
+                  type: boolean
+                org_id:
+                  type: integer
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: User updated successfully
+        '400':
+          description: Invalid field type or no updatable fields provided
+        '404':
+          description: User not found
+        '409':
+          description: >-
+            Conflict — the target is the last active admin and the update
+            would lock them out of the management plane (e.g. locked=true)
+      security:
+      - bearerAuth: []
+      summary: Update User
+      tags:
+      - Admin
+      - Users
+  /api/admin/users/{userId}/disable:
+    put:
+      description: Disable a specific user account.
+      operationId: put_api_admin_users_{userId}_disable
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: User disabled successfully
+        '401':
+          description: Unauthorized
+        '404':
+          description: User not found
+        '409':
+          description: The target is the last active admin
+      security:
+      - bearerAuth: []
+      summary: Disable User
+      tags:
+      - Admin
+      - Users
+  /api/admin/users/{userId}/enable:
+    post:
+      description: Enable a disabled user account by resetting lockout state.
+      operationId: post_api_admin_users_{userId}_enable
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: User enabled successfully
+        '404':
+          description: User not found
+      security:
+      - bearerAuth: []
+      summary: Enable User
+      tags:
+      - Admin
+      - Users
+  /api/admin/users/{userId}/roles:
+    get:
+      description: Get the roles assigned to a specific user.
+      operationId: get_api_admin_users_{userId}_roles
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  roles:
+                    items:
+                      properties:
+                        description:
+                          type: string
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  status:
+                    type: string
+                type: object
+          description: User roles retrieved
+        '404':
+          description: User not found
+      security:
+      - bearerAuth: []
+      summary: Get User Roles
+      tags:
+      - Admin
+      - Users
+    put:
+      description: Assign roles to a specific user.
+      operationId: put_api_admin_users_{userId}_roles
+      parameters:
+      - description: User ID
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                roles:
+                  items:
+                    type: string
+                  type: array
+              required:
+              - roles
+              type: object
+      responses:
+        '200':
+          description: Roles assigned successfully
+        '400':
+          description: Invalid request body
+        '409':
+          description: >-
+            The change would remove the admin role from the last active admin
+      security:
+      - bearerAuth: []
+      summary: Assign User Roles
+      tags:
+      - Admin
+      - Users
   /api/github/login:
     post:
       description: Exchange GitHub authorization code for user information. This endpoint
@@ -1182,6 +1894,134 @@ paths:
       summary: Revoke App Authorization
       tags:
       - User Profile
+  /api/me/mfa/disable:
+    post:
+      description: Disable MFA (TOTP) for the authenticated user.
+      operationId: post_api_me_mfa_disable
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+          description: MFA disabled successfully
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing/invalid Bearer token
+      security:
+      - bearerAuth: []
+      summary: Disable MFA
+      tags:
+      - MFA
+  /api/me/mfa/setup:
+    post:
+      description: Initiate MFA setup by generating a TOTP secret. Returns the base32
+        secret and an otpauth:// URI for authenticator apps / QR codes.
+      operationId: post_api_me_mfa_setup
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secret:
+                    type: string
+                    description: Base32 TOTP shared secret.
+                  otpauth_uri:
+                    type: string
+                    description: otpauth:// provisioning URI (encode as QR for authenticators).
+                  message:
+                    type: string
+                required:
+                - secret
+                - otpauth_uri
+          description: MFA setup initiated
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing/invalid Bearer token
+      security:
+      - bearerAuth: []
+      summary: Setup MFA
+      tags:
+      - MFA
+  /api/me/mfa/verify:
+    post:
+      description: Verify a 6-digit TOTP code to finalize MFA setup. Returns 10
+        single-use backup codes on success.
+      operationId: post_api_me_mfa_verify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - code
+              properties:
+                code:
+                  type: string
+                  description: 6-digit TOTP code from the user's authenticator.
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+              - code
+              properties:
+                code:
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  backup_codes:
+                    type: array
+                    items:
+                      type: string
+                    description: 10 single-use backup codes.
+                  warning:
+                    type: string
+          description: MFA enabled successfully
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing or non-6-digit code
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing/invalid Bearer token, MFA not configured, or wrong code
+      security:
+      - bearerAuth: []
+      summary: Verify MFA Setup
+      tags:
+      - MFA
   /api/me/password:
     put:
       description: Change the current user's password.
@@ -1244,58 +2084,6 @@ paths:
       summary: WebAuthn Register Finish
       tags:
       - WebAuthn
-  /api/orgs:
-    get:
-      description: List all organizations.
-      operationId: get_api_orgs
-      responses:
-        '200':
-          description: Organizations list
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: List Organizations
-      tags:
-      - Organization
-    post:
-      description: Create a new organization.
-      operationId: post_api_orgs
-      responses:
-        '201':
-          description: Organization created
-        '400':
-          description: Invalid request body
-        '401':
-          description: Unauthorized
-        '409':
-          description: Organization slug already exists
-      security:
-      - bearerAuth: []
-      summary: Create Organization
-      tags:
-      - Organization
-  /api/orgs/{orgId}/users:
-    post:
-      description: Add a user to an organization.
-      operationId: post_api_orgs_{orgId}_users
-      parameters:
-      - description: Organization ID
-        in: path
-        name: orgId
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: User added to organization
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: Add User to Organization
-      tags:
-      - Organization
   /api/password-reset/confirm:
     post:
       description: Confirm a password reset using the token sent via email.
@@ -1420,17 +2208,58 @@ paths:
       - WeChat
   /health:
     get:
-      description: Returns the health status of the service.
+      description: Aggregate health status of the service (process + database).
       operationId: get_health
       responses:
         '200':
           content:
             application/json:
-              example:
-                status: ok
-                version: 1.0.0
-          description: Service is healthy
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Service is healthy (or partially — inspect status field)
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Service unhealthy
       summary: Health check
+      tags:
+      - System
+  /health/live:
+    get:
+      description: Liveness probe — always 200 while the process is up (no dependency
+        checks).
+      operationId: get_health_live
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Service is alive
+      summary: Liveness probe
+      tags:
+      - System
+  /health/ready:
+    get:
+      description: Readiness probe — database / redis dependency checks; 503 when a
+        required dependency is down.
+      operationId: get_health_ready
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Service is ready
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Service degraded or unhealthy (inspect status/database/redis)
+      summary: Readiness probe
       tags:
       - System
   /oauth2/authorize:
@@ -1565,278 +2394,119 @@ paths:
       tags:
       - OAuth2
       - Consent
-  /oauth2/device/verify:
-    get:
-      description: Display device verification page.
-      operationId: get_oauth2_device_verify
-      responses:
-        '200':
-          description: Device verification page
-      summary: Verify Device (GET)
-      tags:
-      - OAuth2
-      - Device Flow
+  /oauth2/device/approve:
     post:
-      description: Submit device verification code.
-      operationId: post_oauth2_device_verify
+      description: >-
+        Admin-only approval of a pending device authorization (RFC 8628 user
+        approval step). Requires an admin Bearer token (AuthorizationFilter).
+      operationId: post_oauth2_device_approve
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+              - user_code
+              - user_id
+              properties:
+                user_code:
+                  type: string
+                  description: The user_code shown to the user by the device.
+                user_id:
+                  type: string
+                  description: Approving user's identifier.
       responses:
         '200':
-          description: Device verification submitted
-      summary: Verify Device (POST)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: approved
+                  user_code:
+                    type: string
+          description: Device authorization approved
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing user_code/user_id, or the code is invalid/already processed/expired
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing/invalid Bearer token
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Insufficient permissions (admin role / scope required)
+      security:
+      - bearerAuth: []
+      summary: Approve Device Authorization
       tags:
       - OAuth2
       - Device Flow
   /oauth2/device_authorization:
     post:
-      description: Request device authorization.
+      description: 'RFC 8628 device authorization endpoint. A CONFIDENTIAL client
+        authenticates with client_secret (HTTP Basic preferred); a PUBLIC client
+        sends client_id only. The user then visits verification_uri and an admin
+        approves via /oauth2/device/approve; the device polls /oauth2/token with
+        grant_type=urn:ietf:params:oauth:grant-type:device_code.'
       operationId: post_oauth2_device_authorization
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+              - client_id
+              properties:
+                client_id:
+                  type: string
+                client_secret:
+                  type: string
+                  description: Required for CONFIDENTIAL clients (send via HTTP Basic when possible).
+                scope:
+                  type: string
+                  description: Space-separated requested scopes (optional).
       responses:
         '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceAuthorizationResponse'
           description: Device authorization response
         '400':
-          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_request (missing client_id)
         '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_client (unknown client / bad secret)
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: server_error
       summary: Device Authorization
       tags:
       - OAuth2
       - Device Flow
-  /oauth2/introspect:
-    post:
-      description: RFC 7662 OAuth 2.0 Token Introspection. Returns information about
-        a token.
-      operationId: post_oauth2_introspect
-      parameters:
-      - description: The string value of the token (required)
-        in: query
-        name: token
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              example:
-                active: true
-                client_id: client_123
-                exp: 1680000000
-                scope: read write
-                sub: user_456
-                token_type: Bearer
-          description: Token status and metadata
-        '400':
-          description: Invalid request
-        '401':
-          description: Authentication failed
-        '429':
-          description: 'Too Many Requests -- F-018 rate limit tripped by repeated
-            failed authentication/validation attempts for this (client_ip, client_id).
-            Accompanied by a Retry-After header and an OAuth2-style {error:
-            invalid_request, error_description} body.'
-      security:
-      - clientCredentialsAuth: []
-      summary: Introspect token
-      tags:
-      - OAuth2
-      - Token
-  /oauth2/login:
-    post:
-      description: Authenticates user credentials and generates an authorization code.
-        Usually called by the frontend login page during the authorization code flow.
-      operationId: post_oauth2_login
-      parameters:
-      - description: User's account username (required)
-        in: query
-        name: username
-        required: true
-        schema:
-          type: string
-      - description: User's password (required)
-        in: query
-        name: password
-        required: true
-        schema:
-          type: string
-      - description: Client identifier matches the requesting app (required)
-        in: query
-        name: client_id
-        required: true
-        schema:
-          type: string
-      - description: Redirect URI matching the registered client (required)
-        in: query
-        name: redirect_uri
-        required: true
-        schema:
-          type: string
-      - description: Requested scope, space-separated (optional)
-        in: query
-        name: scope
-        required: false
-        schema:
-          type: string
-      - description: Opaque value to maintain state (recommended)
-        in: query
-        name: state
-        required: false
-        schema:
-          type: string
-      - description: PKCE code challenge (RFC 7636). REQUIRED for PUBLIC clients
-          (vue-client, admin-console) when auth.require_pkce_for_public is
-          enabled (default true, F-011 / RFC 9700 §2.1.1). The matching
-          code_verifier must be sent on the /oauth2/token exchange.
-        in: query
-        name: code_challenge
-        required: false
-        schema:
-          type: string
-      - description: 'PKCE code challenge method: S256 (recommended) or plain.'
-        in: query
-        name: code_challenge_method
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/json:
-              example:
-                redirect_uri: http://127.0.0.1:5173/callback?code=xyz123
-                status: success
-          description: Authentication successful (JSON with redirect_uri)
-        '302':
-          description: Redirect with authorization code (if requested via browser)
-        '401':
-          content:
-            application/json:
-              example:
-                error: invalid_client
-          description: Authentication failed
-      summary: Authenticate user
-      tags:
-      - OAuth2
-      - Authentication
-  /oauth2/mfa/disable:
-    post:
-      description: Disable MFA for the authenticated user.
-      operationId: post_oauth2_mfa_disable
-      responses:
-        '200':
-          description: MFA disabled successfully
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: Disable MFA
-      tags:
-      - MFA
-  /oauth2/mfa/setup:
-    post:
-      description: Initiate MFA setup by generating a TOTP secret.
-      operationId: post_oauth2_mfa_setup
-      responses:
-        '200':
-          description: MFA setup initiated
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: Setup MFA
-      tags:
-      - MFA
-  /oauth2/mfa/setup/verify:
-    post:
-      description: Verify a TOTP code to finalize MFA setup.
-      operationId: post_oauth2_mfa_setup_verify
-      responses:
-        '200':
-          description: MFA enabled successfully
-        '400':
-          description: Invalid request
-        '401':
-          description: Unauthorized or invalid code
-      security:
-      - bearerAuth: []
-      summary: Verify MFA Setup
-      tags:
-      - MFA
-  /oauth2/mfa/verify:
-    post:
-      description: Verify MFA (TOTP) code during login. Completes the
-        authorization-code issuance started by /oauth2/login when MFA was
-        required. The PKCE code_verifier (C4, RFC 7636) must be supplied so
-        the internally-generated code passes PKCE verification against the
-        code_challenge persisted on the session during the first-factor
-        login step.
-      operationId: post_oauth2_mfa_verify
-      parameters:
-      - description: The MFA pending token returned by /oauth2/login when
-          mfa_required was true (required).
-        in: query
-        name: mfa_token
-        required: true
-        schema:
-          type: string
-      - description: The 6-digit TOTP code from the user's authenticator
-          (required).
-        in: query
-        name: code
-        required: true
-        schema:
-          type: string
-      - description: The client_id from the original login (required, must
-          match the first-factor login).
-        in: query
-        name: client_id
-        required: true
-        schema:
-          type: string
-      - description: The redirect_uri from the original login (required,
-          must match).
-        in: query
-        name: redirect_uri
-        required: true
-        schema:
-          type: string
-      - description: PKCE code_verifier matching the code_challenge sent on
-          the first-factor /oauth2/login step (C4, RFC 7636). Required for
-          PUBLIC clients.
-        in: query
-        name: code_verifier
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: MFA verification successful — returns the token pair
-            (access_token, refresh_token, id_token).
-        '400':
-          description: Invalid request (missing mfa_token/code, malformed TOTP)
-        '401':
-          description: Invalid MFA code or client/redirect mismatch
-      summary: Verify MFA Code (Login)
-      tags:
-      - MFA
-  /oauth2/register:
-    post:
-      description: Dynamic client registration.
-      operationId: post_oauth2_register
-      responses:
-        '201':
-          description: Client registered successfully
-        '400':
-          description: Invalid client metadata
-        '401':
-          description: Unauthorized
-      security:
-      - bearerAuth: []
-      summary: Register Client
-      tags:
-      - OAuth2
-      - Dynamic Registration
   /oauth2/end_session:
     get:
       description: 'OIDC RP-Initiated Logout 1.0 §2. Terminates the user''s server-side
@@ -1870,11 +2540,16 @@ paths:
           type: string
       responses:
         '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
           description: Logged out (no post_logout_redirect_uri supplied)
         '302':
           description: Redirect to the validated post_logout_redirect_uri (with state)
         '400':
-          description: post_logout_redirect_uri not registered / no id_token_hint
+          description: 'post_logout_redirect_uri not registered / no id_token_hint
+            (plain-text body, not JSON)'
       summary: RP-Initiated Logout
       tags:
       - OAuth2
@@ -1904,15 +2579,250 @@ paths:
           type: string
       responses:
         '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
           description: Logged out
         '302':
           description: Redirect to post_logout_redirect_uri
         '400':
-          description: Invalid post_logout_redirect_uri
+          description: Invalid post_logout_redirect_uri (plain-text body, not JSON)
       summary: RP-Initiated Logout (POST)
       tags:
       - OAuth2
       - OIDC
+  /oauth2/introspect:
+    post:
+      description: RFC 7662 OAuth 2.0 Token Introspection. Returns information about
+        a token. The calling client MUST authenticate (HTTP Basic preferred;
+        client_id/client_secret form parameters accepted).
+      operationId: post_oauth2_introspect
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+              - token
+              properties:
+                token:
+                  type: string
+                  description: The string value of the token (required).
+                token_type_hint:
+                  type: string
+                  description: 'Optional hint: access_token or refresh_token (accepted, currently ignored).'
+                client_id:
+                  type: string
+                  description: Client identifier (alternative to HTTP Basic authentication).
+                client_secret:
+                  type: string
+                  description: Client secret (alternative to HTTP Basic authentication).
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntrospectionResponse'
+          description: 'Token status and metadata ({"active": false} for unknown/inactive tokens)'
+          headers:
+            Cache-Control:
+              description: Always "no-store".
+              schema:
+                type: string
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_request (missing token)
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_client (authentication failed / auth-method mismatch)
+          headers:
+            WWW-Authenticate:
+              description: Basic realm challenge when HTTP Basic was attempted.
+              schema:
+                type: string
+        '429':
+          description: 'Too Many Requests -- F-018 rate limit tripped by repeated
+            failed authentication/validation attempts for this (client_ip, client_id).
+            Accompanied by a Retry-After header and an OAuth2-style {error:
+            invalid_request, error_description} body.'
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
+      security:
+      - clientCredentialsAuth: []
+      summary: Introspect token
+      tags:
+      - OAuth2
+      - Token
+  /oauth2/login:
+    post:
+      description: Authenticates user credentials and generates an authorization code.
+        Usually called by the frontend login page during the authorization code flow.
+        Accepts a JSON body or form-encoded parameters; when MFA is enabled on the
+        account the response defers to POST /oauth2/mfa/verify.
+      operationId: post_oauth2_login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/LoginSuccessResponse'
+                - $ref: '#/components/schemas/MfaRequiredResponse'
+              examples:
+                success:
+                  summary: Login succeeded (json=true)
+                  value:
+                    status: success
+                    redirect_uri: http://127.0.0.1:5173/callback?code=xyz123
+                mfa_required:
+                  summary: MFA challenge required
+                  value:
+                    mfa_required: true
+                    mfa_token: '42'
+                    message: MFA verification required. Submit TOTP code to /oauth2/mfa/verify
+          description: 'Authentication outcome: authorization code issued (JSON with
+            code/location when json=true) or MFA challenge deferred'
+        '302':
+          description: Redirect with authorization code (browser flow / json omitted);
+            PKCE-missing errors also redirect with ?error=... to a verified redirect_uri
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing username/password (VALIDATION_INVALID_INPUT)
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Authentication failed (AUTH_INVALID_CREDENTIALS)
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Email not verified (AUTHZ_ACCESS_DENIED)
+      summary: Authenticate user
+      tags:
+      - OAuth2
+      - Authentication
+  /oauth2/logout:
+    post:
+      description: Terminates the server-side session behind the presented Bearer
+        access token (also fires OIDC back-channel logout notifications when
+        configured).
+      operationId: post_oauth2_logout
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+          description: Logged out successfully
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Missing/invalid Bearer token
+      security:
+      - bearerAuth: []
+      summary: Logout
+      tags:
+      - OAuth2
+      - Session
+  /oauth2/mfa/verify:
+    post:
+      description: Verify MFA (TOTP) code during login. Completes the
+        authorization-code issuance started by /oauth2/login when MFA was
+        required. The PKCE code_verifier (C4, RFC 7636) must be supplied so
+        the internally-generated code passes PKCE verification against the
+        code_challenge persisted on the session during the first-factor
+        login step. Accepts a JSON body or form-encoded parameters.
+      operationId: post_oauth2_mfa_verify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MfaVerifyRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/MfaVerifyRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/TokenResponse'
+                - type: object
+                  properties:
+                    message:
+                      type: string
+                    mfa_verified:
+                      type: boolean
+          description: MFA verification successful — returns the token pair
+            (access_token, refresh_token, id_token).
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Invalid request (missing mfa_token/code, malformed TOTP)
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+          description: Invalid MFA code or client/redirect mismatch
+      summary: Verify MFA Code (Login)
+      tags:
+      - MFA
+  /oauth2/register:
+    post:
+      description: Dynamic client registration.
+      operationId: post_oauth2_register
+      responses:
+        '201':
+          description: Client registered successfully
+        '400':
+          description: Invalid client metadata
+        '401':
+          description: Unauthorized
+      security:
+      - bearerAuth: []
+      summary: Register Client
+      tags:
+      - OAuth2
+      - Dynamic Registration
   /oauth2/revoke:
     post:
       description: "RFC 7009 OAuth 2.0 Token Revocation. Revokes an access OR
@@ -1922,106 +2832,83 @@ paths:
         authenticate via client_secret (HTTP Basic or body); PUBLIC clients
         (token_endpoint_auth_method='none') authenticate with client_id only
         (RFC 7009 §2.1 exempts them from client authentication at this
-        endpoint)."
+        endpoint). Unknown or already-inactive tokens still return 200 per
+        RFC 7009; the success body is EMPTY."
       operationId: post_oauth2_revoke
-      parameters:
-      - description: The token that the client wants to get revoked (required)
-        in: query
-        name: token
+      requestBody:
         required: true
-        schema:
-          type: string
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+              - token
+              properties:
+                token:
+                  type: string
+                  description: The token that the client wants to get revoked (required).
+                token_type_hint:
+                  type: string
+                  description: 'Optional hint: access_token or refresh_token (accepted, currently ignored).'
+                client_id:
+                  type: string
+                  description: Client identifier (alternative to HTTP Basic authentication).
+                client_secret:
+                  type: string
+                  description: Client secret (alternative to HTTP Basic; required for CONFIDENTIAL clients).
       responses:
         '200':
+          description: Token revoked successfully or token did not exist (empty body)
+        '400':
           content:
             application/json:
               schema:
-                type: object
-          description: Token revoked successfully or token did not exist
-        '400':
-          description: Invalid request
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_request (missing token)
         '401':
-          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_client (authentication failed)
         '429':
           description: 'Too Many Requests -- F-018 rate limit tripped by repeated
             failed authentication/validation attempts for this (client_ip, client_id).
             Accompanied by a Retry-After header and an OAuth2-style {error:
             invalid_request, error_description} body.'
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
       security:
       - clientCredentialsAuth: []
+      - {}
       summary: Revoke token
       tags:
       - OAuth2
       - Token
   /oauth2/token:
     post:
-      description: OAuth2 token endpoint - exchanges authorization code or refresh
-        token for access token.
+      description: OAuth2 token endpoint - exchanges an authorization code, refresh
+        token, client credentials, or device code for access tokens (RFC 6749 §3.2).
+        Request parameters are sent as application/x-www-form-urlencoded (the
+        server also accepts them as query parameters). CONFIDENTIAL clients
+        authenticate via HTTP Basic (preferred) or the client_id/client_secret
+        form fields; PUBLIC clients send client_id only.
       operationId: post_oauth2_token
-      parameters:
-      - description: Type of grant being requested
-        in: query
-        name: grant_type
+      requestBody:
         required: true
-        schema:
-          enum:
-          - authorization_code
-          - refresh_token
-          - client_credentials
-          - urn:ietf:params:oauth:grant-type:device_code
-          type: string
-      - description: Authorization code (required for grant_type=authorization_code)
-        in: query
-        name: code
-        required: false
-        schema:
-          type: string
-      - description: Refresh token (required for grant_type=refresh_token)
-        in: query
-        name: refresh_token
-        required: false
-        schema:
-          type: string
-      - description: Client identifier (required)
-        in: query
-        name: client_id
-        required: true
-        schema:
-          type: string
-      - description: Client secret (required for CONFIDENTIAL clients with
-          token_endpoint_auth_method=client_secret_post; FORBIDDEN for PUBLIC
-          clients whose method is 'none' — F-017 rejects a secret sent by a
-          'none' client).
-        in: query
-        name: client_secret
-        required: false
-        schema:
-          type: string
-      - description: Redirect URI (required for authorization_code grant)
-        in: query
-        name: redirect_uri
-        required: false
-        schema:
-          type: string
-      - description: PKCE code_verifier (RFC 7636). Required for the
-          authorization_code grant when the corresponding /oauth2/login (or
-          /oauth2/authorize) request sent a code_challenge. The server
-          verifies SHA-256(code_verifier) == the stored code_challenge.
-        in: query
-        name: code_verifier
-        required: false
-        schema:
-          type: string
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenRequest'
       responses:
         '200':
           content:
             application/json:
-              example:
-                access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-                expires_in: 3600
-                refresh_token: ref_123456789
-                scope: openid profile
-                token_type: Bearer
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
           description: 'Token response with access_token and refresh_token. F-019
             (RFC 6749 §5.1): success responses carry Cache-Control: no-store and
             Pragma: no-cache and MUST NOT be cached.'
@@ -2037,17 +2924,37 @@ paths:
         '400':
           content:
             application/json:
-              example:
-                error: invalid_grant
-                error_description: Invalid authorization code
-          description: Invalid request
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: >-
+            invalid_request / invalid_grant / unsupported_grant_type /
+            invalid_scope; device grant also returns authorization_pending,
+            slow_down (plus non-standard interval field), expired_token, or
+            access_denied here.
         '401':
-          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: invalid_client (authentication failed / forbidden secret on a PUBLIC client)
+          headers:
+            WWW-Authenticate:
+              description: Basic realm challenge when HTTP Basic was attempted.
+              schema:
+                type: string
         '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
           description: 'Too Many Requests -- F-018 rate limit tripped by repeated
             failed authentication/validation attempts for this (client_ip, client_id),
-            including device_code polling. Accompanied by a Retry-After header and
-            an OAuth2-style {error: invalid_request, error_description} body.'
+            including device_code polling. Accompanied by a Retry-After header.'
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: integer
       summary: Exchange authorization code for access token
       tags:
       - OAuth2
@@ -2056,27 +2963,30 @@ paths:
     get:
       description: 'Returns information about the authenticated user. F-023 (OIDC
         Core §5.3): the access token''s scope MUST include openid; M2M tokens
-        (client_credentials, subject client:*) are rejected with 403. The response
+        (client_credentials, subject client:*) are rejected. The response
         includes the email_verified claim (F-024) when an email is present.'
       operationId: get_oauth2_userinfo
       responses:
         '200':
           content:
             application/json:
-              example:
-                email: john@example.com
-                email_verified: true
-                name: john_doe
-                roles:
-                - user
-                - admin
-                sub: '1'
+              schema:
+                $ref: '#/components/schemas/UserInfoResponse'
           description: User information retrieved successfully
         '400':
           description: Invalid User ID format
         '401':
-          description: Invalid or expired access token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
+          description: 'Invalid/expired access token (invalid_token), or M2M token:
+            client-credentials tokens have no user identity for userinfo'
         '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuth2Error'
           description: 'insufficient_scope -- the access token lacks the openid scope
             (RFC 6750 §3; accompanied by WWW-Authenticate: Bearer error="insufficient_scope")'
         '404':

--- a/docs/backend/api-reference.md
+++ b/docs/backend/api-reference.md
@@ -1,6 +1,6 @@
 # OAuth2 API 接口文档
 
-> **完整 API 规范**: 手工维护的 OpenAPI 源文件为 [`apps/server/openapi.yaml`](../../apps/server/openapi.yaml)（CI 通过 `swagger-cli` 校验）；Swagger UI（`/docs/api`）在线浏览的是运行时由 Controller 代码生成的 `apps/server/docs/api/openapi.json`。
+> **完整 API 规范**: 手工维护的 OpenAPI 源文件为 [`apps/server/openapi.yaml`](../../apps/server/openapi.yaml)（**唯一契约源**，CI 通过 `openapi-spec-validator` + 治理门校验三层一致性与版本同步）；Swagger UI（`/docs/api`）在线浏览的是运行时由 Controller 代码生成的 `apps/server/docs/api/openapi.json`（派生产物）。
 
 本服务提供基于 OAuth2.0 标准（RFC 6749）的认证授权服务。
 
@@ -10,7 +10,7 @@
 |------|------|------|
 | **Password Reset** | 密码重置请求与确认（基于邮件验证码） | `/api/password-reset` |
 | **Email Verification** | 邮箱验证发送与确认 | `/api/email/verify` |
-| **MFA (Multi-Factor Auth)** | TOTP 设置、验证、恢复码管理 | `/api/mfa` |
+| **MFA (Multi-Factor Auth)** | TOTP 设置、验证、恢复码管理 | `/api/me/mfa`（登录补全为 `/oauth2/mfa/verify`） |
 | **Admin API** | 用户管理、客户端管理、审计日志（需 admin 角色） | `/api/admin` |
 | **User Self-Service** | 用户个人资料更新、密码修改、会话管理 | `/api/user` |
 | **OIDC Discovery** | OpenID Connect 发现端点与 JWKS | `/.well-known/openid-configuration`, `/oauth2/jwks` |

--- a/docs/backend/ci-cd-guide.md
+++ b/docs/backend/ci-cd-guide.md
@@ -14,8 +14,13 @@ Push/PR 到 master (及 workflow_dispatch)
         ├── FAST gate
         │     ├── static-checks (ubuntu-22.04) — 源码级守卫：
         │     │     arch-guard / migration-check / api-diff /
-        │     │     测试命名 / manage 脚本对等 / OpenAPI 校验
+        │     │     测试命名 / manage 脚本对等 / OpenAPI 校验 /
+        │     │     OpenAPI 治理门（三层一致性 + 版本同步）
         │     └── frontend (_frontend.yml) — 前端属性测试
+        │
+        ├── openapi-governance (openapi-governance.yml, PR 触发) —
+        │     oasdiff 破坏性变更门（base vs PR 的 openapi.yaml；
+        │     豁免清单 tools/openapi-governance/oasdiff-breaking-ignore.md）
         │
         ├── MAIN gate
         │     └── build-test (_build-test.yml × {linux, windows, macos} 矩阵)

--- a/docs/productization-evolution/next-phase-implementation-plan.md
+++ b/docs/productization-evolution/next-phase-implementation-plan.md
@@ -61,19 +61,10 @@ benchmark M4 报告（`benchmarks/results/SUMMARY.md`）产出了实测数据，
 
 ### 第一梯队：Phase 1 启动 + IAM 低垂果实（立即启动，2–4 周）
 
-#### A1. OpenAPI spec 治理（Phase 1 Layer 1 前置）★ 解除全部客户端工作阻塞
+#### ~~A1. OpenAPI spec 治理（Phase 1 Layer 1 前置）~~ ✅ 已实现（2026-08-17，待合并）
 
-> **设计文档**: [todo/client-sdk-facility-design.md](todo/client-sdk-facility-design.md)
-> **前置**: ~~#41~~ 已修复；死孤儿 openapi.json 已删
-> **工程量**: 1–2 周
-
-**现状**: `apps/server/openapi.yaml` 路径覆盖足（69 操作）但 requestBody/response schema 严重稀疏（D1.5），无法直接驱动客户端生成。
-
-**实施步骤**:
-1. 补齐 YAML 的 requestBody / response schema / schema 定义（M0 核心工作量）
-2. 新增 YAML↔代码一致性门（关闭"C++ 改端点忘改 YAML"的治理漏洞）
-3. 引入 oasdiff 破坏性变更门（客户端可发布的前提）
-4. 验收：生成的 Python 客户端能成功调用 `/oauth2/token` + `/oauth2/introspect`
+> **设计文档**: [todo/client-sdk-facility-design.md](todo/client-sdk-facility-design.md) §十（M0 修订）+ [todo/openapi-spec-governance-plan.md](todo/openapi-spec-governance-plan.md)（实施计划）
+> **交付内容**（分支 `feat/openapi-spec-governance-m0`）: 三层端点对账（routes 82 = docs 80 + 2 例外 = yaml 78 + 2 自文档排除；删 8 条死条目、修 5 处幽灵文档、补 10 处缺注册）+ P0 schema 补齐（token/introspect/revoke/login/userinfo/discovery 等 requestBody（form/JSON 双形态）+ 17 个 schema 定义 + `info.version` 联动 1.2.0）+ 一致性门 `tools/openapi-governance/check_spec_governance.py`（CI static-checks）+ oasdiff 破坏性变更门（`.github/workflows/openapi-governance.yml`，v1.29.1 pinned，bootstrap 豁免 15 条带理由）+ 验收：openapi-python-client 生成客户端实调 token/introspect/负例/discovery 全通过。
 
 #### ~~A2. 用户管理补全~~ ✅ 已实现（PR #52，2026-08-13）
 

--- a/docs/productization-evolution/progress-status.md
+++ b/docs/productization-evolution/progress-status.md
@@ -1,6 +1,6 @@
 # 产品化演进进展总览
 
-> **更新日期**: 2026-08-13
+> **更新日期**: 2026-08-17
 > **维护约定**: 每次完成一个工作项或里程碑后更新本文件。开始新工作前先查本文件确认当前状态。
 > **上游规划**: [productization-evolution-plan.md](productization-evolution-plan.md)（总体路线图）
 > **代码依据**: [iam-architecture-audit.md](iam-architecture-audit.md)（IAM 业务能力审计）
@@ -9,12 +9,12 @@
 
 ## 一、总体进展概览
 
-AuthForge 产品化演进按 [演进方案](productization-evolution-plan.md) 的 4 个 Phase 推进。截至 2026-08-13：
+AuthForge 产品化演进按 [演进方案](productization-evolution-plan.md) 的 4 个 Phase 推进。截至 2026-08-17：
 
 | Phase | 状态 | 完成度 | 说明 |
 |-------|------|--------|------|
 | **Phase 0** — 可信度基线 | ✅ 基本完成 | ~90% | benchmark M1–M4 全部交付（40 JSON + 承重验证报告）；**承重假设裁决：QPS ⚠️接近/可外推达标、P99 ✅低并发达成、内存 ✅SDK 口径远超标（实测 2.5 MB peak WS）、冷启动 ✅观测达成（~4s）**；竞品对比（Phase 0.5）待做 |
-| **Phase 1** — 产品化基础 + 社区启动 | 🟢 已解除阻塞 | 0%（就绪） | Phase 0 数据已落地（含 SDK 内存实测）+ #41 spec bug 已修 → spec 治理 / 文档站 / 客户端 SDK / 技术博客均可启动 |
+| **Phase 1** — 产品化基础 + 社区启动 | 🟡 进行中 | ~20% | **spec 治理（M0）已实现（待合并）——三层端点对账 + P0 schema 补齐 + 一致性门 + oasdiff 破坏性变更门，Python 客户端生成验收通过**；C1 客户端 SDK（M1 Python）现已解除阻塞可启动；文档站/博客待做 |
 | **Phase 2** — 企业版 | 🟡 快速推进 | ~45% | #42 缓存层 Phase 1+2 已交付；#43 授权模型已实现；**用户管理补全已实现（PR #52）**；**Backchannel Logout 后端已交付（PR #50）**；OAuth/OIDC 合规审计 100% 修复；SAML/LDAP/SCIM/多租户待做 |
 | **Phase 3** — 云托管 | ⬜ 未启动 | 0% | 未达启动门槛（自托管付费客户 ≥ N） |
 
@@ -173,6 +173,7 @@ AuthForge 产品化演进按 [演进方案](productization-evolution-plan.md) �
 | 2026-08-13 | **A2 用户管理补全 — 分页/搜索/createUser/软删除（V024）** | PR #52（51674ba..f0b96bf，分支 feat/user-management-crud-v2） |
 | 2026-08-13 | **D1 Backchannel Logout 后端 — 通知器 + logout_token + admin API + 单测** | PR #50（5b3ccb9..9c8cf9f，分支 feat/backchannel-logout-b1） |
 | 2026-08-13 | **内存 SDK 口径实测 — 2.5 MB peak WS（50-120MB 声称保守达标）** | third-party-host-smoke / full-stack-host-smoke 实测 |
+| 2026-08-17 | **A1 OpenAPI spec 治理（M0）— 三层对账 + schema 补齐 + 一致性门 + oasdiff 门，Python 客户端验收通过** | 分支 feat/openapi-spec-governance-m0（待 PR） |
 | 2026-08-05 | 产品化演进方案 + benchmark/client-sdk 设计文档 | a6d570c |
 
 ---

--- a/docs/productization-evolution/todo/client-sdk-facility-design.md
+++ b/docs/productization-evolution/todo/client-sdk-facility-design.md
@@ -1,7 +1,7 @@
 # AuthForge 多语言客户端 SDK 生成方案设计
 
-> **版本**: v1.0
-> **日期**: 2026-08-05
+> **版本**: v1.1（M0 立项修订：补充 §十 M0 落地实测与子决策）
+> **日期**: 2026-08-05（v1.0）/ 2026-08-16（v1.1 M0 修订）
 > **文档性质**: 技术设计（Phase 1 落地蓝图，**非代码**——实施见 §七 milestone，各 milestone 单独立项）
 > **上游规划**: [演进方案 §三 Phase 1](../productization-evolution-plan.md)「多语言 HTTP 客户端 SDK」
 > **姊妹设计**: [基准设施设计](../in-progress/benchmark-facility-design.md)（Phase 0，与本设施协同——见附录 D）
@@ -394,3 +394,83 @@ Phase 1 客户端 SDK（py/go）──请求工具──┘ C++ 工程师(wrk) +
 ---
 
 *本设计基于代码库 v1.0.0 现状（2026-08-05 核实）+ 2026 年生成器生态调研编制。实施为后续 5 个 milestone（M0 必须最先），本文档是它们的共同蓝图与约束源。Layer 1（spec 治理）是 Layer 2（客户端生成）的承重前提——不先治 spec 就生成客户端等于在流沙上盖楼。*
+
+---
+
+## 十、M0 立项修订（2026-08-16 实测，v1.1）
+
+> M0 启动前的实地核查修正了 §二 的若干判断，并落地了 D1.5 遗留子决策。
+> 实施计划（带验收标准）见 [openapi-spec-governance-plan.md](openapi-spec-governance-plan.md)。
+
+### 10.1 三层漂移实测（比 §二 更严重：不止两源，是三层）
+
+对 **Drogon 路由**（`ADD_METHOD_TO` 宏全集，82 操作）、**C++ 文档注册面**（指纹测试基线，75 操作）、
+**YAML**（73 操作）做三方对比（2026-08-16，master `e5548ec`）：
+
+| 层 | 数量 | 发现 |
+|----|------|------|
+| 路由（真实 API 面） | 82 | 12 条路由从未注册文档、从未入 YAML |
+| C++ 文档注册（generated JSON / 指纹） | 75 | **5 条是幽灵文档**（注册了不存在的路径） |
+| 手维护 YAML | 73 | **8 条死条目**（无路由支撑）+ 缺 13 条真实操作 |
+
+具体清单：
+
+**① YAML 死条目（8 操作 / 6 路径，无路由支撑）——删除**：
+- `/api/orgs` GET/POST、`/api/orgs/{orgId}/users` POST —— 路由早已删除（`OrganizationController.cc:20-21` 注释明言"dead /api/orgs endpoints"），YAML 未跟上
+- `/oauth2/device/verify` GET/POST —— 无路由；设备验证页由前端渲染
+- `/oauth2/mfa/setup`、`/oauth2/mfa/setup/verify`、`/oauth2/mfa/disable` —— 旧路径；真实路由已迁至 `/api/me/mfa/*`（`MfaController.h:52-72`）
+
+**② C++ 幽灵文档（5 操作，注册了不存在路径）——修正**：
+- `/oauth2/device/verify` GET/POST、`/oauth2/mfa/setup|setup/verify|disable` —— 同上，`OpenApiGenerator::addEndpoint` 注册的路径与 `ADD_METHOD_TO` 脱节
+
+**③ 真实路由但文档+YAML 双缺（8 操作）——补注册 + 补 YAML**：
+- `/oauth2/logout` POST（SessionController）
+- `/api/me/mfa/setup|verify|disable` POST ×3（MfaController 新路径）
+- `/oauth2/device/approve` POST（admin 授权，DeviceAuthController）
+- `/health/live`、`/health/ready` GET（HealthController）
+- `/.well-known/oauth-authorization-server` GET（RFC 8414，DiscoveryController——**对客户端 SDK 有直接价值**）
+
+**③b 真实路由、YAML 已有、文档注册缺（2 操作）——仅补注册**：
+- `/oauth2/end_session` GET+POST —— YAML 已完整定义（`openapi.yaml` `end_session` 条目），但 C++ 侧未注册文档
+
+**④ YAML 缺但 C++ 文档已有（5 操作）——补进 YAML**：
+- `/api/admin/dashboard` GET、`/api/admin/organizations` GET+POST、`/api/admin/organizations/{slug}` GET、`/api/admin/scopes/resources` GET
+
+**⑤ 有意不文档化（例外清单）**：`GET /login`（服务端渲染 HTML 页，非 API）、`GET /docs/api`（自文档跳转）。
+
+对账后集合（推演，以门脚本实跑为准）：文档注册面 = 75 − 5 + 10 = **80**；
+YAML = 73 − 8 + 13 = **78**。
+
+> §二.3 的判断"指纹测试 = C++ 代码真实注册的 API 面，权威且经测试"需要修正：
+> 指纹只守护**文档注册面**，不守护**路由面**。路由可以存在而无文档（上述 11 条），文档也可以指向不存在的路由（上述 5 条幽灵）。**一致性门必须同时比对路由↔文档↔YAML 三层**（见 10.3）。
+
+### 10.2 D1.5 子决策落地：手维护 YAML（不修生成器）
+
+M0 立项时按 §四 D1.5 的要求裁决：**补齐机制 = 手维护 YAML**。
+
+理由：
+1. `OpenApiGenerator` 的 `EndpointInfo` 结构根本不承载 requestBody/response schema（generated JSON 71 操作 0 requestBody）——修生成器到 schema 级保真度是大工程，而 D1 已把 generated JSON 降级为 Swagger UI 派生产物，ROI 不成立。
+2. YAML 是 CI lint + 一致性门 + 将来客户端生成的输入，直接对照控制器实测契约（M0 已产出 6 个核心端点的逐字段 wire 契约核查，见实施计划附录）手工补齐，可评审、可增量。
+3. #41（生成器 security object bug + 缺 clientCredentialsAuth）维持 N1 排除，不随 M0 修。
+
+### 10.3 D3 修正：一致性门升级为三层比对
+
+原设计只比对 YAML ↔ 指纹。10.1 证明指纹本身会漂移（幽灵文档/漏文档），门升级为：
+
+```
+路由集（源码扫描 ADD_METHOD_TO/METHOD_ADD，无需编译）
+  ↔ 文档注册集（解析指纹测试基线字符串，单一源不复制）
+  ↔ YAML 操作集（解析 openapi.yaml）
+```
+
+两条断言 + 显式例外清单（`GET /login`、`GET /docs/api` 路由级排除；`GET /docs/api/`、`GET /docs/api/openapi.json` YAML 级排除——自文档端点对 SDK 无意义，维持 D1 决策）。解析失败有数量下限兜底（≥60 操作），防止门静默失效。
+
+### 10.4 D4 补充：bootstrap 豁免与版本联动落点
+
+- **oasdiff 首跑豁免**：M0 的破坏性变更不止 8 条死条目删除——P0 端点把误标的 query 参数迁移为 requestBody（如 introspect 的 `token` 从 required query 迁走）、安全声明收紧，oasdiff 同样判 breaking。首跑豁免清单 = **8 条死端点删除 + P0 端点参数/安全声明迁移**，逐条带理由与关联 commit；此后任何新的 breaking 变更必须走 major 升级或显式豁免。
+- **`info.version` 联动落点**：YAML `info.version` 与 `cmake/Version.cmake` 交叉校验进一致性门脚本（当前 YAML 硬编码 1.0.0，项目已 1.2.0——脱节实锤）；`release.yml` 的 version-check job 增加同校验（tag 发布时兜底）。
+- **oasdiff 运行方式**：直接下载官方 release 二进制（Go 单文件，无 JVM），不用 wrapper action，便于本地复现。
+
+### 10.5 AC 修订
+
+§六 AC2 的验收方式细化为**本地故障注入**（从 YAML 副本删一个端点 → 门 fail；往源码副本加一条路由 → 门 fail），CI 侧由本 PR 自身触发新 workflow 验证。AC8 的"完整 requestBody + response schema"以控制器实测契约为准（M0 已核查到 file:line 级），不再以"YAML 里有内容"为满足。

--- a/docs/productization-evolution/todo/openapi-spec-governance-plan.md
+++ b/docs/productization-evolution/todo/openapi-spec-governance-plan.md
@@ -1,0 +1,211 @@
+# OpenAPI Spec 治理实施计划（M0）
+
+> **日期**: 2026-08-16
+> **上游设计**: [client-sdk-facility-design.md](client-sdk-facility-design.md) §四（Layer 1）+ §十（M0 立项修订）
+> **上游任务**: [next-phase-implementation-plan.md](../next-phase-implementation-plan.md) A1
+> **基线**: master `e5548ec`（v1.2.0）
+> **范围**: M0 = D1.5 schema 补齐 + 三层端点对账 + D3 一致性门 + D4 oasdiff 破坏性变更门。M1+（客户端生成）不在本计划。
+
+---
+
+## 一、交付物总览
+
+| # | 交付物 | 类型 |
+|---|--------|------|
+| W1 | `apps/server/openapi.yaml` 重写：端点对账（-8 死条目 / +13 缺失）+ P0 schema 补齐 + `info.version: 1.2.0` | spec |
+| W2 | C++ 文档注册修正（5 处幽灵路径修正/删除 + 10 处缺失补注册），指纹测试基线同步更新 | C++ |
+| W3 | `tools/openapi-governance/check_spec_governance.py`：三层一致性门 + 版本交叉校验（带 selftest） | 工具 |
+| W4 | CI 接线：`ci.yml` static-checks 加一致性门步骤；新增 `.github/workflows/openapi-governance.yml`（oasdiff breaking 门） | CI |
+| W5 | oasdiff 首跑豁免清单（9 条死端点删除的一次性 errata） | 配置 |
+| W6 | `tools/refactor-baseline/endpoints/openapi.signature.txt` 再生（手动 refactor 门保持连贯） | 基线 |
+| W7 | 验收证据：openapi-python-client 生成的客户端实调 `/oauth2/token` + `/oauth2/introspect` 成功 | 验收 |
+
+---
+
+## 二、W2 — C++ 文档注册修正（先做，因为它定义权威集）
+
+原则：**文档注册路径必须与 `ADD_METHOD_TO` 路由逐字相等**；真实路由必须注册文档（例外清单除外）。
+
+| 文件 | 改动 |
+|------|------|
+| `libs/drogon/src/controllers/MfaController.cc` | 3 条文档路径改名：`/oauth2/mfa/setup`→`/api/me/mfa/setup`、`/oauth2/mfa/setup/verify`→`/api/me/mfa/verify`、`/oauth2/mfa/disable`→`/api/me/mfa/disable`（`/oauth2/mfa/verify` 保留） |
+| `libs/drogon/src/controllers/DeviceAuthController.cc` | 删除 `/oauth2/device/verify` GET/POST 幽灵文档；新增 `/oauth2/device/approve` POST 文档（admin，AuthorizationFilter） |
+| `libs/drogon/src/controllers/SessionController.cc` | 新增 `/oauth2/end_session` GET+POST（YAML 已有、仅缺注册）、`/oauth2/logout` POST 文档 |
+| `libs/drogon/src/controllers/HealthController.cc`（注意：该文件现无文档注册机制，`GET /health` 的注册在 SessionController.cc 的 static-ctor 结构里） | 新增 `/health/live`、`/health/ready` GET 文档——用 static-ctor 自注册惯例（服务器与测试二进制都链接到，指纹测试才能看到），避免 initApiDocs 双接线（main.cc + tests/test_main.cc） |
+| `libs/drogon/src/controllers/DiscoveryController.cc` | 新增 `/.well-known/oauth-authorization-server` GET 文档（RFC 8414） |
+| `tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc` | `kFingerprint` 基线更新为对账后集合，并在文件头加注释：此基线被 `tools/openapi-governance/check_spec_governance.py` 解析，改动需同步 |
+
+对账后权威集（文档注册面）= 现 75 − 5 幽灵 + 10 新注册 = **80 操作**；
+YAML = 80 − 2 自文档排除（`/docs/api/`、`/docs/api/openapi.json`）= **78 操作**；
+路由 82 − `GET /login` − `GET /docs/api`（路由级排除）= 80。
+
+> ⚠️ 数字以实施时脚本实跑为准（上式为推演）；门脚本断言的是**集合相等**而非数量。
+
+**例外清单（硬编码进门脚本，带理由注释）**：
+- 路由级（有路由、永不文档化）：`GET /login`（HTML 页面）、`GET /docs/api`（自文档跳转变体）
+- YAML 级（有文档注册、不入 YAML）：`GET /docs/api/`、`GET /docs/api/openapi.json`（SDK 无意义的自文档端点，D1 决策）
+
+**验收 W2**：
+- [ ] Windows 本地构建（`./manage.ps1 build`）+ `ctest -R OpenApiSpec_Property4`（指纹测试）绿
+- [ ] 服务器可启动，`/docs/api/openapi.json`（generated JSON）与新文档注册面一致
+
+## 三、W1 — YAML 重写（核心工作量）
+
+### 3.1 端点层对账
+
+- 删除 8 条死条目（§十.10.1 ①）
+- 新增 13 条缺失：§十.10.1 ③ 的 8 条 + ④ 的 5 条（③b 的 end_session 已在 YAML，仅 W2 补注册）
+- `/oauth2/mfa/verify`、`/oauth2/consent`、`/oauth2/authorize` 等保留条目中把"参数在 query"的误导性声明改为真实位置（见 3.2 契约表）
+
+### 3.2 P0 schema 补齐（以 2026-08-16 控制器实测契约为准）
+
+新增 `components/schemas`（全部从实测契约生成，file:line 依据存于本计划附录 A）：
+
+| Schema | 要点 |
+|--------|------|
+| `OAuth2Error` | RFC 6749 §5.2：`error`(enum) + `error_description?` + `error_uri?`；`/oauth2/*`、`/.well-known/*` 端点的错误体 |
+| `ErrorEnvelope` / `Error` | 应用端点错误：`{"error": {category, code, message, request_id, numeric_code?, details?}}`——修正现有 `Error` schema：补 `numeric_code`（`details` 字段已有，核对类型即可）+ 建模外层 `error` 包装 |
+| `TokenResponse` | 单 schema + 可选字段（access_token, token_type, expires_in, refresh_token?, scope?, roles?, id_token?），描述标注各 grant 的字段出现规则（避免 oneOf 加重生成客户端） |
+| `IntrospectionResponse` | `active` + client_id?/token_type?/exp?/iat?/nbf?/sub?/aud?/iss?/scope?；inactive 时仅 `{active: false}` |
+| `UserInfoResponse` | sub, name, username?, email?, email_verified?, roles? |
+| `OpenIDConfiguration` | discovery 全字段（issuer…claims_supported，含 end_session_endpoint、backchannel_logout_supported） |
+| `OAuthAuthorizationServerMetadata` | RFC 8414 全字段（无 userinfo_endpoint/jwks_uri） |
+| `JWKSet` | `{keys: [{kty, kid?, use?, alg?, n?, e?, x5c?}]}` |
+| `LoginSuccess` / `MfaRequiredResponse` | login `json=true` 的 `{code, location}`；`{mfa_required, mfa_token, message}` |
+| `MessageResponse` | `{message}`（logout/end_session/通用） |
+| `DeviceAuthorizationResponse` | device_code, user_code, verification_uri, expires_in, interval（**无** verification_uri_complete） |
+| `HealthStatus` | health/live/ready 的状态体 |
+
+P0 端点的 requestBody 修正（当前 YAML 把 token/introspect/revoke/login 参数全标 `in: query`，与实现不符）：
+
+| 端点 | 真实请求形态 |
+|------|--------------|
+| `POST /oauth2/token` | `application/x-www-form-urlencoded` body（getParameter = query **或** form；RFC 6749 要求 form）+ HTTP Basic 客户端认证可选。requestBody 用 form schema（grant_type enum 4 值、code、redirect_uri、refresh_token、client_id、client_secret、scope、code_verifier、device_code），同时保留 query 参数声明会误导生成器——**改为 requestBody 为主，query 不声明**，描述注明 Drogon 兼容 query |
+| `POST /oauth2/introspect` | 同上：form body `token` + `token_type_hint?`；客户端凭证 Basic（必须） |
+| `POST /oauth2/revoke` | form body `token` + `token_type_hint?`；Basic（confidential 必须，public 豁免） |
+| `POST /oauth2/login` | JSON body **或** form/query 双形态（SessionController 分支读 jsonObject）；requestBody 声明 `application/json` + `application/x-www-form-urlencoded` 两种 content |
+| `GET /.well-known/*`、`GET /oauth2/userinfo` | 无 body；userinfo 补全 200/401/403 响应 schema |
+
+安全声明修正：token = 无强制 scheme（grant 依赖）；introspect = `clientCredentialsAuth`（必须）；revoke = `clientCredentialsAuth` 可选（public 豁免，`security: [{clientCredentialsAuth: []}, {}]`）。
+
+P1（admin/self-service 响应 schema）与 P2（WebAuthn/social 等）维持现状路径级描述——本 PR 只对账端点，不承诺全量 schema（C1 Python 客户端主要消费 P0）。
+
+`info.version`: 1.0.0 → **1.2.0**（与 `cmake/Version.cmake` 对齐，进 W3 校验）。
+
+**验收 W1**：
+- [ ] `python -m openapi_spec_validator apps/server/openapi.yaml` 绿
+- [ ] 三层一致性门（W3）报告 YAML ↔ 文档注册面差异 = 0（除例外清单）
+- [ ] 6 个 P0 端点均有 requestBody（如适用）+ 主要响应的 `content.application/json.schema.$ref`
+
+## 四、W3 — 一致性门脚本 `tools/openapi-governance/check_spec_governance.py`
+
+检查（单脚本三检查，一次 CI 步骤）：
+
+1. **routes ↔ docs**：源码扫描 `ADD_METHOD_TO`（多行宏需跨行匹配；本仓库无 `METHOD_ADD`）覆盖 `libs/drogon/include/.../controllers/*.h` + `apps/server/**`，提取 `METHOD path` 集——每个宏只取第一个方法 token（GitHub/Google/WeChat 的 `::drogon::Post, ::drogon::Options` 双方法声明只取主方法，OPTIONS 忽略）；解析指纹测试 `kFingerprint` 字符串提取文档注册集；断言 `docs == routes − ROUTE_ONLY`。
+2. **docs ↔ yaml**：解析 `openapi.yaml` paths；断言 `yaml_ops == docs − YAML_EXCLUDED`。
+3. **version sync**：`openapi.yaml` `info.version` == `cmake/Version.cmake` 的 `OAUTH2_PROJECT_VERSION`。
+
+工程约束：
+- 遵循仓库脚本惯例：`--selftest`（fixture 驱动）、退出码 0/1/2、ASCII 输出
+- 复用 `tools/refactor-baseline/parse_endpoints.py` 的 YAML 加载（PyYAML 优先，MiniYaml 兜底）。CI 上 `pip install openapi-spec-validator` 已连带装 PyYAML，但为确定性在新步骤的 pip 行显式加 `pyyaml`；MiniYaml 仅作本地兜底（对本门只读 paths/methods/version 的用途足够）
+- 解析兜底：指纹提取数 < 60 或路由提取数 < 60 → 按 env 错误 fail（防门静默失效）
+- 例外清单常量 + 每条一行理由注释
+
+**验收 W3**：
+- [ ] `python tools/openapi-governance/check_spec_governance.py` 在对账后的树上退出 0
+- [ ] `--selftest` 绿
+- [ ] 故障注入 ①：YAML 副本删一个端点 → 退出 1 且 diff 输出指名该端点
+- [ ] 故障注入 ②：源码副本（fixture）加一条路由 → 退出 1
+- [ ] 故障注入 ③：YAML `info.version` 改错 → 退出 1
+
+## 五、W4/W5 — CI 接线 + oasdiff 门
+
+### 5.1 `ci.yml` static-checks 追加一步
+
+```yaml
+- name: Check OpenAPI Spec Governance (3-layer consistency + version sync)
+  run: python3 tools/openapi-governance/check_spec_governance.py
+```
+
+纯源码扫描，无新依赖，符合 static-checks"source-only"定位。
+
+### 5.2 新增 `.github/workflows/openapi-governance.yml`（PR 触发）
+
+- job `breaking-change`：checkout base（`origin/master`）+ head；下载 pinned oasdiff release 二进制（linux-amd64，版本 pin，SHA 校验可选）；`oasdiff breaking base/apps/server/openapi.yaml head/apps/server/openapi.yaml`；非空 breaking 集 → fail，输出要求"升 major 或更新豁免清单"。
+- 豁免清单：`tools/openapi-governance/oasdiff-breaking-ignore.yaml`（机制以 oasdiff 当前版本文档为准——ignore-file/errata，实施时核实）。首跑豁免 = **8 条死端点删除 + P0 端点参数/安全声明迁移**（query→requestBody 迁移、introspect `token` required query 移除、security 收紧——这些同样是 oasdiff 判定的 breaking），逐条带理由与关联 commit。
+- 该 workflow 同时承担"门本身活着"的验证：本 PR 触发首跑，豁免清单必须恰好覆盖 M0 的破坏性变更（死端点删除 + P0 参数迁移）——多了放水、少了误杀，都算验收失败。
+
+### 5.3 `release.yml` version-check 追加一行
+
+`version-check` job 增加 YAML `info.version` == `cmake/Version.cmake` 校验（tag 发布兜底；PR 侧已由 W3 门覆盖，此处防 release 路径漂移）。
+- [ ] 改动后 YAML 版本与 tag 不一致时 version-check 失败（推演即可，不强求实跑 tag）
+
+**验收 W4/W5**：
+- [ ] 本 PR 上 `openapi-governance.yml` 绿（证明豁免清单恰好覆盖 bootstrap 删除）
+- [ ] 本 PR 上 static-checks 新步骤绿
+- [ ] （门有效性）本地用 oasdiff 二进制对"删除一个存活路径"的副本 spec 实跑 → 报 breaking（AC3 故障注入）
+
+## 六、W6 — refactor-baseline 签名再生
+
+`python tools/diff-endpoint-baseline.py --update-baseline`（statuses/content-types 因 schema 补齐大量变化）；该门仅手动 capture 流程消费，不在 CI，但保持连贯避免下次 refactor 误报。**注**：该基线在 master 上已先行漂移（69 行 vs YAML 73 操作）——本次再生一并收敛，commit 信息注明含存量漂移。
+
+- [ ] 更新后再跑 `diff-endpoint-baseline.py`（diff 模式）退出 0
+
+## 七、W7 — AC8 验收：生成客户端实调
+
+步骤（Windows 本机，PG13 native + Release 构建，构建/启停用 `./manage.ps1` 入口，参照 full-backend-test 基建）：
+1. `pipx run openapi-python-client generate --url file://.../openapi.yaml --output .tmp-acceptance/client`（或 `--path`）
+2. 启动服务器（postgres 模式），用端点测试同款种子客户端凭证
+3. 脚本：生成客户端发起 `client_credentials` token 请求 → 拿 access_token；用 client 凭证 introspect 该 token → `active: true`
+4. 断言：两个调用均由**生成代码**构造请求体（表单字段来自 schema，无需手拼 form）
+
+- [ ] token 200 + `access_token` 非空；introspect 200 + `active == true`
+- [ ] 生成器无因 spec 缺陷导致的警告性跳过（如缺 schema 退化为 Any）
+
+## 八、文档同步（实施后）
+
+| 文档 | 改动 |
+|------|------|
+| `.claude/skills/openapi-update/SKILL.md`（+ `.zcode`/`.codebuddy`/`.qoder` 镜像） | 工作流加第 5 步：跑治理门脚本；提示 MFA 新路径、版本联动 |
+| `docs/backend/api-reference.md` | 对照对账结果核对（尤其 /api/orgs 死条目、mfa 路径、新增 11 端点） |
+| `next-phase-implementation-plan.md` | A1 状态更新 |
+| `progress-status.md` | 加进度行 |
+| `docs/backend/ci-cd-guide.md` | 补 openapi-governance workflow 说明（若该文档覆盖 CI 清单） |
+
+## 九、实施顺序与提交切分
+
+```
+1. C++ 文档注册修正 + 指纹基线更新（W2）        → commit 1（可独立构建验证）
+2. YAML 重写（W1）                              → commit 2
+3. 治理门脚本 + selftest（W3）                   → commit 3
+4. CI 接线 + oasdiff workflow + 豁免清单（W4/W5） → commit 4
+5. baseline 再生（W6）+ 文档同步（§八）           → commit 5
+6. 验收证据（W7 脚本与输出记录）                  → PR 描述附证据
+```
+
+分支：`feat/openapi-spec-governance-m0`。每 commit 独立可回滚；commit 2 依赖 commit 1（否则门尚未存在，无交叉约束）。
+
+## 十、风险与回退
+
+| 风险 | 缓解 |
+|------|------|
+| 指纹测试基线更新后其它测试依赖旧集合 | 全量后端测试跑通再提交（full-backend-test 8 步） |
+| oasdiff ignore 机制与预期不符（版本差异） | 实施首步先下载二进制本地实跑 3 个用例（无变更/删路径/改 schema），再写 workflow |
+| openapi-python-client 对 form requestBody 生成质量不足 | 验收 W7 前置试跑；若 form 支持差，schema 写法调整为 x-www-form-urlencoded 的最简 object 形态（不牺牲契约准确性） |
+| YAML 重写体积大、评审困难 | 只动该动的：P0 端点重写 + 端点对账增删；P1/P2 条目原样保留（diff 可审计） |
+| 指纹 .cc 解析被未来重构破坏 | 解析兜底下限 + 测试文件头注释声明耦合关系 |
+
+## 附录 A：P0 端点 wire 契约实测依据（2026-08-16）
+
+> 由控制器源码 + 集成测试核查，file:line 略（存于任务过程记录）。关键结论：
+
+- 全局无成功包络；错误双形态：`/oauth2/*`、`/.well-known/*` = RFC 6749 体；其余 = `{"error": {...}}` 包络（含 numeric_code/details）
+- token 成功响应**不含** scope 字段（authorization_code grant），含 roles；client_credentials/device 才回 scope；id_token 仅 openid scope 且 JWK 就绪时出现
+- introspect inactive = `{"active": false}`；无 username 字段
+- revoke 成功 = 200 空 body
+- userinfo 401/403 为 RFC 体（invalid_token / insufficient_scope + WWW-Authenticate）
+- end_session 400 为纯文本 body（非 JSON）——spec 中以 description 注明
+- device_authorization 响应无 verification_uri_complete；interval=5, expires_in=600
+- login 支持 JSON body（`json=true` 时 200 JSON `{code, location}`，否则 302）
+- `/api/me/mfa/setup` 200 = `{secret, otpauth_uri, message}`；`verify` 200 = `{message, backup_codes[10]}`；均 Bearer 保护
+- health 三端点：live 恒 200 `{status: ok}`；ready 200/503 依 DB/Redis

--- a/libs/drogon/src/controllers/DeviceAuthController.cc
+++ b/libs/drogon/src/controllers/DeviceAuthController.cc
@@ -50,23 +50,20 @@ struct DeviceAuthControllerDocs
         authDocs.requiresAuth = true;
         ::authforge::drogon::observability::openapi::OpenApiGenerator::addEndpoint(authDocs);
 
-        ::authforge::drogon::observability::openapi::EndpointInfo verifyGetDocs;
-        verifyGetDocs.path = "/oauth2/device/verify";
-        verifyGetDocs.method = "GET";
-        verifyGetDocs.summary = "Verify Device (GET)";
-        verifyGetDocs.description = "Display device verification page.";
-        verifyGetDocs.tags = {"OAuth2", "Device Flow"};
-        verifyGetDocs.requiresAuth = false;
-        ::authforge::drogon::observability::openapi::OpenApiGenerator::addEndpoint(verifyGetDocs);
-
-        ::authforge::drogon::observability::openapi::EndpointInfo verifyPostDocs;
-        verifyPostDocs.path = "/oauth2/device/verify";
-        verifyPostDocs.method = "POST";
-        verifyPostDocs.summary = "Verify Device (POST)";
-        verifyPostDocs.description = "Submit device verification code.";
-        verifyPostDocs.tags = {"OAuth2", "Device Flow"};
-        verifyPostDocs.requiresAuth = false;
-        ::authforge::drogon::observability::openapi::OpenApiGenerator::addEndpoint(verifyPostDocs);
+        // The former /oauth2/device/verify GET+POST doc entries were ghosts:
+        // no ADD_METHOD_TO route ever backed them (the verification page is
+        // rendered by the frontend). Removed; docs must equal routes
+        // (OpenAPI governance gate).
+        ::authforge::drogon::observability::openapi::EndpointInfo approveDocs;
+        approveDocs.path = "/oauth2/device/approve";
+        approveDocs.method = "POST";
+        approveDocs.summary = "Approve Device Authorization";
+        approveDocs.description =
+          "Admin-only approval of a pending device authorization (the user_code "
+          "approval step of RFC 8628). Requires an admin Bearer token.";
+        approveDocs.tags = {"OAuth2", "Device Flow"};
+        approveDocs.requiresAuth = true;
+        ::authforge::drogon::observability::openapi::OpenApiGenerator::addEndpoint(approveDocs);
     }
 };
 

--- a/libs/drogon/src/controllers/DiscoveryController.cc
+++ b/libs/drogon/src/controllers/DiscoveryController.cc
@@ -67,6 +67,23 @@ void DiscoveryController::initApiDocsImpl()
         jwksEndpoint.requiresAuth = false;
         OpenApiGenerator::addEndpoint(jwksEndpoint);
     }
+
+    // RFC 8414 OAuth 2.0 Authorization Server Metadata
+    {
+        authforge::drogon::observability::openapi::EndpointInfo asMetadataEndpoint;
+        asMetadataEndpoint.path = "/.well-known/oauth-authorization-server";
+        asMetadataEndpoint.method = "GET";
+        asMetadataEndpoint.summary = "OAuth 2.0 Authorization Server Metadata";
+        asMetadataEndpoint.description =
+          "RFC 8414 authorization server metadata (endpoints, grant types, "
+          "auth methods). Unlike the OIDC discovery document this carries no "
+          "userinfo/jwks entries.";
+        asMetadataEndpoint.tags = {"OAuth2", "Discovery"};
+        asMetadataEndpoint.parameters = {};
+        asMetadataEndpoint.responses = {{200, "Authorization Server Metadata"}};
+        asMetadataEndpoint.requiresAuth = false;
+        OpenApiGenerator::addEndpoint(asMetadataEndpoint);
+    }
 }
 
 void DiscoveryController::metadata(

--- a/libs/drogon/src/controllers/MfaController.cc
+++ b/libs/drogon/src/controllers/MfaController.cc
@@ -48,7 +48,11 @@ struct MfaControllerDocs
     MfaControllerDocs()
     {
         ::authforge::drogon::observability::openapi::EndpointInfo setupDocs;
-        setupDocs.path = "/oauth2/mfa/setup";
+        // Path must equal the ADD_METHOD_TO route (MfaController.h): the MFA
+        // self-service routes live under /api/me/mfa/*, NOT /oauth2/mfa/*
+        // (those old paths have no backing routes — OpenAPI governance gate
+        // checks docs == routes).
+        setupDocs.path = "/api/me/mfa/setup";
         setupDocs.method = "POST";
         setupDocs.summary = "Setup MFA";
         setupDocs.description = "Initiate MFA setup by generating a TOTP secret.";
@@ -57,7 +61,7 @@ struct MfaControllerDocs
         ::authforge::drogon::observability::openapi::OpenApiGenerator::addEndpoint(setupDocs);
 
         ::authforge::drogon::observability::openapi::EndpointInfo verifySetupDocs;
-        verifySetupDocs.path = "/oauth2/mfa/setup/verify";
+        verifySetupDocs.path = "/api/me/mfa/verify";
         verifySetupDocs.method = "POST";
         verifySetupDocs.summary = "Verify MFA Setup";
         verifySetupDocs.description = "Verify a TOTP code to finalize MFA setup.";
@@ -66,7 +70,7 @@ struct MfaControllerDocs
         ::authforge::drogon::observability::openapi::OpenApiGenerator::addEndpoint(verifySetupDocs);
 
         ::authforge::drogon::observability::openapi::EndpointInfo disableDocs;
-        disableDocs.path = "/oauth2/mfa/disable";
+        disableDocs.path = "/api/me/mfa/disable";
         disableDocs.method = "POST";
         disableDocs.summary = "Disable MFA";
         disableDocs.description = "Disable MFA for the authenticated user.";

--- a/libs/drogon/src/controllers/SessionController.cc
+++ b/libs/drogon/src/controllers/SessionController.cc
@@ -166,8 +166,8 @@ struct OAuth2ControllerDocs
         // Login endpoint
         {
             Json::Value successExample;
-            successExample["status"] = "success";
-            successExample["redirect_uri"] = "http://127.0.0.1:5173/callback?code=xyz123";
+            successExample["code"] = "xyz123";
+            successExample["location"] = "http://127.0.0.1:5173/callback?code=xyz123&state=abc";
 
             Json::Value errorExample;
             errorExample["error"] = "invalid_client";

--- a/libs/drogon/src/controllers/SessionController.cc
+++ b/libs/drogon/src/controllers/SessionController.cc
@@ -385,6 +385,97 @@ struct OAuth2ControllerDocs
             consentEndpoint.requiresAuth = false;
             OpenApiGenerator::addEndpoint(consentEndpoint);
         }
+
+        // Logout endpoint (Bearer-protected programmatic logout)
+        {
+            ::authforge::drogon::observability::openapi::EndpointInfo logoutEndpoint;
+            logoutEndpoint.path = "/oauth2/logout";
+            logoutEndpoint.method = "POST";
+            logoutEndpoint.summary = "Logout";
+            logoutEndpoint.description =
+              "Terminates the server-side session behind the presented Bearer "
+              "access token (also fires OIDC back-channel logout notifications "
+              "when configured).";
+            logoutEndpoint.tags = {"OAuth2", "Session"};
+            logoutEndpoint.responses = {{200, "Logged out"}};
+            logoutEndpoint.requiresAuth = true;
+            OpenApiGenerator::addEndpoint(logoutEndpoint);
+        }
+
+        // OIDC RP-Initiated Logout (GET link-based + POST form-based)
+        {
+            auto endSessionParam = [](const char *name, const char *desc) {
+                ::authforge::drogon::observability::openapi::ParameterInfo p;
+                p.name = name;
+                p.description = desc;
+                p.type = ::authforge::drogon::observability::openapi::ParameterType::STRING;
+                p.location = ::authforge::drogon::observability::openapi::ParameterLocation::QUERY;
+                p.required = false;
+                return p;
+            };
+
+            ::authforge::drogon::observability::openapi::EndpointInfo endSessionGet;
+            endSessionGet.path = "/oauth2/end_session";
+            endSessionGet.method = "GET";
+            endSessionGet.summary = "RP-Initiated Logout";
+            endSessionGet.description =
+              "OIDC RP-Initiated Logout 1.0 §2 (link-based variant). Terminates "
+              "the user's server-side session and optionally redirects to a "
+              "registered post_logout_redirect_uri.";
+            endSessionGet.tags = {"OAuth2", "OIDC"};
+            endSessionGet.parameters = {
+              endSessionParam("id_token_hint", "Previously issued id_token hinting at the client/session to terminate."),
+              endSessionParam("post_logout_redirect_uri", "URI to redirect to after logout; must be registered for the id_token_hint client."),
+              endSessionParam("state", "Opaque value echoed back to the post_logout_redirect_uri."),
+            };
+            endSessionGet.responses = {
+              {200, "Logged out (no post_logout_redirect_uri supplied)"},
+              {302, "Redirect to the validated post_logout_redirect_uri (with state)"},
+              {400, "post_logout_redirect_uri not registered / no id_token_hint"},
+            };
+            endSessionGet.requiresAuth = false;
+            OpenApiGenerator::addEndpoint(endSessionGet);
+
+            ::authforge::drogon::observability::openapi::EndpointInfo endSessionPost;
+            endSessionPost.path = "/oauth2/end_session";
+            endSessionPost.method = "POST";
+            endSessionPost.summary = "RP-Initiated Logout (POST)";
+            endSessionPost.description =
+              "OIDC RP-Initiated Logout (POST form-based variant; see GET for semantics).";
+            endSessionPost.tags = {"OAuth2", "OIDC"};
+            endSessionPost.parameters = endSessionGet.parameters;
+            endSessionPost.responses = endSessionGet.responses;
+            endSessionPost.requiresAuth = false;
+            OpenApiGenerator::addEndpoint(endSessionPost);
+        }
+
+        // Health sub-probes (liveness / readiness). Registered here, next to
+        // the existing /health entry, because HealthController itself has no
+        // doc-registration idiom; the static-ctor self-registers in both the
+        // server and the test binary.
+        {
+            ::authforge::drogon::observability::openapi::EndpointInfo liveEndpoint;
+            liveEndpoint.path = "/health/live";
+            liveEndpoint.method = "GET";
+            liveEndpoint.summary = "Liveness probe";
+            liveEndpoint.description = "Process-is-alive check (always 200 when the server runs).";
+            liveEndpoint.tags = {"System"};
+            liveEndpoint.responses = {{200, "Service is alive"}};
+            liveEndpoint.requiresAuth = false;
+            OpenApiGenerator::addEndpoint(liveEndpoint);
+
+            ::authforge::drogon::observability::openapi::EndpointInfo readyEndpoint;
+            readyEndpoint.path = "/health/ready";
+            readyEndpoint.method = "GET";
+            readyEndpoint.summary = "Readiness probe";
+            readyEndpoint.description =
+              "Dependency readiness check (database / redis); 503 when a "
+              "required dependency is down.";
+            readyEndpoint.tags = {"System"};
+            readyEndpoint.responses = {{200, "Service is ready"}, {503, "A dependency is down"}};
+            readyEndpoint.requiresAuth = false;
+            OpenApiGenerator::addEndpoint(readyEndpoint);
+        }
     }
 };
 

--- a/tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc
+++ b/tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc
@@ -87,6 +87,11 @@ std::string openApiPathMethodFingerprint(const Json::Value &spec)
 // The complete, frozen (path, method) contract. Recorded here as the Task-4
 // preservation baseline for the WHOLE spec (Task 1 froze the deep fields of a
 // representative subset; this freezes the full set as one comparable unit).
+//
+// NOTE: tools/openapi-governance/check_spec_governance.py (CI static-checks)
+// parses the string literals below as the authoritative "docs-registered
+// endpoint set" and diffs them against the ADD_METHOD_TO routes and
+// apps/server/openapi.yaml. If you change this baseline, re-run that gate.
 const std::string &expectedFingerprint()
 {
     // Sorted "METHOD path" lines, matching openApiPathMethodFingerprint().
@@ -94,6 +99,13 @@ const std::string &expectedFingerprint()
     // (path, method) contract (the whole test binary links every controller, so
     // every endpoint's docs are registered). Task 6.4 regenerates this on F'
     // and asserts byte-for-byte equality.
+    //
+    // 2026-08-16 reconciliation (openapi-spec-governance M0): removed ghost
+    // registrations for routes that never existed (/oauth2/device/verify GET+POST,
+    // /oauth2/mfa/{setup,setup/verify,disable}); added missing registrations for
+    // real routes (/api/me/mfa/{setup,verify,disable}, /oauth2/device/approve,
+    // /oauth2/logout, /oauth2/end_session GET+POST, /health/{live,ready},
+    // /.well-known/oauth-authorization-server).
     static const std::string kFingerprint =
       "DELETE /api/admin/clients/{clientId}\n"
       "DELETE /api/admin/roles/{roleId}\n"
@@ -103,6 +115,7 @@ const std::string &expectedFingerprint()
       "DELETE /api/me\n"
       "DELETE /api/me/authorized-apps/{clientId}\n"
       "GET /.well-known/jwks.json\n"
+      "GET /.well-known/oauth-authorization-server\n"
       "GET /.well-known/openid-configuration\n"
       "GET /api/admin/clients\n"
       "GET /api/admin/clients/{clientId}\n"
@@ -127,8 +140,10 @@ const std::string &expectedFingerprint()
       "GET /docs/api/\n"
       "GET /docs/api/openapi.json\n"
       "GET /health\n"
+      "GET /health/live\n"
+      "GET /health/ready\n"
       "GET /oauth2/authorize\n"
-      "GET /oauth2/device/verify\n"
+      "GET /oauth2/end_session\n"
       "GET /oauth2/userinfo\n"
       "POST /api/admin/clients\n"
       "POST /api/admin/clients/{clientId}/reset-secret\n"
@@ -141,6 +156,9 @@ const std::string &expectedFingerprint()
       "POST /api/admin/users/{userId}/enable\n"
       "POST /api/github/login\n"
       "POST /api/google/login\n"
+      "POST /api/me/mfa/disable\n"
+      "POST /api/me/mfa/setup\n"
+      "POST /api/me/mfa/verify\n"
       "POST /api/me/webauthn/register/begin\n"
       "POST /api/me/webauthn/register/finish\n"
       "POST /api/password-reset/confirm\n"
@@ -149,13 +167,12 @@ const std::string &expectedFingerprint()
       "POST /api/verify-email/resend\n"
       "POST /api/wechat/login\n"
       "POST /oauth2/consent\n"
-      "POST /oauth2/device/verify\n"
+      "POST /oauth2/device/approve\n"
       "POST /oauth2/device_authorization\n"
+      "POST /oauth2/end_session\n"
       "POST /oauth2/introspect\n"
       "POST /oauth2/login\n"
-      "POST /oauth2/mfa/disable\n"
-      "POST /oauth2/mfa/setup\n"
-      "POST /oauth2/mfa/setup/verify\n"
+      "POST /oauth2/logout\n"
       "POST /oauth2/mfa/verify\n"
       "POST /oauth2/register\n"
       "POST /oauth2/revoke\n"

--- a/tools/openapi-governance/check_spec_governance.py
+++ b/tools/openapi-governance/check_spec_governance.py
@@ -50,6 +50,11 @@ OPENAPI_YAML = Path("apps/server/openapi.yaml")
 VERSION_CMAKE = Path("cmake/Version.cmake")
 CONTROLLER_GLOBS = [
     "libs/drogon/include/authforge/drogon/controllers/*.h",
+    # .cc globs: today the route macros live in headers, but scanning the
+    # implementation trees too closes the "new controller defines its macro in
+    # the .cc" blind spot. Comment-only mentions of ADD_METHOD_TO don't match
+    # the regexes (they lack the quoted-path + method-token shape).
+    "libs/drogon/src/**/*.cc",
     "apps/server/**/*.h",
     "apps/server/**/*.cc",
 ]
@@ -216,13 +221,14 @@ def _selftest() -> int:
     yaml_ver = extract_yaml_version(FIXTURES / "mini_openapi.yaml")
     cmake_ver = extract_cmake_version(FIXTURES / "mini_version.cmake")
 
-    # Fixture layout (3 documented ops + 1 ROUTE_ONLY + 1 YAML_EXCLUDED):
-    #   routes: GET /x, POST /x, GET /login, GET /docs/api/
-    #   docs:   GET /x, POST /x, GET /docs/api/        (login is route-only)
-    #   yaml:   GET /x, POST /x                        (docs/api excluded)
+    # Fixture layout (4 documented ops + 1 ROUTE_ONLY + 1 YAML_EXCLUDED):
+    #   routes: GET /x, POST /x, PUT /y (bare method name), GET /login, GET /docs/api/
+    #   docs:   GET /x, POST /x, PUT /y, GET /docs/api/   (login is route-only)
+    #   yaml:   GET /x, POST /x, PUT /y                    (docs/api excluded)
     assert "GET /x" in routes and "POST /x" in routes, routes
-    assert docs == {"GET /x", "POST /x", "GET /docs/api/"}, docs
-    assert yaml_ops == {"GET /x", "POST /x"}, yaml_ops
+    assert "PUT /y" in routes, f"bare-name method macro not parsed: {routes}"
+    assert docs == {"GET /x", "POST /x", "PUT /y", "GET /docs/api/"}, docs
+    assert yaml_ops == {"GET /x", "POST /x", "PUT /y"}, yaml_ops
 
     # Happy path: multi-line macros, first-token methods, exclusions, versions.
     ok = run_checks(routes, docs, yaml_ops, "1.2.0", "1.2.0")

--- a/tools/openapi-governance/check_spec_governance.py
+++ b/tools/openapi-governance/check_spec_governance.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""OpenAPI spec governance gate: 3-layer endpoint consistency + version sync.
+
+Asserts three invariants over the HTTP API surface (spec-governance M0,
+docs/productization-evolution/todo/openapi-spec-governance-plan.md):
+
+  1. routes  == docs    -- every ADD_METHOD_TO route registers an OpenAPI doc
+                           (and no doc names a route that does not exist),
+                           modulo ROUTE_ONLY exclusions.
+  2. docs    == yaml    -- apps/server/openapi.yaml mirrors the doc-registered
+                           set, modulo YAML_EXCLUDED self-documentation paths.
+  3. version -- openapi.yaml info.version == cmake/Version.cmake project
+                           version.
+
+Sources (no compilation needed; CI static-checks runs this):
+  routes  : ADD_METHOD_TO macros in controller headers/sources. Multi-line
+            macros are spanned; only the FIRST method token of a macro counts
+            (GitHub/Google/WeChat declare `::drogon::Post, ::drogon::Options`
+            -- the OPTIONS modifier is not a separate route for this gate).
+  docs    : the frozen kFingerprint string literals in
+            tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc
+            (the fingerprint test keeps that set honest against the binary).
+  yaml    : apps/server/openapi.yaml paths.
+
+Exit codes:
+  0  all checks pass
+  1  governance drift detected (diffs printed)
+  2  environment/parse error (missing files, implausible extraction counts)
+
+Usage:
+  check_spec_governance.py [--repo ROOT] [--selftest]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+HERE = Path(__file__).resolve().parent
+REPO_DEFAULT = HERE.parent.parent
+
+sys.path.insert(0, str(REPO_DEFAULT / "tools" / "refactor-baseline"))
+import parse_endpoints  # type: ignore  # noqa: E402  (PyYAML or MiniYaml fallback)
+
+FINGERPRINT_TEST = Path("tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc")
+OPENAPI_YAML = Path("apps/server/openapi.yaml")
+VERSION_CMAKE = Path("cmake/Version.cmake")
+CONTROLLER_GLOBS = [
+    "libs/drogon/include/authforge/drogon/controllers/*.h",
+    "apps/server/**/*.h",
+    "apps/server/**/*.cc",
+]
+
+# ---------------------------------------------------------------------------
+# Exclusions (each entry needs a reason; the gate fails on anything else).
+# ---------------------------------------------------------------------------
+
+# Real routes that are deliberately NEVER doc-registered nor in the YAML.
+ROUTE_ONLY: Set[str] = {
+    # Server-rendered HTML login page (SessionController::showLoginPage), not an API.
+    "GET /login",
+    # Non-slash redirect variant of the Swagger UI entry point; /docs/api/ is
+    # the documented one (ApiDocController).
+    "GET /docs/api",
+}
+
+# Doc-registered operations deliberately ABSENT from the YAML: the API's
+# self-documentation surface has no meaning for SDK consumers (design D1).
+YAML_EXCLUDED: Set[str] = {
+    "GET /docs/api/",
+    "GET /docs/api/openapi.json",
+}
+
+# Extraction sanity floors: the real surface is ~80 ops. A parse regression
+# (refactored test file, changed macro idiom) must fail loudly, not silently
+# compare two empty sets.
+MIN_ROUTES = 60
+MIN_DOCS = 60
+MIN_YAML_OPS = 60
+
+
+# ---------------------------------------------------------------------------
+# Extractors (pure functions over file paths -> sets/strings)
+# ---------------------------------------------------------------------------
+
+# First method token only; `::drogon::Post, ::drogon::Options` yields POST.
+_ROUTE_RES = [
+    re.compile(r'ADD_METHOD_TO\(\s*[^,]+,\s*"([^"]+)"\s*,\s*::drogon::(\w+)', re.S),
+    re.compile(r'ADD_METHOD_TO\(\s*[^,]+,\s*"([^"]+)"\s*,\s*(Get|Post|Put|Delete|Patch)\b', re.S),
+]
+
+_FINGERPRINT_ENTRY_RE = re.compile(r'"([A-Z]+ /[^"\\]+)\\n"')
+
+
+def extract_routes(files: List[Path]) -> Set[str]:
+    ops: Set[str] = set()
+    for f in files:
+        try:
+            src = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for rx in _ROUTE_RES:
+            for m in rx.finditer(src):
+                ops.add(f"{m.group(2).upper()} {m.group(1)}")
+    return ops
+
+
+def extract_docs(fingerprint_test: Path) -> Set[str]:
+    """Parse the frozen kFingerprint string literals in the baseline test."""
+    src = fingerprint_test.read_text(encoding="utf-8")
+    # Anchor on the assignment (comments may mention "kFingerprint"/"enum
+    # class" in prose before the real definition).
+    m = re.search(r"kFingerprint\s*=", src)
+    if not m:
+        raise ValueError("kFingerprint assignment not found in fingerprint test")
+    start = m.end()
+    end = src.find("enum class", start)
+    if end < 0:
+        raise ValueError("terminating 'enum class' not found after kFingerprint")
+    return {em.group(1) for em in _FINGERPRINT_ENTRY_RE.finditer(src[start:end])}
+
+
+def extract_yaml_ops(openapi_yaml: Path) -> Set[str]:
+    doc = parse_endpoints._load_yaml(openapi_yaml.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict) or not isinstance(doc.get("paths"), dict):
+        raise ValueError("openapi.yaml has no paths mapping")
+    ops: Set[str] = set()
+    for path, item in doc["paths"].items():
+        if not isinstance(item, dict):
+            continue
+        for method in ("get", "post", "put", "delete", "patch"):
+            if isinstance(item.get(method), dict):
+                ops.add(f"{method.upper()} {path}")
+    return ops
+
+
+def extract_yaml_version(openapi_yaml: Path) -> str:
+    doc = parse_endpoints._load_yaml(openapi_yaml.read_text(encoding="utf-8"))
+    info = (doc or {}).get("info") or {}
+    version = info.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("openapi.yaml info.version missing")
+    return version
+
+
+def extract_cmake_version(version_cmake: Path) -> str:
+    src = version_cmake.read_text(encoding="utf-8")
+
+    def var(name: str) -> str:
+        m = re.search(rf"set\(\s*{name}\s+(\d+)\s*\)", src)
+        if not m:
+            raise ValueError(f"{name} not found in {version_cmake}")
+        return m.group(1)
+
+    return ".".join(var("OAUTH2_PROJECT_VERSION_" + p) for p in ("MAJOR", "MINOR", "PATCH"))
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def diff_sets(expected: Set[str], actual: Set[str]) -> Tuple[List[str], List[str]]:
+    return sorted(expected - actual), sorted(actual - expected)
+
+
+def run_checks(
+    routes: Set[str],
+    docs: Set[str],
+    yaml_ops: Set[str],
+    yaml_version: str,
+    cmake_version: str,
+) -> List[str]:
+    failures: List[str] = []
+
+    docs_expected_from_routes = routes - ROUTE_ONLY
+    missing_docs, ghost_docs = diff_sets(docs_expected_from_routes, docs)
+    if missing_docs or ghost_docs:
+        failures.append("[routes<->docs] route/doc registration mismatch")
+        for op in missing_docs:
+            failures.append(f"  route without doc registration: {op}")
+        for op in ghost_docs:
+            failures.append(f"  doc registration without backing route: {op}")
+
+    yaml_expected = docs - YAML_EXCLUDED
+    missing_yaml, extra_yaml = diff_sets(yaml_expected, yaml_ops)
+    if missing_yaml or extra_yaml:
+        failures.append("[docs<->yaml] openapi.yaml operation set mismatch")
+        for op in missing_yaml:
+            failures.append(f"  missing from openapi.yaml: {op}")
+        for op in extra_yaml:
+            failures.append(f"  in openapi.yaml but not registered in code: {op}")
+
+    if yaml_version != cmake_version:
+        failures.append(
+            f"[version] openapi.yaml info.version={yaml_version} != "
+            f"cmake/Version.cmake OAUTH2_PROJECT_VERSION={cmake_version}"
+        )
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Self-test (fixtures under tools/openapi-governance/fixtures/)
+# ---------------------------------------------------------------------------
+
+FIXTURES = HERE / "fixtures"
+
+
+def _selftest() -> int:
+    routes = extract_routes([FIXTURES / "mini_controller.h"])
+    docs = extract_docs(FIXTURES / "mini_fingerprint_test.cc")
+    yaml_ops = extract_yaml_ops(FIXTURES / "mini_openapi.yaml")
+    yaml_ver = extract_yaml_version(FIXTURES / "mini_openapi.yaml")
+    cmake_ver = extract_cmake_version(FIXTURES / "mini_version.cmake")
+
+    # Fixture layout (3 documented ops + 1 ROUTE_ONLY + 1 YAML_EXCLUDED):
+    #   routes: GET /x, POST /x, GET /login, GET /docs/api/
+    #   docs:   GET /x, POST /x, GET /docs/api/        (login is route-only)
+    #   yaml:   GET /x, POST /x                        (docs/api excluded)
+    assert "GET /x" in routes and "POST /x" in routes, routes
+    assert docs == {"GET /x", "POST /x", "GET /docs/api/"}, docs
+    assert yaml_ops == {"GET /x", "POST /x"}, yaml_ops
+
+    # Happy path: multi-line macros, first-token methods, exclusions, versions.
+    ok = run_checks(routes, docs, yaml_ops, "1.2.0", "1.2.0")
+    if ok:
+        print("[spec-governance][err] selftest: clean fixture reported failures", file=sys.stderr)
+        for ln in ok:
+            print("   ", ln, file=sys.stderr)
+        return 1
+
+    # Fault 1: YAML drops an op -> drift reported, named.
+    bad1 = run_checks(routes, docs, yaml_ops - {"POST /x"}, "1.2.0", "1.2.0")
+    if not any("missing from openapi.yaml: POST /x" in ln for ln in bad1):
+        print(f"[spec-governance][err] selftest: yaml-drop fault not caught: {bad1!r}", file=sys.stderr)
+        return 1
+
+    # Fault 2: a new undocumented route appears -> drift reported.
+    bad2 = run_checks(routes | {"DELETE /y"}, docs, yaml_ops | {"DELETE /y"}, "1.2.0", "1.2.0")
+    if not any("route without doc registration: DELETE /y" in ln for ln in bad2):
+        print(f"[spec-governance][err] selftest: undocumented-route fault not caught: {bad2!r}", file=sys.stderr)
+        return 1
+
+    # Fault 3: version drift -> reported.
+    bad3 = run_checks(routes, docs, yaml_ops, "1.2.0", "1.3.0")
+    if not any("[version]" in ln for ln in bad3):
+        print(f"[spec-governance][err] selftest: version drift not caught: {bad3!r}", file=sys.stderr)
+        return 1
+
+    # Fault 4: ghost doc (doc names a route that does not exist).
+    bad4 = run_checks(routes, docs | {"PUT /ghost"}, yaml_ops | {"PUT /ghost"}, "1.2.0", "1.2.0")
+    if not any("doc registration without backing route: PUT /ghost" in ln for ln in bad4):
+        print(f"[spec-governance][err] selftest: ghost-doc fault not caught: {bad4!r}", file=sys.stderr)
+        return 1
+
+    print(
+        "[spec-governance] selftest OK "
+        "(multi-line macros; exclusions; yaml-drop / new-route / ghost-doc / version faults)"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _main() -> int:
+    p = argparse.ArgumentParser(description="OpenAPI spec governance gate")
+    p.add_argument("--repo", default=str(REPO_DEFAULT))
+    p.add_argument("--selftest", action="store_true")
+    args = p.parse_args()
+
+    if args.selftest:
+        return _selftest()
+
+    repo = Path(args.repo)
+
+    fingerprint_test = repo / FINGERPRINT_TEST
+    openapi_yaml = repo / OPENAPI_YAML
+    version_cmake = repo / VERSION_CMAKE
+    for f in (fingerprint_test, openapi_yaml, version_cmake):
+        if not f.is_file():
+            print(f"[spec-governance][err] required file missing: {f}", file=sys.stderr)
+            return 2
+
+    route_files: List[Path] = []
+    for pattern in CONTROLLER_GLOBS:
+        route_files.extend(repo.glob(pattern))
+    if not route_files:
+        print("[spec-governance][err] no controller sources matched", file=sys.stderr)
+        return 2
+
+    try:
+        routes = extract_routes(route_files)
+        docs = extract_docs(fingerprint_test)
+        yaml_ops = extract_yaml_ops(openapi_yaml)
+        yaml_version = extract_yaml_version(openapi_yaml)
+        cmake_version = extract_cmake_version(version_cmake)
+    except (OSError, ValueError) as e:
+        print(f"[spec-governance][err] extraction failed: {e}", file=sys.stderr)
+        return 2
+
+    # Sanity floors: implausible counts mean a parse regression, not agreement.
+    if len(routes) < MIN_ROUTES or len(docs) < MIN_DOCS or len(yaml_ops) < MIN_YAML_OPS:
+        print(
+            "[spec-governance][err] extraction produced implausibly small sets "
+            f"(routes={len(routes)}, docs={len(docs)}, yaml={len(yaml_ops)}; "
+            f"floors {MIN_ROUTES}/{MIN_DOCS}/{MIN_YAML_OPS}) -- parse regression?",
+            file=sys.stderr,
+        )
+        return 2
+
+    failures = run_checks(routes, docs, yaml_ops, yaml_version, cmake_version)
+    if failures:
+        print("[spec-governance] FAIL: OpenAPI governance drift detected")
+        for ln in failures:
+            print(ln)
+        print(
+            "Fix by updating apps/server/openapi.yaml AND the doc registrations "
+            "(OpenApiGenerator::addEndpoint) AND the fingerprint test baseline "
+            "together -- see .claude/skills/openapi-update and "
+            "docs/productization-evolution/todo/openapi-spec-governance-plan.md."
+        )
+        return 1
+
+    print(
+        f"[spec-governance] OK: routes={len(routes)} docs={len(docs)} yaml={len(yaml_ops)} "
+        f"(route_only={len(ROUTE_ONLY)}, yaml_excluded={len(YAML_EXCLUDED)}), "
+        f"info.version={yaml_version} == cmake {cmake_version}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tools/openapi-governance/fixtures/mini_controller.h
+++ b/tools/openapi-governance/fixtures/mini_controller.h
@@ -1,0 +1,25 @@
+// Fixture for check_spec_governance.py --selftest. Mirrors the macro idioms
+// of the real controllers: multi-line ADD_METHOD_TO, `::drogon::Post,
+// ::drogon::Options` double declaration (only the first method counts), and
+// the bare-name method fallback.
+#pragma once
+
+class MiniController
+{
+  public:
+    METHOD_LIST_BEGIN
+    ADD_METHOD_TO(
+      MiniController::getX,
+      "/x",
+      ::drogon::Get
+    );
+    ADD_METHOD_TO(
+      MiniController::postX,
+      "/x",
+      ::drogon::Post,
+      ::drogon::Options
+    );
+    ADD_METHOD_TO(MiniController::showLoginPage, "/login", ::drogon::Get);
+    ADD_METHOD_TO(MiniController::docs, "/docs/api/", ::drogon::Get);
+    METHOD_LIST_END
+};

--- a/tools/openapi-governance/fixtures/mini_controller.h
+++ b/tools/openapi-governance/fixtures/mini_controller.h
@@ -21,5 +21,8 @@ class MiniController
     );
     ADD_METHOD_TO(MiniController::showLoginPage, "/login", ::drogon::Get);
     ADD_METHOD_TO(MiniController::docs, "/docs/api/", ::drogon::Get);
+    // Bare method name (no ::drogon:: prefix) exercises the second route
+    // regex branch.
+    ADD_METHOD_TO(MiniController::putY, "/y", Put);
     METHOD_LIST_END
 };

--- a/tools/openapi-governance/fixtures/mini_fingerprint_test.cc
+++ b/tools/openapi-governance/fixtures/mini_fingerprint_test.cc
@@ -1,0 +1,22 @@
+// Fixture for check_spec_governance.py --selftest. Mirrors the shape of
+// tests/integration/concurrency/Property4_OpenApiValidationBaselineTest.cc:
+// a kFingerprint string built from "METHOD path\n" literals, terminated by
+// an "enum class" that follows it.
+#include <string>
+
+namespace
+{
+const std::string &expectedFingerprint()
+{
+    static const std::string kFingerprint =
+      "GET /x\n"
+      "GET /docs/api/\n"
+      "POST /x\n";
+    return kFingerprint;
+}
+
+enum class FilterOutcome
+{
+    Passed
+};
+}  // namespace

--- a/tools/openapi-governance/fixtures/mini_fingerprint_test.cc
+++ b/tools/openapi-governance/fixtures/mini_fingerprint_test.cc
@@ -11,7 +11,8 @@ const std::string &expectedFingerprint()
     static const std::string kFingerprint =
       "GET /x\n"
       "GET /docs/api/\n"
-      "POST /x\n";
+      "POST /x\n"
+      "PUT /y\n";
     return kFingerprint;
 }
 

--- a/tools/openapi-governance/fixtures/mini_openapi.yaml
+++ b/tools/openapi-governance/fixtures/mini_openapi.yaml
@@ -1,0 +1,15 @@
+# Fixture for check_spec_governance.py --selftest (mini API surface).
+openapi: 3.0.0
+info:
+  title: Mini
+  version: 1.2.0
+paths:
+  /x:
+    get:
+      responses:
+        '200':
+          description: ok
+    post:
+      responses:
+        '200':
+          description: ok

--- a/tools/openapi-governance/fixtures/mini_openapi.yaml
+++ b/tools/openapi-governance/fixtures/mini_openapi.yaml
@@ -13,3 +13,8 @@ paths:
       responses:
         '200':
           description: ok
+  /y:
+    put:
+      responses:
+        '200':
+          description: ok

--- a/tools/openapi-governance/fixtures/mini_version.cmake
+++ b/tools/openapi-governance/fixtures/mini_version.cmake
@@ -1,0 +1,5 @@
+# Fixture for check_spec_governance.py --selftest.
+set(OAUTH2_PROJECT_VERSION_MAJOR 1)
+set(OAUTH2_PROJECT_VERSION_MINOR 2)
+set(OAUTH2_PROJECT_VERSION_PATCH 0)
+set(OAUTH2_PROJECT_VERSION "1.2.0")

--- a/tools/openapi-governance/oasdiff-breaking-ignore.md
+++ b/tools/openapi-governance/oasdiff-breaking-ignore.md
@@ -1,0 +1,50 @@
+# oasdiff breaking-change ignore list (bootstrap errata)
+
+Used by `.github/workflows/openapi-governance.yml` via `oasdiff breaking
+--err-ignore <this file>`. Each line below exempts one breaking change from
+the gate; oasdiff matches "METHOD /path" plus the change description text.
+Every entry must carry a reason — this file is the audit trail of every
+breaking change we consciously allowed through the gate.
+
+If you are adding an entry for a NEW change: prefer a major version bump
+instead. This list is not a rubber stamp; reviewers should challenge entries.
+
+---
+
+## 2026-08-16 · spec-governance M0 bootstrap (PR: openapi spec governance)
+
+One-time reconciliation between the spec and the code (design
+docs/productization-evolution/todo/client-sdk-facility-design.md §10.1).
+
+### Dead-endpoint removals (8) — documented endpoints that had NO backing route
+
+The pre-M0 YAML documented endpoints that were removed from the code long
+ago; keeping them was the bug, removing them is the fix. No client can be
+calling these successfully.
+
+- GET /api/orgs api path removed without deprecation — route removed; orgs live under /api/admin/organizations
+- POST /api/orgs api path removed without deprecation — same
+- POST /api/orgs/{orgId}/users api path removed without deprecation — same
+- GET /oauth2/device/verify api path removed without deprecation — verification UI is frontend-rendered; no route ever existed
+- POST /oauth2/device/verify api path removed without deprecation — same
+- POST /oauth2/mfa/disable api path removed without deprecation — real route is POST /api/me/mfa/disable
+- POST /oauth2/mfa/setup api path removed without deprecation — real route is POST /api/me/mfa/setup
+- POST /oauth2/mfa/setup/verify api path removed without deprecation — real route is POST /api/me/mfa/verify
+
+### Request-parameter relocation to form/JSON bodies (6) — the wire contract did NOT change
+
+These endpoints always read parameters via Drogon getParameter/getJsonObject
+(query OR form OR JSON body). The old spec wrongly declared them as query
+parameters; the new spec declares the RFC-correct form/JSON body. The server
+accepts both, so existing callers keep working.
+
+- POST /oauth2/token added required request body — form-encoded body per RFC 6749 §4.1.3; query params still accepted by the server
+- POST /oauth2/introspect added required request body — form-encoded per RFC 7662 §2.1; query still accepted
+- POST /oauth2/revoke added required request body — form-encoded per RFC 7009 §2.1; query still accepted
+- POST /oauth2/login added required request body — JSON or form body; the server still reads query parameters too
+- POST /oauth2/mfa/verify added required request body — JSON or form body; query still accepted
+- POST /oauth2/device_authorization added required request body — form-encoded per RFC 8628 §3.1; query still accepted
+
+### Response body correction (1) — the old spec lied
+
+- POST /oauth2/revoke removed the media type `application/json` for the response with the status `200` — the 200 body is EMPTY per RFC 7009 (the old spec declared a JSON object that never existed)

--- a/tools/refactor-baseline/endpoints/openapi.signature.txt
+++ b/tools/refactor-baseline/endpoints/openapi.signature.txt
@@ -1,6 +1,7 @@
 GET	/.well-known/jwks.json	200	application/json	OpenID Connect,Security	no
+GET	/.well-known/oauth-authorization-server	200	application/json	Discovery,OAuth2	no
 GET	/.well-known/openid-configuration	200	application/json	OpenID Connect	no
-GET	/api/admin/clients	200,401	-	Admin,Clients	yes
+GET	/api/admin/clients	200,401,403	-	Admin,Clients	yes
 POST	/api/admin/clients	201,401	-	Admin,Clients	yes
 GET	/api/admin/clients/{clientId}	200,401,404	-	Admin,Clients	yes
 PUT	/api/admin/clients/{clientId}	200,400,401,404	-	Admin,Clients	yes
@@ -8,15 +9,20 @@ DELETE	/api/admin/clients/{clientId}	200,401,404	-	Admin,Clients	yes
 POST	/api/admin/clients/{clientId}/reset-secret	200,401,404	-	Admin,Clients	yes
 GET	/api/admin/clients/{clientId}/scopes	200,401	-	Admin,Clients	yes
 PUT	/api/admin/clients/{clientId}/scopes	200,400,401	-	Admin,Clients	yes
+GET	/api/admin/dashboard	200,401,403	application/json	Admin,Dashboard	yes
 GET	/api/admin/dashboard/stats	200	application/json	Admin,Dashboard	yes
 GET	/api/admin/logs	200,401	-	Admin,Logs	yes
 GET	/api/admin/oidc/keys	200,401	-	Admin,OIDC	yes
+GET	/api/admin/organizations	200,401,403	application/json	Admin,Organization	yes
+POST	/api/admin/organizations	200,400,401,409	application/json	Admin,Organization	yes
+GET	/api/admin/organizations/{slug}	200,401,404	application/json	Admin,Organization	yes
 GET	/api/admin/roles	200	application/json	Admin,Roles	yes
 POST	/api/admin/roles	201,400,409	-	Admin,Roles	yes
 PUT	/api/admin/roles/{roleId}	200,404	-	Admin,Roles	yes
 DELETE	/api/admin/roles/{roleId}	200,404	-	Admin,Roles	yes
 GET	/api/admin/scopes	200	application/json	Admin,Scopes	yes
 POST	/api/admin/scopes	201,400,409	-	Admin,Scopes	yes
+GET	/api/admin/scopes/resources	200	application/json	Admin,Scopes	yes
 PUT	/api/admin/scopes/{scopeId}	200,404	-	Admin,Scopes	yes
 DELETE	/api/admin/scopes/{scopeId}	200,404	-	Admin,Scopes	yes
 GET	/api/admin/tokens	200,401	-	Admin,Tokens	yes
@@ -24,46 +30,49 @@ POST	/api/admin/tokens/revoke-by-client	200,400,401	-	Admin,Tokens	yes
 POST	/api/admin/tokens/revoke-by-user	200,400,401	-	Admin,Tokens	yes
 DELETE	/api/admin/tokens/{tokenPrefix}	200,401,404	-	Admin,Tokens	yes
 GET	/api/admin/users	200,401	-	Admin,Users	yes
+POST	/api/admin/users	201,400,401,403	-	Admin,Users	yes
 GET	/api/admin/users/{userId}	200,404	application/json	Admin,Users	yes
-PUT	/api/admin/users/{userId}	200,404	-	Admin,Users	yes
-PUT	/api/admin/users/{userId}/disable	200,401,404	-	Admin,Users	yes
+PUT	/api/admin/users/{userId}	200,400,404,409	-	Admin,Users	yes
+DELETE	/api/admin/users/{userId}	200,400,404,409	-	Admin,Users	yes
+PUT	/api/admin/users/{userId}/disable	200,401,404,409	-	Admin,Users	yes
 POST	/api/admin/users/{userId}/enable	200,404	-	Admin,Users	yes
 GET	/api/admin/users/{userId}/roles	200,404	application/json	Admin,Users	yes
-PUT	/api/admin/users/{userId}/roles	200,400	-	Admin,Users	yes
+PUT	/api/admin/users/{userId}/roles	200,400,409	-	Admin,Users	yes
 POST	/api/github/login	200,400,502	application/json	External Auth,GitHub	no
 POST	/api/google/login	200,400,502	application/json	External Auth,Google	no
-GET	/api/me	200,401,404	-	User Profile	yes
+GET	/api/me	200,401,403,404	-	User Profile	yes
 DELETE	/api/me	200,401,404	-	User Profile	yes
 GET	/api/me/authorized-apps	200,401	-	User Profile	yes
 DELETE	/api/me/authorized-apps/{clientId}	200,401,404	-	User Profile	yes
+POST	/api/me/mfa/disable	200,401	application/json	MFA	yes
+POST	/api/me/mfa/setup	200,401	application/json	MFA	yes
+POST	/api/me/mfa/verify	200,400,401	application/json	MFA	yes
 PUT	/api/me/password	200,400,401,404	-	User Profile	yes
 GET	/api/me/webauthn/credentials	200,401	-	WebAuthn	yes
 POST	/api/me/webauthn/register/begin	200,401	-	WebAuthn	yes
 POST	/api/me/webauthn/register/finish	201,400,401	-	WebAuthn	yes
-GET	/api/orgs	200,401	-	Organization	yes
-POST	/api/orgs	201,400,401,409	-	Organization	yes
-POST	/api/orgs/{orgId}/users	200,401	-	Organization	yes
 POST	/api/password-reset/confirm	200,400	-	User Verification	no
 POST	/api/password-reset/request	200,400	-	User Verification	no
 POST	/api/register	200,400	application/json	Registration,User	no
 GET	/api/verify-email	200,400	-	User Verification	no
 POST	/api/verify-email/resend	200,400,401,404	-	User Verification	no
 POST	/api/wechat/login	200,400,502	application/json	External Auth,WeChat	no
-GET	/health	200	application/json	System	no
+GET	/health	200,503	application/json	System	no
+GET	/health/live	200	application/json	System	no
+GET	/health/ready	200,503	application/json	System	no
 GET	/oauth2/authorize	302,400	-	Authorization,OAuth2	no
 POST	/oauth2/consent	302	-	Consent,OAuth2	no
-GET	/oauth2/device/verify	200	-	Device Flow,OAuth2	no
-POST	/oauth2/device/verify	200	-	Device Flow,OAuth2	no
-POST	/oauth2/device_authorization	200,400,401	-	Device Flow,OAuth2	yes
-POST	/oauth2/introspect	200,400,401	application/json	OAuth2,Token	yes
-POST	/oauth2/login	200,302,401	application/json	Authentication,OAuth2	no
-POST	/oauth2/mfa/disable	200,401	-	MFA	yes
-POST	/oauth2/mfa/setup	200,401	-	MFA	yes
-POST	/oauth2/mfa/setup/verify	200,400,401	-	MFA	yes
-POST	/oauth2/mfa/verify	200,400,401	-	MFA	no
+POST	/oauth2/device/approve	200,400,401,403	application/json	Device Flow,OAuth2	yes
+POST	/oauth2/device_authorization	200,400,401,500	application/json	Device Flow,OAuth2	no
+GET	/oauth2/end_session	200,302,400	application/json	OAuth2,OIDC	no
+POST	/oauth2/end_session	200,302,400	application/json	OAuth2,OIDC	no
+POST	/oauth2/introspect	200,400,401,429	application/json	OAuth2,Token	yes
+POST	/oauth2/login	200,302,400,401,403	application/json	Authentication,OAuth2	no
+POST	/oauth2/logout	200,401	application/json	OAuth2,Session	yes
+POST	/oauth2/mfa/verify	200,400,401	application/json	MFA	no
 POST	/oauth2/register	201,400,401	-	Dynamic Registration,OAuth2	yes
-POST	/oauth2/revoke	200,400,401	application/json	OAuth2,Token	yes
-POST	/oauth2/token	200,400,401	application/json	OAuth2,Token	no
-GET	/oauth2/userinfo	200,400,401,404	application/json	OAuth2,User	yes
+POST	/oauth2/revoke	200,400,401,429	application/json	OAuth2,Token	yes
+POST	/oauth2/token	200,400,401,429	application/json	OAuth2,Token	no
+GET	/oauth2/userinfo	200,400,401,403,404	application/json	OAuth2,User	yes
 POST	/oauth2/webauthn/authenticate/begin	200	-	WebAuthn	no
 POST	/oauth2/webauthn/authenticate/finish	200,400,401	-	WebAuthn	no


### PR DESCRIPTION
## A1 — OpenAPI Spec 治理（M0：Layer 1 地基）

> 设计：`docs/productization-evolution/todo/client-sdk-facility-design.md` §十（v1.1 M0 修订）
> 实施计划：`docs/productization-evolution/todo/openapi-spec-governance-plan.md`（评审 APPROVE-WITH-CHANGES，发现已全部落地）
> 关键路径：本 PR 是 C1 Python/Go 客户端 SDK 的阻塞项。

### 问题：三层漂移（2026-08-16 实测）

| 层 | 数量 | 问题 |
|----|------|------|
| Drogon 路由（真实 API 面） | 82 | 12 条路由从未注册文档、从未入 YAML |
| C++ 文档注册（指纹基线） | 75 | **5 条幽灵文档**（指向不存在的路由） |
| 手维护 YAML | 73 | **8 条死条目** + 缺 13 条真实操作 + `info.version` 落后两个 minor |

典型漂移：YAML 至今还在文档化 3 个月前已删除的 `/api/orgs*`；MFA 路由迁到 `/api/me/mfa/*` 后旧路径文档没删、新路径文档没加；`/oauth2/logout`、`/health/ready`、RFC 8414 元数据端点从未入档。

### 交付（6 commits，W1–W8）

1. **`d42a61c` W2 — C++ 文档注册对账**：删 5 处幽灵路径，补 10 处缺注册（end_session/logout/me-mfa/device-approve/health 子探针/RFC 8414），指纹基线 75→80。
2. **`338d7eb` W1 — YAML 重写为客户端生成就绪**：78 操作与文档注册逐字对账；P0 schema 按控制器实测 wire 契约补齐（TokenRequest 表单体、IntrospectionResponse、OAuth2Error vs ErrorEnvelope 双错误形态、discovery 全字段等）；`info.version` → 1.2.0 联动。
3. **`bcfd704` W3 — 治理门**：`check_spec_governance.py` 三层一致性 + 版本同步，fixture 驱动 selftest 覆盖 4 类故障注入。
4. **`c5ee505` W4/W5 — CI 接线**：ci.yml static-checks 加治理门；新 `openapi-governance.yml` oasdiff v1.29.1 破坏性变更门（`-o ERR`）；bootstrap 豁免 15 条（每条带理由）；release.yml version-check 加 info.version 交叉校验。
5. **`423312a` W6** — refactor-baseline 端点签名再生（含 master 存量漂移收敛）。
6. **`fe21a52` W8** — 设计文档 v1.1、实施计划、openapi-update skill（4 处镜像）、api-reference、ci-cd-guide、progress 同步。

### 验收证据

- ✅ 构建（manage.ps1 build-backend）+ 指纹测试 `Integration_P1_OpenApiSpec_Property4_3_1_PathMethodFingerprint_Baseline` 绿
- ✅ 46 个相关测试切片（OpenApiSpec/InitOrder/ApiDoc/Discovery/Health/Mfa/DeviceAuth/OidcBatch）全绿
- ✅ `openapi_spec_validator` 绿；治理门 `routes=82 docs=80 yaml=78` 零差异
- ✅ 故障注入实测：YAML 删端点 → 门 exit 1 精确指名；源码加路由 → 门 exit 1；oasdiff 删存活路径 → `-o ERR` exit 1，豁免清单覆盖后 bootstrap diff exit 0
- ✅ **AC8（W7）**：openapi-python-client 从新 spec 生成客户端，实调活服务器（postgres 模式）：
  ```
  [1/4] token 200 OK  access_token=7I0e...  expires_in=3600  scope='tokens:read'
  [2/4] introspect 200 OK  active=True  client_id=backend-svc  sub='client:backend-svc'
  [3/4] negative token 401 OK  error='invalid_client' (typed OAuth2Error)
  [4/4] discovery 200 OK  issuer=http://localhost:5555
  ```
  表单体由生成代码从 schema 构造（无需手拼 form），响应强类型（TokenResponse/IntrospectionResponse/OAuth2Error）。

### 兼容性说明（ reviewers 请看 ）

死端点删除与参数位置迁移**不改 wire 行为**：删除的 8 条端点无路由（调用必然 404）；token/introspect/revoke/login 的参数服务器一直同时接受 query 与 form/JSON（Drogon `getParameter` 语义），spec 只是修正了误导性声明。oasdiff 豁免清单里有逐条理由。

### 风险与回退

- 指纹基线更新后无其它测试依赖旧集合（全量 46 切片验证）；CI 全量矩阵将二次确认
- 每个 commit 独立可回滚；YAML 重写只动该动的（P1/P2 端点保留原描述，diff 可审计）
