### PR TITLE
docs: documentation governance design v1 (+ Docusaurus content sourcing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ For the versioning policy (when to cut, what to bump, why), see
 - **环境变量前缀统一 `FULLA_*`**（原 `OAUTH2_*`，903 处；协议类名如
   `OAuth2Plugin` 保持不变）。
 - **基础设施命名规范化**：数据库/角色 `fulla_db` / `fulla_user`、容器名
-  `fulla-*`、Redis 键前缀 `fulla:cache:`、Prometheus 指标 `fulla_*`
+  `fulla-*`、Redis 键前缀 `fulla:cache:`、带 authforge 前缀的 Prometheus
+  指标改 `fulla_*`（`oauth2_*` 功能指标名保持不变）
   （升级即全量缓存失效，属预期一次性行为）。
 - **前端品牌**：Fulla Admin / Fulla，包名 `fulla-admin` / `fulla-user`。
 - **专业仓库治理**（PR #93）：AI 工具工作区出库、kiro 设计文档迁入

--- a/docs/documentation-governance.md
+++ b/docs/documentation-governance.md
@@ -1,80 +1,136 @@
-# 文档治理设计 — 入库边界 · 目录重组 · Docusaurus 内容源
+# 文档治理设计 v2 — 基于全文深读的内容裁决 · Docusaurus 内容源
 
-> 状态：**提案 v1**（2026-08-26），经批准后分三个 Phase 执行
-> 原则一句话：**入库是给别人看的（stranger 能据此完成一件事）；留在本地是给维护者和 agent 看的（过程、状态、私人上下文）。**
+> 状态：提案 v2（2026-08-26）。v1 只做了目录/文件名级分类；本版基于**四路并行全文深读**
+> （backend 23 篇 / ops+admin+frontend+perf 16 篇 / history 60 篇 / productization+branding 25 篇）
+> 逐篇给出内容级裁决，全部结论有 file:line 证据支撑。深读原始报告四份存于会话记录，
+> 本文档是其可执行浓缩。
+> 原则：**入库是给别人看的（stranger 能据此完成一件事）；留在本地是给维护者和 agent 看的。**
 
-## 一、入库判据（写进 documentation-standards 的硬标准）
+## 一、入库判据（不变）
 
-一篇文档**入库**当且仅当满足至少一条：
+1. **可执行**：stranger 依此完成一件事（部署/集成/排查/贡献）；
+2. **可决策**：记录理解系统所必需的设计决策及理由（ADR）；
+3. **可信任**：对外承诺（安全策略、合规尽调、版本政策、测量报告与方法论）。
 
-1. **可执行**：stranger 依此完成一件事（部署、集成、排查、贡献）；
-2. **可决策**：记录了别人理解系统所必需的设计决策及其理由（ADR）；
-3. **可信任**：对外承诺（安全策略、兼容性承诺、版本政策、测量报告）。
+## 二、逐篇内容裁决（136 文件 + 根部文档）
 
-不满足任何一条的过程性内容（计划、进度、调研、会话产物、内部经营记录）**留本地**。
+### 2.1 docs/backend/（23 篇 md + swagger-ui 静态资源）
 
-## 二、现状盘点与分类（docs/ 全部 136 文件 + 根部文档）
-
-| 去向 | 内容 | 动作 |
+| 文件 | 裁决 | 关键内容证据 |
 |---|---|---|
-| **入库 · 前台**（站源） | `backend/` 的 architecture-overview、security-architecture、rbac-guide、sdk-integration-guide、sdk-runtime-contract、api-reference、configuration-guide、observability、data-consistency、data-persistence、testing-guide、ci-cd-guide、versioning-and-release、error-code 相关；`ops/` 全部 6 篇；`performance-optimization/` 7 篇；`admin/`、`frontend/` 指南 | 保留入库；重组为站结构（见 §四） |
-| **入库 · 档案**（站源，Archive 区） | `history/design/` 里的高价值设计（并发生命周期审计、错误码标准化、repo 重构、http-integration 计划、已迁入的 6 个 kiro specs）；`branding/rename-impact-fulla.md`（改名决策记录）与 `repo-professionalization-audit.md`（入库标准依据，AGENTS.md 引用） | 改造为 `docs/adr/`（编号+状态+背景+决策+后果），kiro specs 是现成素材 |
-| **留本地**（出库，磁盘保留） | `productization-evolution/` 全部 22 文件（plan/progress/todo/content-strategy/done——内部经营记录）；`branding/rename-candidates.md`（域名调研）；`history/PRD/` 的实施计划与任务清单（PROGRESS、implementation_plan、p0/p1 tasks、fix_macos_ci 等过程稿）；`history/design/superpowers/`（AI 会话产物） | `git rm --cached` + .gitignore 增补 `docs/productization-evolution/` 等路径 |
-| **待删除**（逐个确认） | 疑似重复/被取代稿：`backend/docker-guide.md` vs `docker-deployment.md`（二选一）；孤立 openapi 规范副本（openapi-spec-topology 记忆登记的死孤儿）；`backend/api/` 下与 openapi.yaml 漂移的生成快照 | 确认后 `git rm` |
-| **根部不动** | README ×2、CHANGELOG、CONTRIBUTING、SECURITY、TECH_SPECS、AGENTS、docs/README.md（重写为受众导航） | docs/README.md 重写 |
+| architecture-overview.md | **SITE-READY** | 章节事实全部与现状吻合；建议补 identity 包与缓存装饰器一笔 |
+| ci-cd-guide.md | **SITE-READY** | 与 8 个实际 workflow 核对无硬伤；补 clients-sdk/security 两条一句话 |
+| docker-deployment.md | **SITE-READY** | 与 compose 实测全吻合；池参数按 bench 结论（64）更新 |
+| sdk-integration-guide.md | **SITE-READY** | 仅 L8 `.kiro` 来源路径失效需修 |
+| sdk-runtime-contract.md | **SITE-READY** | 仅 L7 `.kiro` 路径失效需修 |
+| versioning-and-release.md | **SITE-READY** | 治理单一出处；L294 "840 commits" 待办被版本重置超越需改写 |
+| api-reference.md | **REWRITE** | L226 end_session"不验签"已被 #78 推翻（同文错误表却收录 4006，自相矛盾）；L254 Google 路由错；§6 教旧 openapi.json 工作流与治理门冲突 |
+| configuration-guide.md | **REWRITE** | L38 PG15→17；L69 缓存层写成 "future"（已上线且 config.json:152 有配置块）；L132 end_session 旧语义；L176 JWKS 路径错；环境变量表仅 5 个远不全 |
+| data-persistence.md | **REWRITE** | §3 与 §6 对 Redis 存储是否弃用自相矛盾（L96 vs L205）；schema 停在 V002（现 V026）；`fulla:cache:` 键空间缺席；吸收 data-consistency 后补延迟双删一节 |
+| observability.md | **REWRITE** | 缺 #80 缓存失效指标；`oauth2_*` vs `fulla_*` 指标命名口径未澄清；审计示例 2026-01 陈旧 |
+| oidc-guide.md | **REWRITE** | L21/34 JWKS 路由错（实为 `/.well-known/jwks.json`，照抄会拿不到密钥）；缺 end_session/backchannel 集成义务、auth_time/acr/amr、官方 SDK 通道 |
+| rbac-guide.md | **REWRITE** | L62 "roles 进 JWT 未来支持"已实现（TokenService.cc:334）；完全缺 scope 层（V023 双闸模型）；手工 SQL 授予过时（有 admin API） |
+| security-architecture.md | **REWRITE** | L36 secret 传输说法违反 F-017（默认 Basic 头）；威胁表未覆盖 PR#85 已修威胁（#78 伪造登出/#79 缓存竞态/#54 软删除绕过） |
+| testing-guide.md | **REWRITE** | L274 测试数 364+450（实为 501）；L86-119 四月快照；L195-263 四份"[DOC]（已归档）"悬空引用 |
+| data-consistency.md | **MERGE → data-persistence** | 窄而正确，但缺 #79 延迟双删这一最新一致性内容 |
+| docker-guide.md | **MERGE → docker-deployment** | 与后者六成重叠；L19 容器命名 `oauth2-{service}` 漏改；保留其独有：命名规范表/调试容器/full_test_docker 脚本 |
+| google-guide.md + wechat-guide.md | **MERGE → social-login.md** | 同构孪生篇；google L45 无按钮 vs L53 点按钮自相矛盾；以 GitHub 已接线为主线索 |
+| plugin-integration.md | **MERGE → sdk-integration-guide** | 后者 §3 的 quickstart 子集 |
+| security-hardening.md | **MERGE → security-architecture** | 限流数字与 config.prod.json 全面不符（3/2/5 vs 文档 5/5/10）；四月快照与悬空引用删除；须注明 Hodor 仅 prod 启用 |
+| database-encoding-guide.md | **LOCAL** | 单机 SQL_ASCII 排查记录；含危险的 pg catalog DELETE 建议 |
+| documentation-standards.md | **LOCAL** | 仓库目录元规则，随 CONTRIBUTING 走；本治理落地时改写 |
+| ddd-domain-model.md | **ARCHIVE** | 自称"未经评审提案"；现状映射诚实，是未来演进底稿非现状文档 |
 
-边界案例裁定：`history/PRD/` 里的**设计**类（admin_console_design、frontend_design、mfa_auth_code_pkce_design）——保留价值看是否仍反映现状；反映的转 ADR，失效的归档标注 "superseded"，纯过程的留本地。
+### 2.2 docs/ops/ + admin/ + frontend/ + performance-optimization/（16 篇）
 
-## 三、执行 Phase 划分
+| 文件 | 裁决 | 关键证据 |
+|---|---|---|
+| ops/account-lockout.md | **SITE-READY** | 扎实；凭证口径需统一（见矛盾 #1） |
+| ops/postgresql-major-upgrade.md | **SITE-READY** | 最新且准确；修 L122 deploy 名；**补入 docs/README 索引（现在漏挂）** |
+| ops/deployment.md | **REWRITE（小）** | L571-583 initdb.d 手动迁移在 prod 不可执行（迁移已烘焙进镜像）；L783 Prometheus 直连与 loopback 绑定矛盾；性能调优节已正确同步最新结论 |
+| ops/deployment-windows-docker-desktop.md | **REWRITE** | 测试数 55/51 过期（实 59/52）；"80% 通过即成功"坏口径；6 处本机路径；admin123 凭证冲突 |
+| ops/verification-checklist.md | **REWRITE** | dev 容器表混入不存在的 nginx；`oauth2_migrations` 表名错（实 schema_migrations）；硬编码密码 WinDockerTest2024!；表数量门槛 >=7 过期；同文两个 admin 邮箱 |
+| ops/security-checklist.md | **MERGE → backend/security-hardening** | 整改结项备忘；L76-84 两条 filter-branch 命令复制粘贴事故 |
+| admin/e2e-testing-guide.md | **REWRITE（轻）** | L903 死链；附录"7 文件/53 用例"实为 16/174；§9 与 account-lockout 全篇重复 |
+| admin/test-cases.md | **SITE-READY** | 无硬伤，与实际 spec 对应健康 |
+| frontend/test-cases.md | **SITE-READY** | 无硬伤，覆盖当前功能面 |
+| performance-optimization/ 全部 7 篇 | **LOCAL** | prompt 是 AI 会话产物；wave 报告/仪器化/非代码方案/内存调查全是内部证据链（基线代际混乱，混排上站会呈现三个互相矛盾的 QPS 世界观）；面向用户的结论已正确抽取到 ops/deployment §性能调优；upstream-drogon-session-issue.md 是上游约束唯一记录，issue 发出后转链接再 ARCHIVE |
 
-- **Phase A（结构重组）**：建 `docs/adr/`（迁 6-10 篇 + 编号）；出库本地类；删死稿；重写 `docs/README.md` 为五区受众导航（评估 / 集成 / 运维 / 贡献 / 档案）。
-- **Phase B（文档站骨架）**：`website/` 目录（Docusaurus 3）+ GitHub Pages 部署 workflow + 站结构搭建（§四）。
-- **Phase C（内容补齐）**：三篇缺失深潜（session 管理、token 生命周期、multi-tenancy）+ 既有文档的 frontmatter/导航适配 + 双语策略落地。
+### 2.3 docs/history/（60 篇）：ADR 矿
 
-## 四、Docusaurus 内容源设计（与治理合并考虑的核心）
+**修正 v1 误判**：superpowers/specs/ 并非全部会话产物——其中 2 篇是真设计文档。
 
-**关键决策：站源 = 入库前台文档本体，不做第二份拷贝。** 单一事实源原则——`docs/` 重组后的结构就是站点结构，Docusaurus 用 sidebar 配置引用，绝不复制内容（复制必然漂移，正是本治理要消灭的问题）。
+- **ADR 转化清单（11 + 1 备选，按优先级）**——每篇已提炼决策陈述：
+  1. **产品 + 双 SDK 架构与依赖铁律**（sdk-refactor §2/§4.1/§5.2：Domain 禁 Drogon、oauth2/identity 互不依赖、端口下沉 common、arch-guard 强制）
+  2. **Drogon 自注册符号链接策略**（sdk-refactor §5.5/§5.7：显式 registerController 替代 whole-archive + 插件零改动方案 A）
+  3. **ErrorCatalog 单一权威与双通道错误**（error-code AD-1..6 + auth-flow-gap "不折叠原则"与 G7 防枚举例外）
+  4. **Opaque Access Token + 凭据哈希存储 + 迁移不可变**（production_hardening_spec §五；**注意**：决策表写 Argon2id 实际落地 PBKDF2-SHA256 310K，转 ADR 时必须修正）
+  5. **email 为主登录标识**（email-first §7 五项决策，V020 在库）
+  6. **异步回调生命周期模式**（并发审计四主线；CacheMap 线程安全语义结论）
+  7. **MFA 第二因子会话绑定**（mfa-fix：pending 绑定 + 防枚举同码，V022 在库）
+  8. **首方 SPA 登录凭证暴露面控制**（mfa_auth_code_pkce §6 修正版 + 现状 authService.ts：AJAX+PKCE 闭包、token 不落 localStorage、托管登录页方案搁置）
+  9. **ORM 生成模型豁免 + 迁移冻结**（repo-refactor §0/§1.2——已穿越两次重构验证）
+  10. **限流选型 Hodor**（superpowers/specs：令牌桶三级限流，config.prod 在用）
+  11. **集成测试平台分档**（http-integration-plan：DB-backed 测试限 Linux、进程内起 app、社交面不可达结论）
+  12. （备选）**客户端认证 PUBLIC/CONFIDENTIAL 分类**（client-secret spec）
+  另：productization/done/async-refactor-assessment 蒸馏"**为何 C++17 禁协程**"一页 ADR（贡献者必问）。
+- **ARCHIVE 保留 11 篇**（history/README + 各 bugfix/审计原始记录 + 6 篇 superseded 设计）；
+- **LOCAL 37 篇**（全部 tasks/requirements/plans 类 checkbox 文档与过程稿）；
+- **DELETE 1 篇**：PRD/frontend_design.md（是 frontend/oauth2_frontend_design.md 的严格子集+更早快照，已 diff 确认）。
 
-### 4.1 站点信息架构（受众路径）
+### 2.4 productization-evolution/ + branding/（25 篇）：两处对 v1 的硬修正
 
-```
-website/（Docusaurus 3，GitHub Pages 部署）
-├── docs/ → 内容源指向仓库 docs/（见 4.2 引用方式）
-│   ├── intro/          # 项目定位、能力地图（复用 README 内容）、Quick Start
-│   ├── architecture/   # 总览、安全架构、SDK 分层、模块地图
-│   ├── domains/        # 认证 / 授权 / 访问控制 / 令牌生命周期 / 多租户（深潜，Phase C 补齐三篇）
-│   ├── sdk/            # C++ 集成三件套、Python/Go 客户端
-│   ├── operate/        # 部署（compose/Helm/Windows）、配置、可观测性、安全清单、账号锁定
-│   ├── contribute/     # 构建、测试、CI/CD、版本与发版、文档标准
-│   └── adr/            # 决策档案（只读历史）
-├── API 渲染            # openapi.yaml → 站内 API 参考页（swagger-ui 或 redoc 组件页 + 源链）
-├── benchmark 区        # COMPARISON.md + 方法论（可信任承诺类）
-└── Blog（可选）        # 发版公告 = CHANGELOG 节选； Discussions Announcements 互链
-```
+- **LOCAL 21 篇**（含 content-strategy "去 AI 味+软文流程"——公开即自伤；progress-status 枚举未修复安全项 #71/#73——不进站放大；research 含未公开定价 $499/$5000）；
+- **例外一（SITE，benchmark 区）：in-progress/competitor-benchmark-design.md 必须保持入库**——README 徽章链的 COMPARISON.md 与双语 README、benchmarks/competitors/README 共**三处公开入口指向它**；内容为可公开方法论（三同原则/官方配置出处/诚实修订记录），环境披露（WSL2 8vCPU/16GB）是复现性必需且已在公开 README 中；出库即断三条公开链。迁移：为它脱离即将出库的目录单独安家（建议挪至 `docs/benchmark/`）；
+- **例外二（SITE，档案/信任区）：done/oauth-oidc-compliance-audit.md 保持入库**——31 项全部已修复的 RFC 合规尽调，CHANGELOG.md:453 公开引用；是评估者眼中的信任资产（加"2026-08-07 基线快照"标注）；
+- **branding/rename-impact-fulla.md → ARCHIVE 入库但先脱敏**：删除/泛化 §L9 本机路径与工作区细节（含完整磁盘路径、记忆库哈希、WSL 路径）；压缩 P0 "先占资产"步骤（暴露 fulla.dev/PyPI 占位意图）；CHANGELOG:40 引用其 §3，出库断链；
+- **branding/repo-professionalization-audit.md → ARCHIVE 入库**：AGENTS.md 公开引用其为入库标准；
+- **branding/rename-candidates.md → LOCAL（最高敏感级）**：暴露 fulla.dev 未注册状态 + 9 个备选名可用性清单 + 自贬评估——资产落袋前等于给抢注者递情报；
+- 卫生项：`.mimosa/` 会话 JSON 已混入 docs/productization-evolution/（未跟踪）→ .gitignore 增补 `.mimosa/`（已有？核实）。
 
-### 4.2 内容源引用方式（三选一，推荐 a）
+## 三、跨文档矛盾登记簿（Phase A 必修清单）
 
-- **a. 目录即站源**：把 §二"前台"文档物理移动到 `docs/<区>/`（如 `docs/operate/deployment.md`），`website/docusaurus.config.js` 的 sidebar 直接指向仓库根 `../docs/`（Docusaurus 支持自定义 docs 路径）。**零拷贝、零漂移**；README 里的相对链接同步更新一次。
-- b. symlink/脚本同步：Windows 仓库不可靠，弃。
-- c. 双目录维护：必然漂移，弃。
+深读发现的矛盾**必须在上站前修平**，否则站点会把矛盾双语放大：
 
-### 4.3 双语策略
+| # | 矛盾 | 定谳依据 |
+|---|---|---|
+| 1 | **admin 默认凭证三种口径**（'admin' vs admin123 vs admin/admin123+admin-console 双客户端） | 以 apps/server/seed/dev_admin_user.sql 实测定谳，全站统一 |
+| 2 | end_session "不验签"（api-reference L226、configuration-guide L132）vs 错误表收录 4006 | 代码已强制验签（#78）；两处正文改写 |
+| 3 | Redis 缓存层 "future"（configuration-guide L69）vs 已上线（architecture-overview L12 还指错章节） | config.json cache 块为准；configuration-guide 补缓存配置节 |
+| 4 | CHANGELOG 宣称指标全改 `fulla_*` vs 代码实发 `oauth2_*`（authforge_* 前缀的已改） | **已在本 PR 修正 CHANGELOG 措辞** |
+| 5 | JWKS 路径三个版本（/oauth2/jwks、/oauth2/.well-known/jwks.json、/.well-known/jwks.json） | DiscoveryController.cc:60 定谳 |
+| 6 | PG 版本 15 vs 17（configuration-guide L38） | 17 |
+| 7 | Google 路由 /google/login vs /api/google/login | Controller 定谳 |
+| 8 | rbac-guide 单闸角色模型 vs api-reference 双闸（role+scope）vs "JWT roles 未来支持" | 现状=双闸+roles 已签发 |
+| 9 | 测试数量 364+450 vs 501；e2e "7 文件/53 用例" vs 16/174 | 脚本与 spec 实测 |
+| 10 | verification-checklist 的 oauth2-nginx(dev)/oauth2_migrations/WinDockerTest2024!/表名无前缀 | compose/V001/实配置定谳 |
+| 11 | docs/README.md 索引摘要 "session unbounded leak ~730B" vs 调查报告 v2 已撤回（TTL 有界 750B） | 后者定谳；README 重写时消化 |
+| 12 | 两个限流器（Hodor 全局 vs F-018 失败计数）从未说明并存关系与启用条件 | 重写时合并讲清 |
 
-Phase B 先英文站（受众最大化）；中文沿用 GitHub 上 `README.zh-CN.md` + wiki（已上线）承载；Phase C 视流量决定是否启用 Docusaurus i18n（`website/i18n/zh/`，内容源同构）。
+## 四、Docusaurus 内容源（核心决策不变，素材清单更新）
 
-### 4.4 部署与守门
+**站源 = docs/ 本体，零拷贝。** 站点七区与现状素材的映射（"现成"=SITE-READY，"重写后"=REWRITE/MERGE 完成）：
 
-- `website/` 入库（主流做法，CNCF 系项目标配）；`node_modules/`、`website/build/` 进 .gitignore。
-- `.github/workflows/website.yml`：paths 过滤 `docs/**` 与 `website/**`，PR 预览构建 + master 推送部署 GitHub Pages（与 fulla.dev 域名对接，注册后 CNAME）。
-- 文档改动入口守门：`website.yml` 构建失败 = 死链/断图即刻暴露，替代人工检查。
+| 站区 | 内容源 | 状态 |
+|---|---|---|
+| intro | README 能力地图复用 + Quick Start（README Path A/B） | 现成 |
+| architecture | architecture-overview + security-architecture（重写后）+ 模块地图 | 1 现成 1 重写 |
+| domains | social-login（合并后）、oidc-guide（重写后）、rbac/access-control（重写后）、token-lifecycle（**新写**：吸收 data-persistence 一节+refresh family）、session-management（**新写**：吸收 drogon#278 结论）、multi-tenancy（**新写**） | 3 重写 + 3 新写 |
+| sdk | sdk-integration-guide（吸收 plugin-integration）+ sdk-runtime-contract + 官方 Python/Go 说明（client-sdk 设计的"auth 手写"理由 200 字） | 基本现成 |
+| operate | deployment（小修）、docker-deployment（吸收 docker-guide）、configuration-guide（重写后）、observability（重写后）、account-lockout、postgresql-major-upgrade、verification-checklist（重写后）、testing/e2e/ci-cd/versioning（contribute 区亦可） | 4 现成 4 重写 |
+| benchmark | COMPARISON.md + **competitor-benchmark-design.md（新家 docs/benchmark/）** + benchmarks/README | 现成 |
+| adr | **12 篇新转化 ADR** + ddd-domain-model（标注提案）+ 合规尽调报告（信任档案）+ rename-impact（脱敏后）+ professionalization-audit | 新建 |
+| API | openapi.yaml 直渲染（swagger-ui 静态资源不上站，属服务器托管物） | 插件 |
 
-### 4.5 明确不进站的内容
+双语：英文先行，中文由 README.zh-CN + wiki 承载（已上线），Phase C 视流量上 i18n。
 
-本地类（§二留本地行）、`docs/history/` 的过程稿、benchmarks 原始 JSON（报告进站、数据留库）、内部安全审计过程稿。
+## 五、执行 Phase（修订）
 
-## 五、验收标准
+- **Phase A（内容修复与重组，量最大）**：
+  A1 修矛盾登记簿 12 项（含 seed SQL 定谳凭证）；A2 六组 MERGE 落地；A3 ADR 转化 12 篇；A4 出库 LOCAL 类（productization-evolution 出库时把 2 个例外先迁新家 + 修三处公开链接）+ DELETE 3 篇；A5 docs/README.md 重写为受众导航。
+- **Phase B（站骨架）**：website/ + 七区 sidebar + Pages 部署 + 死链守门。
+- **Phase C（内容补齐）**：三篇新写深潜 + api-reference 重写 + 双语策略评估。
 
-1. `git ls-files docs` 中每篇文档能归入 §一 三条判据之一（抽查即过）；
-2. 站点构建零死链，sidebar 五区导航完整；
-3. README ×2 只做门面，任何深度内容都有 docs/ 落点；
-4. 新增文档有唯一去处判断表（documentation-standards.md 更新版承载）。
+## 六、验收标准（不变，略增）
+
+v1 四条全部保留，另加：⑤ 矛盾登记簿 12 项全部关闭；⑥ CHANGELOG 引用的文档链接零断链（合规报告、rename-impact §3）。

--- a/docs/documentation-governance.md
+++ b/docs/documentation-governance.md
@@ -1,0 +1,80 @@
+# 文档治理设计 — 入库边界 · 目录重组 · Docusaurus 内容源
+
+> 状态：**提案 v1**（2026-08-26），经批准后分三个 Phase 执行
+> 原则一句话：**入库是给别人看的（stranger 能据此完成一件事）；留在本地是给维护者和 agent 看的（过程、状态、私人上下文）。**
+
+## 一、入库判据（写进 documentation-standards 的硬标准）
+
+一篇文档**入库**当且仅当满足至少一条：
+
+1. **可执行**：stranger 依此完成一件事（部署、集成、排查、贡献）；
+2. **可决策**：记录了别人理解系统所必需的设计决策及其理由（ADR）；
+3. **可信任**：对外承诺（安全策略、兼容性承诺、版本政策、测量报告）。
+
+不满足任何一条的过程性内容（计划、进度、调研、会话产物、内部经营记录）**留本地**。
+
+## 二、现状盘点与分类（docs/ 全部 136 文件 + 根部文档）
+
+| 去向 | 内容 | 动作 |
+|---|---|---|
+| **入库 · 前台**（站源） | `backend/` 的 architecture-overview、security-architecture、rbac-guide、sdk-integration-guide、sdk-runtime-contract、api-reference、configuration-guide、observability、data-consistency、data-persistence、testing-guide、ci-cd-guide、versioning-and-release、error-code 相关；`ops/` 全部 6 篇；`performance-optimization/` 7 篇；`admin/`、`frontend/` 指南 | 保留入库；重组为站结构（见 §四） |
+| **入库 · 档案**（站源，Archive 区） | `history/design/` 里的高价值设计（并发生命周期审计、错误码标准化、repo 重构、http-integration 计划、已迁入的 6 个 kiro specs）；`branding/rename-impact-fulla.md`（改名决策记录）与 `repo-professionalization-audit.md`（入库标准依据，AGENTS.md 引用） | 改造为 `docs/adr/`（编号+状态+背景+决策+后果），kiro specs 是现成素材 |
+| **留本地**（出库，磁盘保留） | `productization-evolution/` 全部 22 文件（plan/progress/todo/content-strategy/done——内部经营记录）；`branding/rename-candidates.md`（域名调研）；`history/PRD/` 的实施计划与任务清单（PROGRESS、implementation_plan、p0/p1 tasks、fix_macos_ci 等过程稿）；`history/design/superpowers/`（AI 会话产物） | `git rm --cached` + .gitignore 增补 `docs/productization-evolution/` 等路径 |
+| **待删除**（逐个确认） | 疑似重复/被取代稿：`backend/docker-guide.md` vs `docker-deployment.md`（二选一）；孤立 openapi 规范副本（openapi-spec-topology 记忆登记的死孤儿）；`backend/api/` 下与 openapi.yaml 漂移的生成快照 | 确认后 `git rm` |
+| **根部不动** | README ×2、CHANGELOG、CONTRIBUTING、SECURITY、TECH_SPECS、AGENTS、docs/README.md（重写为受众导航） | docs/README.md 重写 |
+
+边界案例裁定：`history/PRD/` 里的**设计**类（admin_console_design、frontend_design、mfa_auth_code_pkce_design）——保留价值看是否仍反映现状；反映的转 ADR，失效的归档标注 "superseded"，纯过程的留本地。
+
+## 三、执行 Phase 划分
+
+- **Phase A（结构重组）**：建 `docs/adr/`（迁 6-10 篇 + 编号）；出库本地类；删死稿；重写 `docs/README.md` 为五区受众导航（评估 / 集成 / 运维 / 贡献 / 档案）。
+- **Phase B（文档站骨架）**：`website/` 目录（Docusaurus 3）+ GitHub Pages 部署 workflow + 站结构搭建（§四）。
+- **Phase C（内容补齐）**：三篇缺失深潜（session 管理、token 生命周期、multi-tenancy）+ 既有文档的 frontmatter/导航适配 + 双语策略落地。
+
+## 四、Docusaurus 内容源设计（与治理合并考虑的核心）
+
+**关键决策：站源 = 入库前台文档本体，不做第二份拷贝。** 单一事实源原则——`docs/` 重组后的结构就是站点结构，Docusaurus 用 sidebar 配置引用，绝不复制内容（复制必然漂移，正是本治理要消灭的问题）。
+
+### 4.1 站点信息架构（受众路径）
+
+```
+website/（Docusaurus 3，GitHub Pages 部署）
+├── docs/ → 内容源指向仓库 docs/（见 4.2 引用方式）
+│   ├── intro/          # 项目定位、能力地图（复用 README 内容）、Quick Start
+│   ├── architecture/   # 总览、安全架构、SDK 分层、模块地图
+│   ├── domains/        # 认证 / 授权 / 访问控制 / 令牌生命周期 / 多租户（深潜，Phase C 补齐三篇）
+│   ├── sdk/            # C++ 集成三件套、Python/Go 客户端
+│   ├── operate/        # 部署（compose/Helm/Windows）、配置、可观测性、安全清单、账号锁定
+│   ├── contribute/     # 构建、测试、CI/CD、版本与发版、文档标准
+│   └── adr/            # 决策档案（只读历史）
+├── API 渲染            # openapi.yaml → 站内 API 参考页（swagger-ui 或 redoc 组件页 + 源链）
+├── benchmark 区        # COMPARISON.md + 方法论（可信任承诺类）
+└── Blog（可选）        # 发版公告 = CHANGELOG 节选； Discussions Announcements 互链
+```
+
+### 4.2 内容源引用方式（三选一，推荐 a）
+
+- **a. 目录即站源**：把 §二"前台"文档物理移动到 `docs/<区>/`（如 `docs/operate/deployment.md`），`website/docusaurus.config.js` 的 sidebar 直接指向仓库根 `../docs/`（Docusaurus 支持自定义 docs 路径）。**零拷贝、零漂移**；README 里的相对链接同步更新一次。
+- b. symlink/脚本同步：Windows 仓库不可靠，弃。
+- c. 双目录维护：必然漂移，弃。
+
+### 4.3 双语策略
+
+Phase B 先英文站（受众最大化）；中文沿用 GitHub 上 `README.zh-CN.md` + wiki（已上线）承载；Phase C 视流量决定是否启用 Docusaurus i18n（`website/i18n/zh/`，内容源同构）。
+
+### 4.4 部署与守门
+
+- `website/` 入库（主流做法，CNCF 系项目标配）；`node_modules/`、`website/build/` 进 .gitignore。
+- `.github/workflows/website.yml`：paths 过滤 `docs/**` 与 `website/**`，PR 预览构建 + master 推送部署 GitHub Pages（与 fulla.dev 域名对接，注册后 CNAME）。
+- 文档改动入口守门：`website.yml` 构建失败 = 死链/断图即刻暴露，替代人工检查。
+
+### 4.5 明确不进站的内容
+
+本地类（§二留本地行）、`docs/history/` 的过程稿、benchmarks 原始 JSON（报告进站、数据留库）、内部安全审计过程稿。
+
+## 五、验收标准
+
+1. `git ls-files docs` 中每篇文档能归入 §一 三条判据之一（抽查即过）；
+2. 站点构建零死链，sidebar 五区导航完整；
+3. README ×2 只做门面，任何深度内容都有 docs/ 落点；
+4. 新增文档有唯一去处判断表（documentation-standards.md 更新版承载）。


### PR DESCRIPTION
Task 2 of the agreed sequence — the design doc for review before the big restructure lands. Core decisions: (1) hard inclusion criteria — a doc ships only if executable / decision-record / trust-promise; (2) file-level triage of all 136 files into site-facing / ADR archive / local-only / delete; (3) Docusaurus sourcing = **docs/ is the site source, zero copies** (custom docs path, no sync scripts), audience IA with 7 sections, EN-first (zh stays README+wiki), GitHub Pages deploy with link-check gating. Execution in 3 phases (A restructure → B website skeleton → C content gap-fill). Approving this PR green-lights Phase A.