### PR TITLE
chore(community): issue templates + contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: "\U0001F41B Bug report"
+description: Something is broken or behaves incorrectly
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component / domain
+      options:
+        - Authentication (password / MFA / WebAuthn / social login)
+        - Authorization (OAuth2 / OIDC flows, scopes, consent)
+        - Token lifecycle (issue / refresh / introspect / revoke)
+        - Admin console (frontends/admin)
+        - User frontend (frontends/user)
+        - C++ SDK (find_package / headers)
+        - Python client (fulla-oauth2)
+        - Go client
+        - Deployment & ops (Docker / Helm / config)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Server version (GitHub Release tag) and, if relevant, client package version. e.g. v1.0.0 / fulla-oauth2 1.0.0"
+      placeholder: "v1.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment mode
+      options:
+        - Docker Compose (dev)
+        - Docker Compose (prod)
+        - Helm / Kubernetes
+        - Built from source
+        - Embedded via C++ SDK
+        - Client SDK only (no server)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the incorrect behavior, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal reproduction — endpoint calls, config snippets, or UI clicks. Include request/response where possible.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / error envelope
+      description: Server logs, error envelopes (code/message/request_id), or browser console output. Redact secrets.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "\U0001F64F Questions & help"
+    url: https://github.com/voidvec/fulla/discussions/categories/q-a
+    about: Ask usage questions in Discussions (Q&A category) before opening an issue
+  - name: "\U0001F510 Report a security vulnerability"
+    url: https://github.com/voidvec/fulla/blob/master/SECURITY.md
+    about: Please do NOT report vulnerabilities in public issues — follow SECURITY.md

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: "\U0001F4A1 Feature request"
+description: Suggest a capability or improvement
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component / domain
+      options:
+        - Authentication (password / MFA / WebAuthn / social login)
+        - Authorization (OAuth2 / OIDC flows, scopes, consent)
+        - Token lifecycle (issue / refresh / introspect / revoke)
+        - Multi-tenancy / organizations
+        - Admin console (frontends/admin)
+        - User frontend (frontends/user)
+        - C++ SDK
+        - Python client (fulla-oauth2)
+        - Go client
+        - Deployment & ops (Docker / Helm / observability)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What are you trying to achieve that the project currently makes hard or impossible?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What should exist instead? Rough is fine — references to other products or RFCs help.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you can live with, or designs you rejected.


### PR DESCRIPTION
Task 3 of the agreed sequence. Form-based bug/feature templates with a domain dropdown (authn / authz / token lifecycle / frontends / SDKs / ops), version + deployment fields; config.yml routes questions to Discussions and vulns to SECURITY.md. Note: Discussions categories (Announcements / Q&A / Ideas / General / Show and tell) need one-time enabling in repo settings — PAT lacks admin scope.