### PR TITLE
ci(frontend): add production builds to the fast frontend gate

### DIFF
--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -33,3 +33,16 @@ jobs:
           echo "=== frontends/admin: error-mapping property tests (shared errorAdapter source) ==="
           npm ci
           npm run test:unit
+
+      # Phase 1 of "frontend tests into CI" (docs task list): production
+      # build is the cheapest real gate — admin's build script type-checks
+      # (tsc && vite build), user's bundles (vue-tsc adoption tracked
+      # separately). Full-stack Playwright e2e (16+8) is Phase 2, its own
+      # path-filtered workflow.
+      - name: Production build (admin, includes tsc type-check)
+        working-directory: ${{ github.workspace }}/frontends/admin
+        run: npm run build
+
+      - name: Production build (user)
+        working-directory: ${{ github.workspace }}/frontends/user
+        run: npm run build

--- a/.github/workflows/_frontend.yml
+++ b/.github/workflows/_frontend.yml
@@ -34,6 +34,18 @@ jobs:
           npm ci
           npm run test:unit
 
+      # Phase 1 of "frontend tests into CI": production build is the cheapest
+      # real gate. Admin's build script type-checks (tsc && vite build);
+      # user's bundles (vue-tsc adoption tracked separately). Full-stack
+      # Playwright e2e (16+8) is Phase 2, its own path-filtered workflow.
+      - name: Production build (admin, includes tsc type-check)
+        working-directory: ${{ github.workspace }}/frontends/admin
+        run: npm run build
+
+      - name: Production build (user)
+        working-directory: ${{ github.workspace }}/frontends/user
+        run: npm run build
+
       # Phase 1 of "frontend tests into CI" (docs task list): production
       # build is the cheapest real gate — admin's build script type-checks
       # (tsc && vite build), user's bundles (vue-tsc adoption tracked


### PR DESCRIPTION
Task 1 Phase 1. The existing property-test job now also production-builds both frontends (admin's build includes tsc type-check; user's is bundle-only until vue-tsc is adopted). ~1 min added to the fast gate; catches type/bundling regressions every PR. Phase 2 (full-stack Playwright e2e with PG+Redis containers, path-filtered) follows after the docs-governance work.