### PR TITLE
fix(release): guard release-notes size, fall back to curated CHANGELOG section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,23 @@ jobs:
         env:
           OUTPUT: RELEASE_NOTES.md
 
+      - name: Guard notes size (fallback to curated CHANGELOG section)
+        # git-cliff --latest diffs against the previous tag; when none exists
+        # (the v1.0.0 series reset deleted the old series) it spans the whole
+        # history and blows past GitHub's 125k-char release-body limit (422).
+        run: |
+          if [ ! -s RELEASE_NOTES.md ] || [ "$(wc -c < RELEASE_NOTES.md)" -gt 120000 ]; then
+            echo "::warning::cliff notes empty/oversized; falling back to CHANGELOG section"
+            awk -v ver="${GITHUB_REF_NAME#v}" '
+              BEGIN { p = 0 }
+              /^## \[/ { p = (index($0, "[" ver "]") == 4) ? 1 : 0 }
+              p { print }
+            ' CHANGELOG.md > RELEASE_NOTES.md
+          fi
+          # Hard stop rather than a 422 downstream if even the fallback failed.
+          test -s RELEASE_NOTES.md || { echo "::error::empty release notes"; exit 1; }
+          echo "notes size: $(wc -c < RELEASE_NOTES.md) bytes"
+
       - name: Append verification instructions to the notes
         run: |
           cat >> RELEASE_NOTES.md <<EOF


### PR DESCRIPTION
The v1.0.0 tag run failed at 'GitHub Release' with **HTTP 422: body is too long (maximum 125000 characters)**: git-cliff `--latest` has no previous tag to diff against (the series reset deleted them), so the notes spanned all 1085 commits.

Fix: after cliff, if notes are empty or >120k bytes, extract this version's curated section from CHANGELOG.md (verified locally: 3250 bytes for 1.0.0); hard-fail if even the fallback is empty. One-time condition — later releases have a previous tag — but the guard stays as insurance.

After this merges, v1.0.0 will be re-tagged on the new master (delete + re-push; tag re-runs can't pick up post-tag workflow fixes) together with the PyPI token fix.