### PR TITLE
docs: Phase C deep-dives + English-primary bilingual site (en + zh-CN)

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -383,7 +383,8 @@ ctest --output-on-failure
 
 ## 项目文档
 
-**在线文档站：[fulla.dev](https://fulla.dev)** —— 由本仓库 `docs/` 目录直接构建，随 master 持续更新。
+**在线文档站：[fulla.dev/zh-CN](https://fulla.dev/zh-CN)** —— 由本仓库 `docs/` 目录（英文正本）及其
+`website/i18n/zh-CN/` 中文译本直接构建，随 master 持续更新；站点右上角可切换中英文。
 
 **评估选型** — [架构总览](docs/architecture/architecture-overview.md) · [安全架构](docs/architecture/security-architecture.md) · [RBAC 权限](docs/domains/rbac-guide.md) · [性能对比](benchmarks/competitors/results/COMPARISON.md)
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-fulla.dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,57 @@
-# 文档中心
+# Documentation
 
-按受众组织的**用户向**文档树（维护者过程文档在仓库外的 `docs-local/`，判据见
-[documentation-governance.md](documentation-governance.md)）。本树同时是
-[fulla.dev](https://fulla.dev) 文档站的唯一内容源（零拷贝）。
+The **user-facing** documentation tree, organized by audience (maintainer
+process docs live outside the repo in `docs-local/`; criteria in
+[documentation-governance.md](documentation-governance.md)). This tree is the
+**English canonical** and the sole content source of
+[fulla.dev](https://fulla.dev) (Docusaurus, zero copies); the Chinese
+translation mirrors it at `website/i18n/zh-CN/` and is served at
+[fulla.dev/zh-CN](https://fulla.dev/zh-CN).
 
-## 评估（Evaluate）
+## Evaluate
 
-- [架构总览](architecture/architecture-overview) — 技术栈、模块布局、授权码时序、存储策略
-- [安全架构](architecture/security-architecture) — 威胁模型、token 生命周期、密钥与哈希、安全头与限流
-- [性能对比](../benchmarks/competitors/results/COMPARISON.md)（[方法论](benchmark/competitor-benchmark-design.md)）
+- [Architecture Overview](architecture/architecture-overview.md) — tech stack, module layout, authorization-code flow, storage strategy
+- [Security Architecture](architecture/security-architecture.md) — threat model, token lifecycle, keys & hashes, security headers & rate limiting
+- [Benchmark comparison](https://github.com/voidvec/fulla/blob/master/benchmarks/competitors/results/COMPARISON.md) ([methodology](benchmark/competitor-benchmark-design.md))
 
-## 集成（Integrate）
+## Integrate
 
-**C++ SDK（嵌入）**：[集成指南](sdk/sdk-integration-guide) · [运行时契约](sdk/sdk-runtime-contract)
+**C++ SDK (embedded)**: [Integration Guide](sdk/sdk-integration-guide.md) · [Runtime Contract](sdk/sdk-runtime-contract.md)
 
-**HTTP API（任意语言）**：[API 参考](domains/api-reference)（权威契约：
-[openapi.yaml](../apps/server/openapi.yaml)）· [OIDC 集成](domains/oidc-guide) ·
-[社交登录](domains/social-login) · [RBAC 与访问控制](domains/rbac-guide)
+**HTTP API (any language)**: [API Reference](domains/api-reference.md) (authoritative contract:
+[openapi.yaml](https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml)) ·
+[OIDC Integration](domains/oidc-guide.md) · [Social Login](domains/social-login.md) ·
+[RBAC & Access Control](domains/rbac-guide.md)
 
-## 架构深潜（Architecture）
+## Deep dives
 
-- [数据与持久化](architecture/data-persistence) — 存储分层、缓存一致性（延迟双删）、token 家族
+[Token Lifecycle](domains/token-lifecycle.md) · [Session Management](domains/session-management.md) · [Multi-Tenancy](domains/multi-tenancy.md) · [Data & Persistence](architecture/data-persistence.md)
 
-## 运维（Operate）
+## Operate
 
-[生产部署](operate/deployment) · [Docker 部署](operate/docker-deployment) ·
-[Windows/Docker Desktop](operate/deployment-windows-docker-desktop) ·
-[配置指南](operate/configuration-guide) · [可观测性](operate/observability) ·
-[账号锁定](operate/account-lockout) · [PG 大版本升级](operate/postgresql-major-upgrade) ·
-[部署验收清单](operate/verification-checklist)
+[Production Deployment](operate/deployment.md) · [Docker Deployment](operate/docker-deployment.md) ·
+[Windows / Docker Desktop](operate/deployment-windows-docker-desktop.md) ·
+[Configuration Guide](operate/configuration-guide.md) · [Observability](operate/observability.md) ·
+[Account Lockout](operate/account-lockout.md) · [PostgreSQL Major Upgrades](operate/postgresql-major-upgrade.md) ·
+[Deployment Verification Checklist](operate/verification-checklist.md)
 
-## 贡献（Contribute）
+## Contribute
 
-[测试指南](contribute/testing-guide) · [CI/CD](contribute/ci-cd-guide) ·
-[版本与发版](contribute/versioning-and-release) · [文档治理](documentation-governance.md) ·
-前端测试：[Admin 用例](contribute/admin-test-cases) · [User 用例](contribute/user-frontend-test-cases) ·
-[E2E 方法论](contribute/admin-e2e-testing-guide)
+[Testing Guide](contribute/testing-guide.md) · [CI/CD](contribute/ci-cd-guide.md) ·
+[Versioning & Release](contribute/versioning-and-release.md) · [Documentation Governance](documentation-governance.md) ·
+Frontend tests: [Admin cases](contribute/admin-test-cases.md) · [User cases](contribute/user-frontend-test-cases.md) ·
+[E2E methodology](contribute/admin-e2e-testing-guide.md)
 
-## 决策档案（ADR）
+## Decision record (ADR)
 
-[docs/adr/](adr/) — 12 篇现行架构决策记录（SDK 分层、ErrorCatalog、Opaque token、协程排除等），
-另附三份历史档案：[OAuth/OIDC 合规尽调报告](adr/oauth-oidc-compliance-audit.md)（2026-08-07
-基线，31 项已全部修复）、[改名影响分析](adr/rename-impact-fulla.md)、[专业仓库改造审计](adr/repo-professionalization-audit.md)。
+[docs/adr/](adr/) — 12 current architecture decision records (SDK layering,
+ErrorCatalog, opaque tokens, coroutine exclusion, …) plus three historical
+archives: the [OAuth/OIDC compliance audit](adr/oauth-oidc-compliance-audit.md)
+(2026-08-07 baseline, all 31 findings fixed), the
+[rename impact analysis](adr/rename-impact-fulla.md), and the
+[repo professionalization audit](adr/repo-professionalization-audit.md)
+(the three archives are kept in Chinese with an English note).
 
-> 更早期的完整设计档案（kiro specs 全文、PRD 设计）由 git 历史与维护者本地保存；
-> ADR 已提炼其仍有效的决策。
+> Earlier design archives (kiro specs in full, PRD designs) live in git
+> history and maintainer-local storage; the ADRs distill the decisions that
+> still hold.

--- a/docs/adr/ADR-0001.md
+++ b/docs/adr/ADR-0001.md
@@ -1,19 +1,19 @@
 ---
 adr: 0001
-title: 产品主线与双可嵌入 SDK 的架构及依赖铁律
+title: Architecture and Dependency Iron Rules for the Product Mainline and the Two Embeddable SDKs
 date: 2026-08-26
 status: Accepted
-source: sdk-refactor design.md §2/§4.1/§5.2（原始档案已出库，git 历史可溯）
+source: sdk-refactor design.md §2/§4.1/§5.2 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-仓库同时承载一个可直接部署的授权服务器产品与可复用的协议引擎。若不约束依赖方向，Domain 代码会被框架类型渗透，SDK 消费方将被迫引入 Drogon。
+The repository carries both a directly deployable authorization-server product and a reusable protocol engine. Without constraining dependency direction, Domain code would be permeated by framework types and SDK consumers would be forced to pull in Drogon.
 
-## 决策
+## Decision
 
-以产品为主线交付，同时沉淀 fulla::oauth2 与 fulla::identity 两个可嵌入 SDK。Domain 三包（common/oauth2/identity）禁止 include Drogon（允许 jsoncpp）；oauth2 与 identity 互不编译依赖；跨包端口全部下沉 common；apps/server 是唯一装配点负责依赖注入；tools/arch-guard 在 CI 强制以上全部。
+Deliver with the product as the mainline while distilling fulla::oauth2 and fulla::identity into two embeddable SDKs. The three Domain packages (common/oauth2/identity) are forbidden from including Drogon (jsoncpp is allowed); oauth2 and identity have no compile-time dependency on each other; all cross-package ports sink into common; apps/server is the sole assembly point responsible for dependency injection; tools/arch-guard enforces all of the above in CI.
 
-## 后果与现状对照
+## Consequences and Current State
 
-libs/ 下 7 个库目录（8 个 CMake 包，含 `common/testing`）与 include/fulla/*/ports/ 均按此落地；arch-guard（tools/arch-guard）是 CI 门禁。消费方可只用引擎 + 任意单存储后端。
+The 7 library directories under libs/ (8 CMake packages, including `common/testing`) and include/fulla/*/ports/ are all implemented accordingly; arch-guard (tools/arch-guard) is a CI gate. Consumers can use just the engine plus any single storage backend.

--- a/docs/adr/ADR-0002.md
+++ b/docs/adr/ADR-0002.md
@@ -1,19 +1,19 @@
 ---
 adr: 0002
-title: Drogon 自注册符号的链接与插件兼容策略
+title: Linking and Plugin-Compatibility Strategy for Drogon Self-Registration Symbols
 date: 2026-08-26
 status: Accepted
-source: sdk-refactor design.md §5.5/§5.7（原始档案已出库，git 历史可溯）
+source: sdk-refactor design.md §5.5/§5.7 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-C++ 静态库中 Drogon 依赖静态初始化自注册；whole-archive 链接在多平台/多消费方场景 fragile 且拖入全部符号。
+In C++ static libraries, Drogon relies on static-initialization self-registration; whole-archive linking is fragile across platforms/consumers and drags in every symbol.
 
-## 决策
+## Decision
 
-Controller 采用 `HttpController<T,false>` + 显式 `registerController`，不依赖 whole-archive；OAuth2Plugin 保持类名与各 config（`config.{json,dev,ci,prod,bench}.json`）plugins 块的零改动（方案 A）。边界：若插件改为静态库分发，消费方仍需 whole-archive 才能拉入自注册符号。
+Controllers use `HttpController<T,false>` + an explicit `registerController`, with no reliance on whole-archive; OAuth2Plugin keeps its class name and the plugins blocks of every config (`config.{json,dev,ci,prod,bench}.json`) untouched (Option A). Boundary: if the plugin is ever distributed as a static library, consumers will still need whole-archive to pull in the self-registration symbols.
 
-## 后果与现状对照
+## Consequences and Current State
 
-SDK Smoke（find_package 全栈消费方）在 CI 验证该策略；examples/ 提供参考宿主。
+SDK Smoke (a find_package full-stack consumer) validates this strategy in CI; examples/ provides reference hosts.

--- a/docs/adr/ADR-0003.md
+++ b/docs/adr/ADR-0003.md
@@ -1,19 +1,19 @@
 ---
 adr: 0003
-title: ErrorCatalog 单一权威来源与双通道错误处理
+title: ErrorCatalog as the Single Source of Truth and Dual-Channel Error Handling
 date: 2026-08-26
 status: Accepted
-source: error-code-message-standardization design.md（AD-1..AD-6）+ auth-flow-error-code-gaps（原始档案已出库，git 历史可溯）
+source: error-code-message-standardization design.md（AD-1..AD-6）+ auth-flow-error-code-gaps (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-错误码/文案/HTTP 状态分散在控制器内导致漂移；应用侧与协议侧错误体格式天然不同。
+Error codes/messages/HTTP statuses scattered inside controllers caused drift; the application-side and protocol-side error body formats are inherently different.
 
-## 决策
+## Decision
 
-全部错误码（含 OAuth2 协议码）的 code/numeric/category/HTTP 状态/默认文案以编译期 ErrorCatalog 为唯一权威；Application 端点走 ErrorResponder 错误信封，协议端点走 RFC 6749 错误体（含 Filter 层）；前端错误目录镜像后端并构建期校验（errorAdapter 纯函数）。原则：不同失败原因不得折叠进同一 code；例外：防枚举场景（账户锁定与密码错误同码）是刻意设计。
+For every error code (including OAuth2 protocol codes), the code/numeric/category/HTTP status/default message treats the compile-time ErrorCatalog as the sole authority; Application endpoints use the ErrorResponder error envelope, while protocol endpoints use the RFC 6749 error body (including the Filter layer); the frontend error catalog mirrors the backend's and is validated at build time (errorAdapter is a pure function). Principle: distinct failure causes must not be folded into the same code; exception: anti-enumeration scenarios (account lockout sharing the same code as a wrong password) are deliberate design.
 
-## 后果与现状对照
+## Consequences and Current State
 
-ErrorCatalog.cc（525 行）+ 单测强制文档同步（api-reference 错误表由测试校验）；PR#85 的 4006 即按此流程新增。
+ErrorCatalog.cc (525 lines) + unit tests force documentation sync (the api-reference error table is verified by tests); the 4006 added in PR#85 went through exactly this process.

--- a/docs/adr/ADR-0004.md
+++ b/docs/adr/ADR-0004.md
@@ -1,19 +1,19 @@
 ---
 adr: 0004
-title: Opaque Access Token 与凭据哈希存储、版本化迁移
+title: Opaque Access Tokens, Credential-Hash Storage, and Versioned Migrations
 date: 2026-08-26
 status: Accepted
-source: production_hardening_spec.md §五（原始档案已出库，git 历史可溯）
+source: production_hardening_spec.md §五 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-JWT access token 会扩大泄漏面且难以即时吊销；明文存储 token/secret 使数据库泄漏等于凭据泄漏。
+JWT access tokens widen the leak surface and are hard to revoke instantly; storing tokens/secrets in plaintext means a database leak equals a credential leak.
 
-## 决策
+## Decision
 
-Access Token 保持 Opaque 随机串，资源服务器经 introspection（RFC 7662）验证，不引入 JWT access token（id_token 仍为 JWT）；数据库只存 SHA-256(token) 与 secret 哈希；schema 变更一律走只增不改的 V### 版本化迁移。落地注记：决策表原写 Argon2id，实际落地 PBKDF2-SHA256 310K 迭代（PasswordHasher 预留升级位）。
+Access tokens remain opaque random strings, validated by resource servers via introspection (RFC 7662); no JWT access token is introduced (the id_token remains a JWT); the database stores only SHA-256(token) and secret hashes; every schema change goes through append-only V### versioned migrations. Implementation note: the decision table originally said Argon2id, but what actually landed is PBKDF2-SHA256 with 310K iterations (PasswordHasher reserves an upgrade slot).
 
-## 后果与现状对照
+## Consequences and Current State
 
-introspection/revocation 端点为公开契约；V001–V026 追加式演进；迁移不可变由 CI migration-check 门禁。
+The introspection/revocation endpoints are public contract; V001–V026 evolved append-only; migration immutability is enforced by the CI migration-check gate.

--- a/docs/adr/ADR-0005.md
+++ b/docs/adr/ADR-0005.md
@@ -1,19 +1,19 @@
 ---
 adr: 0005
-title: email 为主登录标识
+title: Email as the Primary Login Identifier
 date: 2026-08-26
 status: Accepted
-source: email-first-auth-design.md §7（原始档案已出库，git 历史可溯）
+source: email-first-auth-design.md §7 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-username 与 email 双标识并存导致登录歧义与唯一约束冲突。
+Coexisting username and email identifiers caused login ambiguity and unique-constraint conflicts.
 
-## 决策
+## Decision
 
-登录标识按是否含 @ 分流（username 字符集与 email 互斥保证无歧义）；email 必填且注册/登录共用 normalizeEmail；username 可选但保留 UNIQUE（NULL 豁免）；登录链路验证最宽容（正则仅限注册/改密）；API 字段名沿用 username 保持兼容；OIDC name 回退 email。
+Login identifiers are dispatched by whether they contain @ (the username charset and email are mutually exclusive, guaranteeing no ambiguity); email is required, and registration/login share normalizeEmail; username is optional but keeps its UNIQUE constraint (NULL exempt); the login path validates most leniently (regex applies only to registration/password change); the API field name stays username for compatibility; the OIDC name falls back to email.
 
-## 后果与现状对照
+## Consequences and Current State
 
-V020 迁移在库；verification-checklist 等运维文档的登录口径以此为准。
+The V020 migration is in the repository; the login semantics in operational documents such as verification-checklist follow this ADR.

--- a/docs/adr/ADR-0006.md
+++ b/docs/adr/ADR-0006.md
@@ -1,19 +1,19 @@
 ---
 adr: 0006
-title: 异步回调生命周期模式
+title: Async Callback Lifetime Pattern
 date: 2026-08-26
 status: Accepted
-source: 并发审计报告四主线 + CacheMap 线程安全语义结论（原始档案已出库，git 历史可溯）
+source: 并发审计报告四主线 + CacheMap 线程安全语义结论 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-Drogon 异步回调中裸 this 捕获与跨线程无锁访问是历史缺陷的主要来源（11 项审计缺陷）。
+Bare this captures in Drogon async callbacks and lock-free cross-thread access were the main source of historical defects (11 audit findings).
 
-## 决策
+## Decision
 
-带异步回调的对象一律 enable_shared_from_this；lambda 捕获 self/weak_ptr，禁止裸 this（禁协程）；初始化用 Meyers Singleton / call_once 消 SIOF；承认并依赖 drogon::CacheMap 自身互斥锁的线程安全（EventLoop* 仅驱动过期定时器，不做 loop 编排）；look-aside 缓存 stampede 属可接受的非线性一致。
+Any object carrying async callbacks uses enable_shared_from_this; lambdas capture self/weak_ptr and bare this is forbidden (as are coroutines); initialization uses Meyers Singleton / call_once to eliminate SIOF; the thread safety of drogon::CacheMap's own mutex is acknowledged and relied upon (the EventLoop* only drives expiring timers and does no loop orchestration); look-aside cache stampedes are accepted as non-linearizable consistency.
 
-## 后果与现状对照
+## Consequences and Current State
 
-该纪律写入 .claude/rules/db-operations.md 成为项目铁律；并发审计的 11 项缺陷全部修复并有回归测试。
+This discipline is codified in .claude/rules/db-operations.md as a project iron rule; all 11 concurrency-audit defects have been fixed with regression tests.

--- a/docs/adr/ADR-0007.md
+++ b/docs/adr/ADR-0007.md
@@ -1,19 +1,19 @@
 ---
 adr: 0007
-title: MFA 第二因子登录会话绑定
+title: MFA Second-Factor Login Session Binding
 date: 2026-08-26
 status: Accepted
-source: mfa-fix 设计档案（原始档案已出库，git 历史可溯）
+source: mfa-fix 设计档案 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-MFA verify 若不绑定首因子上下文，跨 client 混淆与 redirect_uri 旁路可组合出账户接管。
+If MFA verify does not bind the first-factor context, cross-client confusion and a redirect_uri bypass can be combined into account takeover.
 
-## 决策
+## Decision
 
-MFA verify 必须校验：client 注册关系 + redirect_uri 白名单 + 与首因子登录一致的 pending 绑定（users.mfa_pending_client_id / mfa_pending_redirect_uri，验证后清 NULL 防重放）。所有新拒绝统一 AUTH_INVALID_CREDENTIALS 401，消除 client 注册枚举 oracle。已知接受的限制：mfa_token 无过期与并发覆盖。
+MFA verify must check: the client registration relationship + the redirect_uri whitelist + a pending binding consistent with the first-factor login (users.mfa_pending_client_id / mfa_pending_redirect_uri, cleared to NULL after verification to prevent replay). All new rejections use the unified AUTH_INVALID_CREDENTIALS 401, eliminating the client-registration enumeration oracle. Known accepted limitations: mfa_token has no expiry and can be overwritten concurrently.
 
-## 后果与现状对照
+## Consequences and Current State
 
-V022 迁移在库；MfaController 按 pending 绑定实现。
+The V022 migration is in the repository; MfaController is implemented according to the pending binding.

--- a/docs/adr/ADR-0008.md
+++ b/docs/adr/ADR-0008.md
@@ -1,19 +1,19 @@
 ---
 adr: 0008
-title: 首方 SPA 登录的凭证暴露面控制
+title: Credential Exposure-Surface Control for First-Party SPA Login
 date: 2026-08-26
 status: Accepted
-source: mfa_auth_code_pkce_design.md §6/§7 + production_hardening_batch1_2 §1.1（原始档案已出库，git 历史可溯）
+source: mfa_auth_code_pkce_design.md §6/§7 + production_hardening_batch1_2 §1.1 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-SPA 登录若把 PKCE verifier/token 持久化到 storage，XSS 即等于会话劫持。
+If SPA login persists the PKCE verifier/token to storage, XSS immediately equals session hijacking.
 
-## 决策
+## Decision
 
-首方登录保留 AJAX /oauth2/login（json=true）直取授权码，PKCE verifier 由闭包持有不持久化；第三方走 authorize 整页跳转 + sessionStorage 中转；access_token 仅存内存不落 localStorage；后端整页托管登录页方案经评审后搁置。安全表述采用修正口径：缩小暴露窗口而非根除泄露。
+First-party login keeps the AJAX /oauth2/login (json=true) flow that returns the authorization code directly, with the PKCE verifier held by a closure and never persisted; third parties use the authorize full-page redirect + a sessionStorage relay; the access_token lives only in memory and never reaches localStorage; the backend-hosted full-page login-page approach was shelved after review. The security wording follows the corrected framing: shrink the exposure window rather than eradicate leakage.
 
-## 后果与现状对照
+## Consequences and Current State
 
-frontends/user 的 authService/http 按此实现；第三方集成路径在 oidc-guide 说明。
+frontends/user's authService/http implement this; the third-party integration path is documented in oidc-guide.

--- a/docs/adr/ADR-0009.md
+++ b/docs/adr/ADR-0009.md
@@ -1,19 +1,19 @@
 ---
 adr: 0009
-title: ORM 生成模型豁免重命名与迁移冻结
+title: Rename Exemption for ORM-Generated Models and Migration Freeze
 date: 2026-08-26
 status: Accepted
-source: repo-structure-refactor design.md §0/§1.2（原始档案已出库，git 历史可溯）
+source: repo-structure-refactor design.md §0/§1.2 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-drogon_ctl 生成的模型类若参与人工重命名，重生成即漂移；已应用迁移若被修改，多环境 schema 校验即失效。
+If drogon_ctl-generated model classes undergo manual renaming, regeneration drifts immediately; if already-applied migrations are modified, multi-environment schema validation breaks.
 
-## 决策
+## Decision
 
-drogon_ctl 生成的 14 个模型类名/命名空间永不重命名（凌驾于统一命名风格之上，仅允许整目录搬迁）；已合并的 V### 迁移文件冻结，schema 变更只追加新版本。
+The 14 drogon_ctl-generated model class names/namespaces are never renamed (this overrides the unified naming style; only whole-directory relocation is allowed); merged V### migration files are frozen, and schema changes only append new versions.
 
-## 后果与现状对照
+## Consequences and Current State
 
-该决策穿越 repo 重构与 SDK 重构两次验证；migration-check（M5）在 CI 强制迁移不可变；2026-08 更名工程中 oauth2_* 表名/类名保持正是此 ADR 的应用。
+This decision was validated through both the repo refactor and the SDK refactor; migration-check (M5) enforces migration immutability in CI; keeping the oauth2_* table/class names intact during the 2026-08 renaming project is precisely this ADR in action.

--- a/docs/adr/ADR-0010.md
+++ b/docs/adr/ADR-0010.md
@@ -1,19 +1,19 @@
 ---
 adr: 0010
-title: 限流选型 Hodor
+title: Hodor as the Rate-Limiting Choice
 date: 2026-08-26
 status: Accepted
-source: hodor-rate-limiter-migration 设计档案（原始档案已出库，git 历史可溯）
+source: hodor-rate-limiter-migration 设计档案 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-自研 Redis 固定窗口限流 Filter 维护成本高且与存储耦合。
+The homegrown Redis fixed-window rate-limiting Filter carried high maintenance costs and was coupled to storage.
 
-## 决策
+## Decision
 
-全局侧限流采用 Drogon 官方 Hodor 插件：令牌桶、进程内 CacheMap（零外部依赖）、IP/用户/全局三级、trust_ips 白名单、纯 JSON 配置；弃用自研 Redis 固定窗口。拒绝体收编为错误信封 VALIDATION_RATE_LIMITED（429）。仅在 config.prod.json 挂载；认证侧防爆破由 F-018 失败计数限流另行承担（两者作用面不同）。
+Global-side rate limiting adopts the official Drogon Hodor plugin: token bucket, in-process CacheMap (zero external dependencies), IP/user/global tiers, a trust_ips whitelist, pure-JSON configuration; the homegrown Redis fixed window is retired. The rejection body is folded into the error envelope VALIDATION_RATE_LIMITED (429). Mounted only in config.prod.json; authentication-side brute-force protection is carried separately by F-018 failure-count rate limiting (the two operate on different surfaces).
 
-## 后果与现状对照
+## Consequences and Current State
 
-config.prod.json plugins 块在用；见 security-architecture 的限流节。
+The config.prod.json plugins block is in active use; see the rate-limiting section of security-architecture.

--- a/docs/adr/ADR-0011.md
+++ b/docs/adr/ADR-0011.md
@@ -1,19 +1,19 @@
 ---
 adr: 0011
-title: 集成测试平台分档
+title: Integration-Test Platform Tiering
 date: 2026-08-26
 status: Accepted
-source: http-integration-test-coverage-plan.md（原始档案已出库，git 历史可溯）
+source: http-integration-test-coverage-plan.md (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-Windows/macOS 无法容器化 PG/Redis，DB-backed 测试若三平台全跑则矩阵不可行。
+Windows/macOS cannot containerize PG/Redis; running DB-backed tests on all three platforms would make the matrix infeasible.
 
-## 决策
+## Decision
 
-DB-backed 集成/契约测试只在 Linux CI 腿运行（配 PG/Redis 服务容器）；Windows/macOS 跑 memory-only 配置（FULLA_MEMORY_TESTS_ONLY=ON 剔除 SchemaSetup）；测试进程内起全量 app + SchemaManager 播种；社交登录/WebAuthn 控制器的覆盖不作为 HTTP 测试达标条件。
+DB-backed integration/contract tests run only on the Linux CI leg (with PG/Redis service containers); Windows/macOS run the memory-only configuration (FULLA_MEMORY_TESTS_ONLY=ON excludes SchemaSetup); tests bring up the full app in-process and seed it via SchemaManager; coverage of the social-login/WebAuthn controllers is not treated as an HTTP-test completion criterion.
 
-## 后果与现状对照
+## Consequences and Current State
 
-ci.yml 三平台矩阵按此分档；本地 full_test 走真实 DB。
+The ci.yml three-platform matrix is tiered accordingly; the local full_test runs against a real DB.

--- a/docs/adr/ADR-0012.md
+++ b/docs/adr/ADR-0012.md
@@ -1,19 +1,19 @@
 ---
 adr: 0012
-title: C++17 锁定与协程排除
+title: C++17 Lock-in and Coroutine Exclusion
 date: 2026-08-26
 status: Accepted
-source: async-refactor-assessment.md 蒸馏（原始档案已出库，git 历史可溯）
+source: async-refactor-assessment.md 蒸馏 (original archive removed from the repo; recoverable from git history)
 ---
 
-## 背景
+## Context
 
-回调风格被诟病为回调地狱；C++20 协程可消除回调但带来 ABI/调试/栈追溯成本。
+The callback style is criticized as callback hell; C++20 coroutines can eliminate callbacks but bring ABI/debugging/stack-tracing costs.
 
-## 决策
+## Decision
 
-保持 C++17 与回调风格：协程被排除的原因是 MSVC/gcc 对协程 ABI 仍不稳、栈追溯与崩溃报告在协程帧上失效、Drogon 官方 CoroMapper 与本项目 Mapper+Criteria 纪律（含 JOIN 禁令）不兼容。触发重评条件：工具链协程支持成熟且出现无法用回调表达的复杂控制流。
+Stay on C++17 with the callback style: coroutines are excluded because MSVC/gcc coroutine ABIs are still unstable, stack tracing and crash reporting break on coroutine frames, and Drogon's official CoroMapper is incompatible with this project's Mapper+Criteria discipline (including the JOIN ban). Re-evaluation trigger: mature coroutine support in the toolchains plus complex control flows that callbacks cannot express.
 
-## 后果与现状对照
+## Consequences and Current State
 
-回调纪律由 ADR-0006 的生命周期模式约束；db-operations.md 明确禁 CoroMapper。
+Callback discipline is governed by the lifetime pattern of ADR-0006; db-operations.md explicitly bans CoroMapper.

--- a/docs/adr/oauth-oidc-compliance-audit.md
+++ b/docs/adr/oauth-oidc-compliance-audit.md
@@ -1,9 +1,12 @@
 ---
-title: 档案 · OAuth/OIDC 规范性审查报告（2026-08-07 基线）
-date: 2026-08-07
-status: 已整改（31 项发现全部修复并有回归测试守护）
-sidebar_label: 档案 · 合规尽调报告
+title: Archive · OAuth/OIDC Compliance Audit (2026-08-07 baseline, in Chinese)
 ---
+
+> **Language note**: this is a historical trust archive kept in its original
+> Chinese. The 2026-08-07 OAuth/OIDC compliance-audit baseline (all 31
+> findings fixed, regression-tested) is preserved verbatim for third-party
+> assessors. The current security design lives in
+> [Security Architecture](../architecture/security-architecture.md).
 
 > 本报告是 2026-08-07 对 fulla（时名 authforge）的完整 OAuth/OIDC 合规尽调
 > **基线快照**：逐条附 file:line 证据与规范章节引文。报告发布后所有发现均已在

--- a/docs/adr/rename-impact-fulla.md
+++ b/docs/adr/rename-impact-fulla.md
@@ -1,9 +1,11 @@
 ---
-title: 档案 · authforge→fulla 改名影响分析（2026-08-25 快照）
-date: 2026-08-25
-status: 已执行（PR #93/#94/#95 落地；v1.0.0 序列重置首发）
-sidebar_label: 档案 · 改名影响分析
+title: Archive · authforge→fulla Rename Impact Analysis (in Chinese)
 ---
+
+> **Language note**: historical archive, kept in its original Chinese. The
+> authforge→fulla rename impact analysis (executed via PR #93/#94/#95;
+> version series reset to v1.0.0). Current rules live in
+> [documentation-governance.md](../documentation-governance.md).
 
 > 本文档是改名决策的历史档案（入库版，本机细节已泛化）。其中的执行计划已全部
 > 完成：仓库已改名 voidvec/fulla、版本序列重置为 v1.0.0、PyPI fulla-oauth2 已

--- a/docs/adr/repo-professionalization-audit.md
+++ b/docs/adr/repo-professionalization-audit.md
@@ -1,9 +1,11 @@
 ---
-title: 档案 · 专业仓库改造审计（2026-08-25）
-date: 2026-08-25
-status: 已执行（chore/professional-repo-cleanup 落地）
-sidebar_label: 档案 · 仓库改造审计
+title: Archive · Repo Professionalization Audit (in Chinese)
 ---
+
+> **Language note**: historical archive, kept in its original Chinese. The
+> 2026-08-25 repo-professionalization audit (executed via
+> chore/professional-repo-cleanup). Current rules live in
+> [documentation-governance.md](../documentation-governance.md).
 
 # 专业仓库改造审计 — 入库范围清理清单
 

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -1,21 +1,21 @@
-# 架构总览
+# Architecture Overview
 
-本文从技术栈、模块布局、请求流转与部署形态四个视角，概括 fulla 的整体架构。
+This page summarizes the overall architecture of fulla from four perspectives: technology stack, module layout, request flow, and deployment topology.
 
-## 1. 技术栈
+## 1. Technology Stack
 
-| 层 | 技术 | 用途 |
+| Layer | Technology | Purpose |
 |---|---|---|
-| Web 框架 | Drogon | 高性能异步 C++ HTTP 服务 |
-| 主数据库 | PostgreSQL 17 | 用户、角色、客户端、授权码与令牌的持久化（2026-08-18 起为部署默认；服务端也可运行在 15 上——升级路径见 [PG 大版本升级](../operate/postgresql-major-upgrade.md)） |
-| 缓存 / KV | Redis | Postgres 前置的可选 L2 缓存（client 与 access-token 读路径）；独立 Redis 存储已弃用（限流为进程内实现，不依赖 Redis） |
-| 前端 | Vue 3 + Vite | OAuth2 授权码流程的 SPA 客户端 |
-| 部署 | Docker Compose | 本地与类生产全栈部署 |
-| 可观测 | Prometheus | 经 Drogon PromExporter 采集指标 |
+| Web framework | Drogon | High-performance asynchronous C++ HTTP services |
+| Primary database | PostgreSQL 17 | Persistence for users, roles, clients, authorization codes, and tokens (deployment default since 2026-08-18; the server also runs on 15 — see [PG Major-Version Upgrade](../operate/postgresql-major-upgrade.md) for the upgrade path) |
+| Cache / KV | Redis | Optional L2 cache in front of Postgres (client and access-token read paths); the standalone Redis store is deprecated (rate limiting is implemented in-process and does not depend on Redis) |
+| Frontend | Vue 3 + Vite | SPA client for the OAuth2 authorization-code flow |
+| Deployment | Docker Compose | Local and production-like full-stack deployment |
+| Observability | Prometheus | Metrics collected via the Drogon PromExporter |
 
-## 2. 模块布局
+## 2. Module Layout
 
-为保证真正的可插拔，项目重构为「核心插件库 + 演示服务器」两层：
+To keep the system genuinely pluggable, the project is structured as two tiers: a core plugin library plus a demo server:
 
 ```text
 HTTP 请求
@@ -44,7 +44,7 @@ HTTP 请求
           `-- RedisRepositoryBundle：Redis 存储（libs/storage-redis）
 ```
 
-## 3. 授权码流程
+## 3. Authorization-Code Flow
 
 ```mermaid
 sequenceDiagram
@@ -68,40 +68,42 @@ sequenceDiagram
     Core-->>SPA: userinfo JSON
 ```
 
-## 4. 存储策略
+## 4. Storage Strategy
 
-`OAuth2Plugin` 依据 `config.json` 中的 `storage_type` 选择后端。
+`OAuth2Plugin` selects the backend according to `storage_type` in `config.json`.
 
-| storage_type | 实现 | 典型用途 |
+| storage_type | Implementation | Typical use |
 |---|---|---|
-| memory | `MemoryRepositoryBundle` | 单元测试与本地快速演示 |
-| redis | `RedisRepositoryBundle` | **已弃用**——启动时打 ERROR 日志，并以 `unsupported_grant_type` 拒绝 `refresh_token` 授权；不要使用。Redis 现在仅作为 Postgres 前置的可选缓存层（见[配置指南 §3](../operate/configuration-guide.md)） |
-| postgres | `PostgresRepositoryBundle` | 生产持久化存储 |
+| memory | `MemoryRepositoryBundle` | Unit tests and fast local demos |
+| redis | `RedisRepositoryBundle` | **Deprecated** — logs an ERROR at startup and rejects the `refresh_token` grant with `unsupported_grant_type`; do not use. Redis now serves only as an optional cache layer in front of Postgres (see [Configuration Guide §3](../operate/configuration-guide.md)) |
+| postgres | `PostgresRepositoryBundle` | Production persistent storage |
 
-> 每个 `*RepositoryBundle` 同时装配同一后端下的 client / grant / token / consent / userinfo 五个仓储实现（见各 `libs/storage-*/include` 下的头文件）。
+> Each `*RepositoryBundle` assembles all five repository implementations for its backend — client / grant / token / consent / userinfo (see the headers under each `libs/storage-*/include`).
 
-## 5. 前后端集成
+## 5. Frontend–Backend Integration
 
-前端从登录页发起 OAuth2 授权码流程：将 CSRF `state` 存于 localStorage，
-处理 `/callback`、用授权码换取令牌，随后调用 `/oauth2/userinfo`。
+The frontend starts the OAuth2 authorization-code flow from the login page: it stores
+the CSRF `state` in localStorage, handles `/callback`, exchanges the authorization
+code for tokens, and then calls `/oauth2/userinfo`.
 
-第三方社交登录时，前端接收外部授权码后提交给后端端点：
+For third-party social login, the frontend receives the external authorization code
+and submits it to backend endpoints:
 
 - `/api/google/login`
 - `/api/wechat/login`
 
-与 provider 的令牌交换在服务端完成，provider 密钥不暴露给浏览器。
+Token exchange with the provider happens on the server side; provider secrets are never exposed to the browser.
 
-## 6. 部署形态
+## 6. Deployment Topology
 
-Docker Compose 默认启动：
+Docker Compose starts the following by default:
 
-- `fulla-frontend`：端口 `8080`
-- `fulla-admin`（管理后台）：端口 `8081`
-- `fulla-backend`：端口 `5555`
-- PostgreSQL：宿主端口 `5433`
-- Redis：宿主端口 `6380`
-- Prometheus：端口 `9090`
+- `fulla-frontend`: port `8080`
+- `fulla-admin` (admin console): port `8081`
+- `fulla-backend`: port `5555`
+- PostgreSQL: host port `5433`
+- Redis: host port `6380`
+- Prometheus: port `9090`
 
-生产环境建议在反向代理终结 TLS，再将 API 请求代理到 Drogon 后端
-（完整步骤见[生产部署](../operate/deployment.md)）。
+For production, terminate TLS at a reverse proxy and proxy API requests to the Drogon
+backend (see [Production Deployment](../operate/deployment.md) for the full procedure).

--- a/docs/architecture/data-persistence.md
+++ b/docs/architecture/data-persistence.md
@@ -1,27 +1,27 @@
-# OAuth2 数据持久化文档 (Data Persistence)
+# OAuth2 Data Persistence
 
-本文档详细描述了 OAuth2 插件的持久化层设计、数据库 Schema、Redis 键值结构以及安全加固方案。
+This document describes the OAuth2 plugin's persistence layer design, database schema, Redis key-value structure, and security hardening.
 
-## 1. 设计目标
+## 1. Design Goals
 
-- **存储解耦**：通过仓储接口（`libs/oauth2/include/fulla/oauth2/repository/` 下的 `IClientRepository`、`IGrantRepository`、`ITokenRepository` 等）抽象，支持内存、PostgreSQL、Redis 等多种存储后端，各后端以 `*RepositoryBundle` 装配实现。
-- **数据持久化**：确保 Client 信息、Token、Auth Code 等关键数据不丢失。
-- **安全加固**：Client Secret 绝不明文存储，强制使用 SHA256 加盐哈希。
-- **异步高性能**：底层操作全部采用 `execSqlAsync` 和 `execCommandAsync`，基于回调机制，充分利用 Drogon 的非阻塞 I/O 能力。
+- **Storage decoupling**: repository interfaces (`IClientRepository`, `IGrantRepository`, `ITokenRepository`, etc. under `libs/oauth2/include/fulla/oauth2/repository/`) abstract over multiple storage backends such as memory, PostgreSQL, and Redis; each backend is assembled as a `*RepositoryBundle` implementation.
+- **Data durability**: ensure that critical data — client information, tokens, auth codes — is never lost.
+- **Security hardening**: client secrets are never stored in plaintext; salted SHA256 hashing is mandatory.
+- **Asynchronous, high performance**: all low-level operations use `execSqlAsync` and `execCommandAsync` on a callback basis, fully exploiting Drogon's non-blocking I/O.
 
 ---
 
-## 2. PostgreSQL 存储方案
+## 2. PostgreSQL Storage
 
-适用于生产环境，提供严格的全部关系型数据一致性。
+Suited to production environments; provides strict, full relational data consistency.
 
 ### 2.1 Database Schema
 
-由迁移脚本 `apps/server/migrations/V002__oauth2_core.sql` 创建（幂等，`IF NOT EXISTS`；后续迁移会追加 scopes、device codes、lockout 等列）。核心表结构如下：
+Created by the migration script `apps/server/migrations/V002__oauth2_core.sql` (idempotent, `IF NOT EXISTS`; subsequent migrations add scopes, device codes, lockout, and other columns). The core tables:
 
-#### 客户端表 (`oauth2_clients`)
+#### Client table (`oauth2_clients`)
 
-存储接入的客户端应用信息。
+Stores information about registered client applications.
 
 ```sql
 CREATE TABLE IF NOT EXISTS oauth2_clients (
@@ -35,9 +35,9 @@ CREATE TABLE IF NOT EXISTS oauth2_clients (
 );
 ```
 
-#### 授权码表 (`oauth2_codes`)
+#### Authorization-code table (`oauth2_codes`)
 
-短期有效的授权凭证。
+Short-lived authorization credentials.
 
 ```sql
 CREATE TABLE IF NOT EXISTS oauth2_codes (
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS oauth2_codes (
 );
 ```
 
-#### 访问令牌表 (`oauth2_access_tokens`)
+#### Access-token table (`oauth2_access_tokens`)
 
 ```sql
 CREATE TABLE IF NOT EXISTS oauth2_access_tokens (
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS oauth2_access_tokens (
 );
 ```
 
-#### 刷新令牌表 (`oauth2_refresh_tokens`)
+#### Refresh-token table (`oauth2_refresh_tokens`)
 
 ```sql
 CREATE TABLE IF NOT EXISTS oauth2_refresh_tokens (
@@ -91,34 +91,36 @@ CREATE TABLE IF NOT EXISTS oauth2_refresh_tokens (
 
 ---
 
-## 3. Redis 存储方案（已弃用）
+## 3. Redis Storage (Deprecated)
 
-> **⚠️ 独立 Redis 存储已弃用（F-005）**：该模式启动时打 ERROR 日志，并以
-> `unsupported_grant_type` 拒绝 `refresh_token` 授权；历史上 refresh token
-> 从未在该模式持久化。新部署一律用 `postgres` + 可选 Redis 缓存层（§缓存
-> 一致性）。以下键空间仅作存量部署参考。
+> **⚠️ The standalone Redis storage mode is deprecated (F-005)**: in this mode the server logs an
+> ERROR at startup and rejects the `refresh_token` grant with `unsupported_grant_type`;
+> historically, refresh tokens were never persisted in this mode. New deployments must use
+> `postgres` plus the optional Redis cache layer (§ Cache Consistency). The key space below is
+> kept only as a reference for existing deployments.
 
-### 3.1 Key Pattern 设计
+### 3.1 Key Pattern Design
 
-所有 Key 均以 `oauth2:` 前缀开头（缓存层另有独立的 `fulla:cache:` 前缀，
-事务协调键族 `oauth2:transaction:*` 未列入下表）。
+All keys are prefixed with `oauth2:` (the cache layer has its own separate `fulla:cache:`
+prefix; the transaction-coordination key family `oauth2:transaction:*` is not listed in the
+table below).
 
-| 实体 | Key 格式 | 类型 | TTL | 说明 |
+| Entity | Key format | Type | TTL | Notes |
 |------|-------------|------|-----|------|
-| **Client** | `oauth2:client:{client_id}` | Hash | 无 | 字段: `secret` (Hash), `salt`, `redirect_uris` (JSON), `allowed_scopes` (JSON) |
-| **Auth Code** | `oauth2:code:{code}` | String | 10分钟 | Value: JSON 序列化对象 |
-| **Access Token** | `oauth2:token:{token}` | String | 1小时 | Value: JSON 序列化对象 |
-| **Refresh Token**| `oauth2:refresh:{token}` | String | 30天 | Value: JSON 序列化对象 |
+| **Client** | `oauth2:client:{client_id}` | Hash | none | Fields: `secret` (hash), `salt`, `redirect_uris` (JSON), `allowed_scopes` (JSON) |
+| **Auth Code** | `oauth2:code:{code}` | String | 10 minutes | Value: JSON-serialized object |
+| **Access Token** | `oauth2:token:{token}` | String | 1 hour | Value: JSON-serialized object |
+| **Refresh Token**| `oauth2:refresh:{token}` | String | 30 days | Value: JSON-serialized object |
 
-### 3.2 示例数据
+### 3.2 Sample Data
 
-**Client (Hash Structure)**:
+**Client (Hash structure)**:
 
 ```bash
 HSET oauth2:client:vue-client secret "42a121b66fb9f1d4f73125788f42eb6799110c6aeae5a9a12a2fed5307a0088d" salt "random_salt" redirect_uris "[\"http://localhost:5173/callback\"]"
 ```
 
-**Auth Code (String Value)**:
+**Auth Code (String value)**:
 
 ```json
 {
@@ -133,26 +135,26 @@ HSET oauth2:client:vue-client secret "42a121b66fb9f1d4f73125788f42eb6799110c6aea
 
 ---
 
-## 4. 安全加固 (Security Hardening)
+## 4. Security Hardening
 
-为了防止数据库泄露导致 Client Secret 暴露，本系统实施了强制哈希策略。
+To prevent client-secret exposure in the event of a database breach, the system enforces a strict hashing policy.
 
-### 4.1 算法与流程
+### 4.1 Algorithm and Flow
 
-1. **存储时**：
-    - 生成随机 `salt`（可选，但在 Postgres Schema 中建议预留）。
-    - 计算 `Hash = SHA256(raw_secret + salt)`。
-    - 数据库存储 `Hash` (Hex String) 和 `salt`。
+1. **On storage**:
+    - Generate a random `salt` (optional, but recommended to reserve in the Postgres schema).
+    - Compute `Hash = SHA256(raw_secret + salt)`.
+    - Store `Hash` (hex string) and `salt` in the database.
 
-2. **验证时**：
-    - 用户提交 `input_secret`。
-    - 系统读取库中的 `stored_hash` 和 `salt`。
-    - 计算 `CheckHash = SHA256(input_secret + salt)`。
-    - 比对 `CheckHash` 与 `stored_hash` (忽略大小写)。
+2. **On validation**:
+    - The client submits `input_secret`.
+    - The system reads `stored_hash` and `salt` from the database.
+    - Compute `CheckHash = SHA256(input_secret + salt)`.
+    - Compare `CheckHash` with `stored_hash` (case-insensitive).
 
-### 4.2 代码实现
+### 4.2 Code
 
-位于 `RedisClientRepository::validateClient` 和 `PostgresClientRepository::validateClient` 中。
+Implemented in `RedisClientRepository::validateClient` and `PostgresClientRepository::validateClient`.
 
 ```cpp
 // 核心逻辑示例
@@ -163,21 +165,21 @@ return lower(calculatedHash) == lower(storedHash);
 
 ---
 
-## 5. 数据生命周期管理 (Data Lifecycle)
+## 5. Data Lifecycle Management
 
-为了防止数据库无限增长，系统实现了自动化的过期数据清理机制。
+To keep the database from growing without bound, the system implements an automated expired-data cleanup mechanism.
 
-### 5.1 策略概览
+### 5.1 Policy Overview
 
-| 存储后端 | 清理策略 | 实现机制 | 频率 |
+| Storage backend | Cleanup strategy | Mechanism | Frequency |
 |----------|----------|----------|------|
-| **Redis** | **TTL 自动清理** | 依赖 Redis 原生 `SETEX`/`EXPIRE` 机制，无需应用层干预。 | 实时 |
-| **PostgreSQL**| **定期删除** | 由 `OAuth2CleanupService` 调用 `IGrantRepository` / `ITokenRepository` 的清理方法删除过期 Auth Code、Access/Refresh Token。 | 默认每 1 小时 |
-| **Memory** | **定期扫描** | 同上，由 `OAuth2CleanupService` 触发各仓储的过期清理。 | 默认每 1 小时 |
+| **Redis** | **TTL auto-expiry** | Relies on Redis-native `SETEX`/`EXPIRE`; no application-layer involvement. | Real time |
+| **PostgreSQL**| **Periodic deletion** | `OAuth2CleanupService` calls the cleanup methods of `IGrantRepository` / `ITokenRepository` to delete expired auth codes and access/refresh tokens. | Default: every 1 hour |
+| **Memory** | **Periodic scan** | Same as above; `OAuth2CleanupService` triggers each repository's expiry cleanup. | Default: every 1 hour |
 
-### 5.2 调度器实现
+### 5.2 Scheduler Implementation
 
-清理由独立的 `OAuth2CleanupService`（`libs/drogon/src/plugin/OAuth2CleanupService.cc`）承担，在 `OAuth2Plugin::initAndStart` 中创建并启动，间隔由插件配置项 `cleanup_interval_seconds` 控制（默认 `3600`，见 `config.json`）：
+Cleanup is performed by a dedicated `OAuth2CleanupService` (`libs/drogon/src/plugin/OAuth2CleanupService.cc`), created and started in `OAuth2Plugin::initAndStart`; the interval is controlled by the plugin configuration key `cleanup_interval_seconds` (default `3600`; see `config.json`):
 
 ```cpp
 cleanupService_ = std::make_shared<OAuth2CleanupService>(grantRepo_, tokenRepo_);
@@ -185,49 +187,54 @@ double cleanupInterval = config.get("cleanup_interval_seconds", 3600.0).asDouble
 cleanupService_->start(cleanupInterval);
 ```
 
-服务内部用 `drogon::app().getLoop()->runEvery(interval, ...)` 周期触发，并通过 `weak_from_this()` 防止在销毁后回调。
+Internally the service uses `drogon::app().getLoop()->runEvery(interval, ...)` for periodic firing, and `weak_from_this()` to guard against callbacks after destruction.
 
-### 5.3 接口定义
+### 5.3 Interface Definition
 
-清理不再集中于单一的 `IOAuth2Storage::deleteExpiredData`；而是按仓储拆分，由 `IGrantRepository`（Auth Code）与 `ITokenRepository`（Access/Refresh Token）各自提供过期删除方法，由 `OAuth2CleanupService` 编排调用。
+Cleanup is no longer concentrated in a single `IOAuth2Storage::deleteExpiredData`; it is split per repository — `IGrantRepository` (auth codes) and `ITokenRepository` (access/refresh tokens) each expose their own expired-deletion methods, orchestrated by `OAuth2CleanupService`.
 
-## 6. 存储后端选型与 Memory 后端警告 (F-031)
+## 6. Storage Backend Selection and the Memory-Backend Warning (F-031)
 
-> **⚠️ Memory 存储后端仅供测试 / 开发使用，生产环境禁用。**
+> **⚠️ The memory storage backend is for testing/development only; it must not be used in production.**
 
-`storage_type="memory"`（见 `config.ci.json`）将所有 client / token / code /
-consent 数据保存在进程内存中，**密钥（client_secret）以明文存储**（不经
-SHA-256 加盐哈希），且：
+`storage_type="memory"` (see `config.ci.json`) keeps all client / token / code / consent
+data in process memory, with **secrets (client_secret) stored in plaintext** (no SHA-256
+salted hashing), and:
 
-- 进程重启即丢失全部数据（无持久化）；
-- 无多用户 / 多实例共享（每个进程一份独立状态）；
-- 无事务、无原子 CAS 保证（测试桩实现）；
-- Memory identity 仓库永远从 `findByUsername` 返回 `nullopt`，因此 admin
-  登录链路在该模式下不可用（`loginAsAdmin()` 返回 `nullopt`，依赖它的集成
-  测试会干净跳过）。
+- All data is lost on process restart (no persistence);
+- No multi-user / multi-instance sharing (each process holds an independent copy of the state);
+- No transactions, no atomic CAS guarantees (test-stub implementation);
+- The memory identity repository always returns `nullopt` from `findByUsername`, so the
+  admin login path is unavailable in this mode (`loginAsAdmin()` returns `nullopt`;
+  integration tests that depend on it skip cleanly).
 
-**生产部署必须使用 `storage_type="postgres"`**（Postgres 是唯一受支持的生产
-存储后端；独立 Redis 存储模式已弃用，见 F-005 / [配置指南 §3](../operate/configuration-guide.md)）。
-Memory 后端存在的唯一目的是让 Windows / macOS CI 环境在无 Postgres 时仍能
-跑通不依赖 DB 的测试用例（contract 测试、纯单测、协议错误信封测试等）。
+**Production deployments must use `storage_type="postgres"`** (Postgres is the only supported
+production storage backend; the standalone Redis storage mode is deprecated — see F-005 /
+[Configuration Guide §3](../operate/configuration-guide.md)). The only reason the memory
+backend exists is to let Windows/macOS CI environments run the DB-independent test cases
+(contract tests, pure unit tests, protocol error-envelope tests, etc.) when no Postgres is
+available.
 
-## 数据一致性专题
+## Data Consistency Notes
 
-### 授权码单次使用（防双花）
+### Authorization-code single use (anti double-spend)
 
-`consumeAuthCode` 在存储层保证原子性：PostgreSQL 用 `UPDATE ... WHERE consumed = false ... RETURNING`
-（raw SQL 豁免条款）；Redis 后端用 Lua 脚本；Memory 后端用互斥锁。契约由
-`tests/contract/GrantRepositoryContractTest.cc` 的三实现同测覆盖。
+`consumeAuthCode` guarantees atomicity at the storage layer: PostgreSQL uses `UPDATE ... WHERE consumed = false ... RETURNING`
+(a raw-SQL exemption); the Redis backend uses a Lua script; the memory backend uses a mutex. The contract
+is covered for all three implementations by `tests/contract/GrantRepositoryContractTest.cc`.
 
-### 缓存一致性：延迟双删
+### Cache consistency: delayed double-delete
 
-Redis L2 缓存（键前缀 `fulla:cache:`）的写路径失效采用**延迟双删**：立即 DEL + 事件循环上
-延迟二次 DEL（默认 200ms，`cache.invalidation_double_delete_delay_ms` 可配，钳位 [50,2000]），
-以覆盖"读线程在 DEL 前刚回填旧值"的竞态窗口（issue #79）。二次 DEL 失败可观测：
-`fulla_cache_invalidation_failures_total{kind}` 计数器（issue #80）。读路径为 cache-aside，
-未命中回源 PostgreSQL 后回填（TTL 兜底最终一致）。
+Write-path invalidation for the Redis L2 cache (key prefix `fulla:cache:`) uses a **delayed
+double-delete**: an immediate DEL plus a second, delayed DEL on the event loop (default 200ms,
+configurable via `cache.invalidation_double_delete_delay_ms`, clamped to [50,2000]). This covers
+the race window where "a reader thread backfills a stale value just before the DEL" (issue #79).
+Second-DEL failures are observable via the `fulla_cache_invalidation_failures_total{kind}`
+counter (issue #80). The read path is cache-aside: on a miss it falls through to PostgreSQL and
+backfills (with TTL as the eventual-consistency backstop).
 
-### refresh token 家族与级联撤销
+### Refresh-token families and cascading revocation
 
-refresh token 存储家族标识（V008），检测到重放即撤销整个家族；撤销可按 token / client / user
-三个粒度发起（管理 API 与 `/oauth2/revoke`）。
+Refresh tokens store a family identifier (V008); on detected replay the entire family is
+revoked. Revocation can be initiated at three granularities — per token / per client / per
+user (admin API and `/oauth2/revoke`).

--- a/docs/architecture/security-architecture.md
+++ b/docs/architecture/security-architecture.md
@@ -1,96 +1,96 @@
-# OAuth2 安全架构设计 (Security Architecture)
+# OAuth2 Security Architecture
 
-本文档详细描述了本系统的安全威胁模型及相应的防御机制，涵盖 Token 生命周期管理、加密存储及防攻击策略。
+This document describes the system's security threat model and the corresponding defense mechanisms, covering token lifecycle management, secret storage, and anti-attack strategies.
 
-## 1. 威胁模型与防御 (Threat Model)
+## 1. Threat Model
 
-| 威胁类型 | 描述 | 防御机制 | 对应文档 |
+| Threat | Description | Defense | Related docs |
 |----------|------|----------|----------|
-| **Replay Attack** (重放攻击) | 攻击者截获 Auth Code 并在合法客户端之前或之后尝试兑换。 | **Atomic Consume** (原子消费) + **One-Time Use Enforcement**。 | [Data Consistency](data-persistence) |
-| **Credential Leakage** (凭据泄露) | 数据库被拖库导致 Client Secret 泄露。 | **SHA256 Salted Hash**。数据库仅存 Hash 值，绝不存明文。 | [Data Persistence](data-persistence) |
-| **Token Theft** (令牌窃取) | Access Token 被截获。 | **Short-lived Token** (1小时) + **Refresh Token Rotation** (轮转机制)。 | 本文档 |
-| **CSRF** | 攻击者诱导用户进行非预期的授权。 | 强制校验 **state** 参数 (推荐客户端实现)。 | [API Reference](../domains/api-reference.md) |
+| **Replay Attack** | An attacker intercepts an auth code and attempts to redeem it before or after the legitimate client. | **Atomic Consume** + **One-Time Use Enforcement**. | [Data Consistency](data-persistence) |
+| **Credential Leakage** | A database breach leaks client secrets. | **SHA256 Salted Hash**. The database stores only hashes, never plaintext. | [Data Persistence](data-persistence) |
+| **Token Theft** | An access token is intercepted. | **Short-lived Token** (1 hour) + **Refresh Token Rotation**. | This document |
+| **CSRF** | An attacker tricks a user into an unintended authorization. | Mandatory validation of the **state** parameter (recommended for clients to implement). | [API Reference](../domains/api-reference.md) |
 
-## 2. Token 生命周期管理
+## 2. Token Lifecycle Management
 
 ### 2.1 Access Token
 
-- **有效期**: 1小时。
-- **用途**: 访问受保护资源（如 `/userinfo`）。
-- **验证**: 无状态（JWT）或有状态（DB 查询）。本项目采用 **有状态** 验证，支持即时撤销。
+- **Lifetime**: 1 hour.
+- **Purpose**: Access to protected resources (e.g. `/userinfo`).
+- **Validation**: stateless (JWT) or stateful (DB lookup). This project uses **stateful** validation, which supports immediate revocation.
 
 ### 2.2 Refresh Token
 
-- **有效期**: 30天。
-- **用途**: 在 Access Token 过期后换取新 Token。
-- **安全机制: 轮转 (Rotation)**
-  - 每次刷新时，不仅颁发新的 Access Token，也会 **颁发新的 Refresh Token**。
-  - 旧的 Refresh Token 立即失效。
-  - **检测机制**: 如果检测到旧 Refresh Token 被再次使用，系统可视为 Token 泄露，并级联撤销该 `token_family` 下的所有关联 Token（已实现，见 §7.2）。
+- **Lifetime**: 30 days.
+- **Purpose**: Exchanged for a new token once the access token has expired.
+- **Security mechanism: Rotation**
+  - On every refresh, the server issues not only a new access token but also **a new refresh token**.
+  - The old refresh token is invalidated immediately.
+  - **Detection**: If an old refresh token is presented again, the system treats it as token theft and cascades revocation of every token under that `token_family` (implemented; see §7.2).
 
-## 3. 密钥管理 (Secrets Management)
+## 3. Secrets Management
 
 ### 3.1 Client Secrets
 
-- **存储**: `sha256(secret + salt)`
-- **传输**: 仅在 POST body 中通过 HTTPS 传输。
+- **Storage**: `sha256(secret + salt)`
+- **Transport**: Only over HTTPS, in the POST body.
 
-### 3.2 配置文件
+### 3.2 Configuration Files
 
-- 敏感信息（如 DB 密码、Redis 密码）建议通过 **环境变量** 注入，而非硬编码在 `config.json` 中。
-- 生产环境部署时，应确保配置文件权限严格限制。
+- Sensitive values (such as DB and Redis passwords) should be injected via **environment variables** rather than hardcoded in `config.json`.
+- In production deployments, configuration file permissions should be strictly restricted.
 
-## 4. 最佳实践建议
+## 4. Best-Practice Recommendations
 
-- **HTTPS**: 生产环境 **必须** 启用 HTTPS/TLS，否则 OAuth2 毫无安全性可言。
-- **PKCE**: 对于移动端/SPA 客户端，建议开启 PKCE (Proof Key for Code Exchange) 模式（本后端已实现并对 PUBLIC 客户端默认强制启用，支持 `plain` 与 `S256`）。
-- **IP 白名单**: 对于高权限 Client，建议限制 Token 兑换的源 IP。
+- **HTTPS**: Production **must** enable HTTPS/TLS; without it, OAuth2 offers no security whatsoever.
+- **PKCE**: Mobile/SPA clients should enable PKCE (Proof Key for Code Exchange) — this backend implements it and enforces it by default for PUBLIC clients, supporting both `plain` and `S256`.
+- **IP allowlist**: For high-privilege clients, restrict the source IPs allowed to redeem tokens.
 
-## 5. Token 存储安全 (Token Storage)
+## 5. Token Storage Security
 
-所有 Token（Access Token、Refresh Token）在数据库中 **仅存储 SHA-256 哈希值**，绝不存储明文。
+All tokens (access tokens, refresh tokens) are stored in the database **as SHA-256 hashes only** — never in plaintext.
 
-- **存储格式**: `SHA-256(token_value)`
-- **验证流程**: 客户端提交 Token → 服务端计算哈希 → 与数据库哈希比对
-- **优势**: 即使数据库泄露，攻击者无法还原出有效 Token
+- **Storage format**: `SHA-256(token_value)`
+- **Validation flow**: client submits token → server computes the hash → compares against the stored hash
+- **Benefit**: Even if the database leaks, an attacker cannot recover a valid token
 
-## 6. 密码哈希策略 (Password Hashing)
+## 6. Password Hashing Policy
 
-### 6.1 当前标准 (OWASP 2023)
+### 6.1 Current Standard (OWASP 2023)
 
-- **算法**: PBKDF2-SHA256
-- **迭代次数**: 310,000 次（符合 OWASP 2023 推荐）
-- **Salt**: 每用户独立随机 Salt（16 字节）
-- **输出**: 32 字节密钥
+- **Algorithm**: PBKDF2-SHA256
+- **Iterations**: 310,000 (per the OWASP 2023 recommendation)
+- **Salt**: A unique random salt per user (16 bytes)
+- **Output**: 32-byte key
 
-### 6.2 遗留密码迁移
+### 6.2 Legacy Password Migration
 
-系统支持从旧版 SHA-256 单次哈希渐进式迁移到 PBKDF2：
+The system supports gradual migration from the legacy single-iteration SHA-256 hashing to PBKDF2:
 
-1. 用户登录时，系统检测密码哈希格式
-2. 若为旧格式（SHA-256），验证通过后自动升级为 PBKDF2
-3. 迁移对用户透明，无需重置密码
+1. On login, the system detects the password hash format
+2. If it is the legacy format (SHA-256), the hash is automatically upgraded to PBKDF2 after successful verification
+3. The migration is transparent to users; no password reset is required
 
-## 7. Refresh Token 轮转与家族追踪 (Refresh Token Rotation)
+## 7. Refresh Token Rotation and Family Tracking
 
-### 7.1 家族追踪机制 (Family-Based Tracking)
+### 7.1 Family-Based Tracking
 
-每个 Refresh Token 链共享一个 `token_family` 标识符：
+Every refresh-token chain shares a `token_family` identifier:
 
-- 首次颁发 RT 时生成唯一 `token_family` ID
-- 后续轮转的 RT 继承同一 `token_family`
-- 系统可追踪整个 Token 链的生命周期
+- A unique `token_family` ID is generated when the first RT is issued
+- Subsequent rotated RTs inherit the same `token_family`
+- The system can track the lifecycle of the entire token chain
 
-### 7.2 重用检测与级联撤销
+### 7.2 Reuse Detection and Cascading Revocation
 
-当检测到已撤销的 Refresh Token 被再次使用时：
+When a revoked refresh token is presented again:
 
-1. **检测**: 收到的 RT 在数据库中标记为已撤销
-2. **判定**: 视为 Token 泄露（攻击者持有旧 RT）
-3. **响应**: 级联撤销该 `token_family` 下的 **所有** Token
-4. **结果**: 合法用户和攻击者均需重新认证
+1. **Detection**: The received RT is marked revoked in the database
+2. **Verdict**: Treated as token theft (the attacker holds an old RT)
+3. **Response**: Cascading revocation of **all** tokens under that `token_family`
+4. **Outcome**: Both the legitimate user and the attacker must re-authenticate
 
-### 7.3 时序图
+### 7.3 Sequence Diagram
 
 ```mermaid
 sequenceDiagram
@@ -105,49 +105,56 @@ sequenceDiagram
     U--xA: 下次请求失败，需重新登录
 ```
 
-## 8. Subject 隐私保护 (Subject Privacy)
+## 8. Subject Privacy
 
 ### 8.1 UUID public_sub
 
-- **外部标识**: 使用 UUID v4 作为 `public_sub`（公开主体标识符）
-- **内部标识**: 数据库自增 ID 仅用于内部关联
-- **防枚举**: UUID 不可预测，攻击者无法通过递增 ID 枚举用户
-- **OIDC 兼容**: `id_token` 中的 `sub` claim 使用 `public_sub`
+- **External identifier**: UUID v4 is used as the `public_sub` (public subject identifier)
+- **Internal identifier**: The database auto-increment ID is used only for internal joins
+- **Anti-enumeration**: UUIDs are unpredictable; attackers cannot enumerate users by incrementing IDs
+- **OIDC compatibility**: The `sub` claim in `id_token` uses `public_sub`
 
-### 8.2 对比
+### 8.2 Comparison
 
-| 方案 | 可枚举 | 信息泄露 | OIDC 兼容 |
+| Approach | Enumerable | Information leakage | OIDC compatible |
 |------|--------|----------|-----------|
-| 自增 ID | ✗ 可预测 | 泄露用户数量 | ✓ |
-| UUID public_sub | ✓ 不可预测 | 无信息泄露 | ✓ |
+| Auto-increment ID | ✗ predictable | Leaks the user count | ✓ |
+| UUID public_sub | ✓ unpredictable | No information leakage | ✓ |
 
-## HTTP 安全响应头
+## HTTP Security Response Headers
 
-全局中间件为所有响应附加：`X-Content-Type-Options: nosniff`、`X-Frame-Options: DENY`、
-`Referrer-Policy: strict-origin-when-cross-origin`、`Content-Security-Policy`（API 域收敛策略）。
+A global middleware attaches the following to every response: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`,
+`Referrer-Policy: strict-origin-when-cross-origin`, and `Content-Security-Policy` (a restrictive policy for the API domain).
 
-## 全局限流：Hodor（仅生产配置启用）
+## Global Rate Limiting: Hodor (enabled in production configuration only)
 
-全局侧限流由 Drogon 官方 **Hodor** 插件承担（令牌桶 + 进程内 CacheMap，IP/用户/全局三级），
-**只在 `config.prod.json` 挂载**（开发配置不含该插件）。当前生产阈值（以 `config.prod.json`
-为准，此处为快照）：`/oauth2/login` IP 容量 3 / 用户容量 2；`/oauth2/token` 5/min；其余端点
-全局 5000、每 IP 30。拒绝响应经错误信封 `VALIDATION_RATE_LIMITED`（429）返回。
+Global-side rate limiting is handled by Drogon's official **Hodor** plugin (token bucket +
+in-process CacheMap, at the IP/user/global levels), and it is **mounted only in `config.prod.json`**
+(the development configuration does not include the plugin). Current production thresholds
+(authoritative source is `config.prod.json`; this is a snapshot): `/oauth2/login` IP capacity 3 /
+user capacity 2; `/oauth2/token` 5/min; all other endpoints 5000 global and 30 per IP. Rejected
+responses are returned via the error envelope `VALIDATION_RATE_LIMITED` (429).
 
-> 注意与 F-018 的关系：这是**全局侧**限流（任意请求，防扫）；`configuration-guide` §8 的
-> 进程内失败计数限流是**认证侧**防爆破（login/token 失败计数），两者并存、作用面不同。
+> Note on the relationship to F-018: this is **global-side** rate limiting (any request,
+> anti-scanning); the in-process failure-count rate limiting in `configuration-guide` §8 is
+> **authentication-side** brute-force protection (login/token failure counts). The two coexist
+> and cover different surfaces.
 
-## 安全运维清单
+## Security Operations Checklist
 
-**例行验证**：密钥不入库（`git grep` 抽查 + Secret Hygiene CI 门）；`.env*` 均被 ignore；
-前端生产构建无内嵌凭据。
+**Routine verification**: no secrets committed to the repository (`git grep` spot checks + the
+Secret Hygiene CI gate); all `.env*` files ignored; frontend production builds contain no
+embedded credentials.
 
-**密钥轮换**：JWKS 当前为单 kid 静态密钥（F-029 为后续运维任务，轮换流程未自动化）；
-DB/SMTP/社交凭据轮换 = 改 env + 滚动重启。
+**Key rotation**: JWKS currently uses a single static `kid` (F-029 is a follow-up operations
+task; the rotation procedure is not automated); rotating DB/SMTP/social credentials = change
+env vars + rolling restart.
 
-**事件响应**：泄漏怀疑 → 立即轮换受影响凭据 → 如涉历史提交，用 `git filter-repo`
-（勿用已弃用的 filter-branch）重写并强推 → 通报。
+**Incident response**: suspected leak → immediately rotate the affected credentials → if
+historical commits are involved, rewrite them with `git filter-repo` (not the deprecated
+filter-branch) and force-push → notify.
 
-**pre-commit 钩子模板**（可选）：
+**pre-commit hook template** (optional):
 
 ```bash
 #!/bin/sh

--- a/docs/benchmark/competitor-benchmark-design.md
+++ b/docs/benchmark/competitor-benchmark-design.md
@@ -1,402 +1,409 @@
-# Fulla 竞品性能基准对比设计
+# fulla Competitor Performance Benchmark Comparison Design
 
-> **版本**: v1.1（2026-08-15 评审修订：新增 M0 前置参数化、S5 池规模修正、GC 抖动场景钉死、Fulla 同 session 重跑、Zitadel JWT-profile 认证说明、warmup 口径对齐入仓数据）
-> **日期**: 2026-08-15
-> **文档性质**: 技术设计（Phase 0.5 落地蓝图，**非代码**——实施见 §七 milestone）
-> **上游规划**: [演进方案 §三 Phase 0]（productization-evolution-plan：本地维护档案） P0「自托管竞品对比基准」
-> **前置依赖**: 基准设施设计（内部档案，已随 productization-evolution 目录转为本地维护） M1–M4 已交付（S1–S6 自测数据已入仓 `benchmarks/results/`）
-> **验证对象**: 调研报告 §3.1（内部档案，已转本地维护） 竞品列（Keycloak/Ory）的量级参考数字
-
----
-
-## 零、TL;DR
-
-- **做什么**：在**同一台机器、同一套 wrk 阶梯、同一个 PostgreSQL 后端**下压 Keycloak / Ory Hydra / Zitadel，与 Fulla 已入仓的自测数据（`benchmarks/results/SUMMARY.md`）产出同口径对比表。
-- **比什么**：S1 discovery / S2 client_credentials / S3 introspect / S5 refresh_token / S6 userinfo 五个单步场景 + 冷启动 + 稳态 RSS + **GC 抖动长跑**（5 分钟 P99 时间序列——Fulla 无 GC 的核心差异化证据）。
-- **不比什么**：S4 auth_code（各产品登录/consent 流程不可 wrk 统一驱动）；Auth0（SaaS，无法自托管）；竞品的极限调优配置（一律用官方推荐生产配置）。
-- **核心原则**：公平性优先于数字好看。竞品社区会质疑，方法论必须无懈可击——同硬件、同并发阶梯、同后端、各产品官方推荐配置、脚本全部入仓可复现。
-- **验收**：四家同口径对比表（QPS / P99 / 稳态 RSS / 冷启动 / GC 抖动）落盘 `benchmarks/competitors/results/COMPARISON.md`；第三方按 README 一键复现。
+> **Version**: v1.1 (2026-08-15 review revision: adds M0 prerequisite parameterization, S5 pool-size correction, pinned GC-jitter scenario, fulla same-session rerun, Zitadel JWT-profile authentication note, warmup methodology aligned with in-repo data)
+> **Date**: 2026-08-15
+> **Document type**: Technical design (Phase 0.5 implementation blueprint, **not code** — for implementation see the §7 milestones)
+> **Upstream planning**: [Evolution Plan §3 Phase 0] (productization-evolution-plan: locally maintained archive), item P0 "self-hosted competitor comparison benchmark"
+> **Prerequisites**: Benchmark infrastructure design (internal archive, moved to local maintenance along with the productization-evolution directory), M1–M4 delivered (S1–S6 self-test data committed under `benchmarks/results/`)
+> **Verification target**: The competitor column (Keycloak/Ory) order-of-magnitude reference numbers in survey report §3.1 (internal archive, moved to local maintenance)
 
 ---
 
-## 一、目标与非目标
+## 0. TL;DR
 
-### 1.1 目标
+- **What**: Load-test Keycloak / Ory Hydra / Zitadel on the **same machine, with the same wrk ladder and the same PostgreSQL backend**, producing a like-for-like comparison table against fulla's committed self-test data (`benchmarks/results/SUMMARY.md`).
+- **What gets compared**: The five single-step scenarios S1 discovery / S2 client_credentials / S3 introspect / S5 refresh_token / S6 userinfo, plus cold start, steady-state RSS, and the **GC-jitter long run** (5-minute P99 time series — fulla's core no-GC differentiation evidence).
+- **What does not get compared**: S4 auth_code (each product's login/consent flows cannot be driven uniformly by wrk); Auth0 (SaaS, cannot be self-hosted); competitors' extreme tuned configurations (official recommended production configurations are used throughout).
+- **Core principle**: Fairness over flattering numbers. Competitor communities will challenge the results, so the methodology must be beyond reproach — same hardware, same concurrency ladder, same backend, each product's officially recommended configuration, all scripts committed and reproducible.
+- **Acceptance**: A four-product like-for-like comparison table (QPS / P99 / steady-state RSS / cold start / GC jitter) landed in `benchmarks/competitors/results/COMPARISON.md`; a third party can reproduce it one-command-style from the README.
 
-| # | 目标 | 衡量 |
+---
+
+## 1. Goals and Non-Goals
+
+### 1.1 Goals
+
+| # | Goal | Measured by |
 |---|------|------|
-| G1 | **同环境竞品对比数据**：把调研报告 §3.1 的竞品列（"来自各产品社区公开基准，非同环境对比"）替换为同环境实测 | §六验收 ✅ COMPARISON.md |
-| G2 | **验证差异化叙事**：C++ 无 GC / 低内存 / 低尾延迟的卖点是否有同环境数据支撑 | GC 抖动长跑 + 稳态 RSS 对比 |
-| G3 | **可复现**：第三方按 `benchmarks/competitors/README.md` 在同规格机器跑出误差 &lt;15% 的数据 | 复现门槛（沿用自测设施 AC1） |
-| G4 | **诚实修订**：若某维度 Fulla 不领先，据实修订调研报告 §3.1/§3.2 的卖点排序 | 报告更新 |
+| G1 | **Same-environment competitor data**: replace the survey report §3.1 competitor column ("from each product community's public benchmarks, not a same-environment comparison") with same-environment measurements | §6 acceptance ✅ COMPARISON.md |
+| G2 | **Validate the differentiation narrative**: whether the C++ no-GC / low-memory / low-tail-latency claims are supported by same-environment data | GC-jitter long run + steady-state RSS comparison |
+| G3 | **Reproducible**: a third party following `benchmarks/competitors/README.md` on an identically specced machine obtains data within &lt;15% deviation | Reproduction threshold (reusing the self-test infrastructure's AC1) |
+| G4 | **Honest revision**: if fulla does not lead on some dimension, revise the claim ordering in survey report §3.1/§3.2 accordingly | Report update |
 
-### 1.2 非目标
+### 1.2 Non-Goals
 
-| # | 非目标 | 为什么 / 归属 |
+| # | Non-Goal | Why / owner |
 |---|--------|--------------|
-| N1 | Auth0 / Okta 等托管竞品 | SaaS 无法自托管、无法控制环境；其公开数字不可复现。仅保留在调研报告的量级参考里 |
-| N2 | S4 auth_code 场景对比 | 各产品的登录页/重定向/consent 交互流完全不同，wrk 无法统一驱动（详见 §四 D4） |
-| N3 | 竞品极限调优 | 一律官方推荐生产配置。极限调优对比是军备竞赛，无公信力；官方文档链接随结果附上 |
-| N4 | 功能/协议覆盖度对比 | 属产品能力审计（iam-architecture-audit.md），与性能无关 |
-| N5 | Fulla 阶梯数据重跑 | 同 session 仍会重跑（见 §5.1 v1.1 修正：gcjitter/RSS/冷启动必采 + R7 消漂移）；"复用"仅指沿用同一 runner/口径，2026-08-12 入仓数据降级为历史基线 |
+| N1 | Hosted competitors such as Auth0 / Okta | SaaS cannot be self-hosted and the environment cannot be controlled; their public numbers are not reproducible. They remain only as order-of-magnitude references in the survey report |
+| N2 | S4 auth_code scenario comparison | Each product's login page/redirect/consent interaction flows are completely different; wrk cannot drive them uniformly (see §4 D4) |
+| N3 | Competitor extreme tuning | Officially recommended production configurations only. Extreme-tuning comparisons are an arms race with no credibility; official documentation links are attached alongside the results |
+| N4 | Feature/protocol coverage comparison | That belongs to a product capability audit (iam-architecture-audit.md) and is unrelated to performance |
+| N5 | Rerunning the fulla ladder data | fulla is still rerun in the same session (see the §5.1 v1.1 revision: gcjitter/RSS/cold start are mandatory + R7 eliminates drift); "reuse" only means reusing the same runner/methodology — the 2026-08-12 in-repo data is demoted to a historical baseline |
 
 ---
 
-## 二、背景：为什么现在做
+## 2. Background: Why Now
 
-### 2.1 Phase 0 已完成自测，对比是最后缺口
+### 2.1 Phase 0 self-testing is done; the comparison is the last gap
 
-Phase 0（benchmark M1–M4）已于 2026-08-12 交付：S1–S6 六场景、40 个 JSON、承重验证报告（`benchmarks/results/SUMMARY.md`）。Fulla 自身数字已可信。
+Phase 0 (benchmark M1–M4) was delivered on 2026-08-12: six scenarios S1–S6, 40 JSON files, and a load-bearing validation report (`benchmarks/results/SUMMARY.md`). fulla's own numbers are now credible.
 
-调研报告 §3.1 的竞品列（Keycloak ~10–20k QPS、Ory ~30–50k QPS）标注为"社区公开基准，非同环境对比，仅作量级参考"。**没有同环境对比数据，"比 Keycloak 快 N 倍"就不能出现在任何对外物里。**
+The survey report §3.1 competitor column (Keycloak ~10–20k QPS, Ory ~30–50k QPS) is annotated "public community benchmarks, not a same-environment comparison, order-of-magnitude reference only". **Without same-environment comparison data, "N× faster than Keycloak" must not appear in any external material.**
 
-### 2.2 Fulla 自测基线（对比基准，2026-08-12 实测）
+### 2.2 fulla self-test baseline (the comparison baseline, measured 2026-08-12)
 
-| 场景 | 稳态 QPS | 稳态 P99 | 错误率 |
+| Scenario | Steady-state QPS | Steady-state P99 | Error rate |
 |------|---------|---------|--------|
-| S1 discovery | 86,332 | —（低并发 &lt;1ms） | 0.006% |
-| S2 client_credentials | 8,915 | 8ms | 0.000% |
-| S3 introspect | 17,132 | 12ms | 0.000% |
-| S5 refresh_token | 1,982 | 26ms | 0.000% |
-| S6 userinfo | 16,674 | 12ms | 0.000% |
+| S1 discovery | 86,332 | — (low concurrency &lt;1 ms) | 0.006% |
+| S2 client_credentials | 8,915 | 8 ms | 0.000% |
+| S3 introspect | 17,132 | 12 ms | 0.000% |
+| S5 refresh_token | 1,982 | 26 ms | 0.000% |
+| S6 userinfo | 16,674 | 12 ms | 0.000% |
 
-环境：WSL2 8 vCPU / 16GB / PG 连接池 25 / Redis 20 / wrk 4.1.0 / 阶梯 2→128。
-详见 `benchmarks/results/SUMMARY.md`。
+Environment: WSL2 8 vCPU / 16GB / PG connection pool 25 / Redis 20 / wrk 4.1.0 / ladder 2→128.
+See `benchmarks/results/SUMMARY.md` for details.
 
-### 2.3 现有可复用资产
+### 2.3 Existing reusable assets
 
-| 资产 | 复用方式 |
+| Asset | Reuse approach |
 |------|---------|
-| `run-scenario.sh` 阶梯 runner（warmup→measure→JSON） | 竞品场景直接传不同的 `.lua`；runner 加**可选**参数（`READY_PATH`/`RESULTS_DIR`/`WRK_LIB_DIR`/`--reissue` 钩子，见 M0.1），单一实现不复制第二份 |
-| `parse-wrk.py`（wrk 文本→schema v1 JSON） | 场景无关，仅加 `--product/--product-version` 透传参数（M0.2） |
-| `observe/docker-stats.sh` + `scrape-metrics.sh` | docker-stats 加 `CONTAINER_GLOB` 参数（M0.3）采竞品容器 RSS/CPU；scrape-metrics 仅 Fulla 可用（竞品无 `/metrics` 端点，观察项拆分） |
-| `measure-cold-start.sh` 模式 | 每家竞品一个等价的冷启动计时脚本 |
-| `lib/gen-tokens.py` 思路 | 竞品 token 池生成（各家 introspect 的 token 须由其自身签发，见 D5） |
-| docker-compose 底座（PG15） | 竞品 compose 复用同一 PG 版本与连接池配置 |
+| `run-scenario.sh` ladder runner (warmup→measure→JSON) | Competitor scenarios simply pass different `.lua` files; the runner gains **optional** parameters (`READY_PATH`/`RESULTS_DIR`/`WRK_LIB_DIR`/`--reissue` hook, see M0.1) — a single implementation, no second copy |
+| `parse-wrk.py` (wrk text→schema v1 JSON) | Scenario-agnostic; only gains `--product/--product-version` pass-through parameters (M0.2) |
+| `observe/docker-stats.sh` + `scrape-metrics.sh` | docker-stats gains a `CONTAINER_GLOB` parameter (M0.3) to sample competitor container RSS/CPU; scrape-metrics remains fulla-only (competitors have no `/metrics` endpoint; observation items are split) |
+| `measure-cold-start.sh` pattern | One equivalent cold-start timing script per competitor |
+| `lib/gen-tokens.py` idea | Competitor token pool generation (each product's introspect tokens must be issued by the product itself, see D5) |
+| docker-compose base (PG15) | Competitor composes reuse the same PG version and connection pool configuration |
 
 ---
 
-## 三、关键约束与设计决策
+## 3. Key Constraints and Design Decisions
 
-### D1 — 公平性三同原则（同硬件 / 同工具 / 同后端）
+### D1 — Fairness: the three-same principle (same hardware / same tool / same backend)
 
-**这是整个方案的可信度基础。**
+**This is the credibility foundation of the entire plan.**
 
-| 维度 | 统一值 | 说明 |
+| Dimension | Unified value | Notes |
 |------|--------|------|
-| 硬件 | 同一台机器（Phase 0 用的 WSL2 8 vCPU/16GB，或后续专用裸机） | 四家依次跑，中间 `docker compose down -v` 清场 |
-| OS/内核 | 同一 WSL2 Ubuntu | — |
-| 压测工具 | wrk 4.1.0，同一份阶梯参数（2→4→8→16→32→64→128）、warmup 5s / measure 10s（与入仓自测数据口径一致；Keycloak warmup 60s，见 D2 豁免） | 复用 `run-scenario.sh`，不写第二套 runner |
-| 后端存储 | PostgreSQL 15（同一 image tag），连接池对齐 25 | 竞品各自支持的连接池上限可能 &lt;25，取 `min(25, 官方上限)` 并在结果中标注 |
-| 网络拓扑 | localhost cross-container（wrk 在宿主机） | 与自测一致 |
-| 结果格式 | schema v1 JSON（`parse-wrk.py`） | 四家数据同构，`run-comparison.sh` 才能聚合 |
-| 端口 | 各家栈固定端口（fulla 5555 / Keycloak 8080 / Hydra 4444+4445 / Zitadel 8080） | 串行执行互不冲突；每家 setup 前置断言端口空闲 |
+| Hardware | The same machine (the WSL2 8 vCPU/16GB used by Phase 0, or a later dedicated bare-metal box) | The four products run sequentially, with `docker compose down -v` cleanup in between |
+| OS/kernel | The same WSL2 Ubuntu | — |
+| Load tool | wrk 4.1.0, the same ladder parameters (2→4→8→16→32→64→128), warmup 5 s / measure 10 s (aligned with the in-repo self-test methodology; Keycloak warmup 60 s, see the D2 exemption) | Reuses `run-scenario.sh`; no second runner is written |
+| Backend storage | PostgreSQL 15 (the same image tag), connection pool aligned at 25 | A competitor's supported pool ceiling may be &lt;25; use `min(25, official ceiling)` and note it in the results |
+| Network topology | localhost cross-container (wrk on the host) | Same as the self-test |
+| Result format | schema v1 JSON (`parse-wrk.py`) | All four products' data are isomorphic, so `run-comparison.sh` can aggregate them |
+| Ports | Fixed ports per stack (fulla 5555 / Keycloak 8080 / Hydra 4444+4445 / Zitadel 8080) | Serial execution avoids conflicts; each setup asserts up front that the ports are free |
 
-### D2 — 竞品配置 = 官方推荐生产配置（不调优、不调差）
+### D2 — Competitor configuration = officially recommended production configuration (no tuning up, no tuning down)
 
-**依据**：极限调优对比无公信力；故意调差是学术造假。
+**Rationale**: Extreme-tuning comparisons have no credibility; deliberately tuning down is academic fraud.
 
-| 竞品 | 配置基线 | 官方出处 |
+| Competitor | Configuration baseline | Official source |
 |------|---------|---------|
-| Keycloak | `start --optimized` + PostgreSQL，内存按官方建议 2GB 限额 | [Running Keycloak in a container](https://www.keycloak.org/server/containers) |
-| Ory Hydra | 官方 docker-compose + PostgreSQL DSN | [Ory Hydra docs](https://www.ory.sh/docs/hydra/self-hosted/deploy-hydra) |
-| Zitadel | 官方 compose（`setup mode` 初始化 + PostgreSQL） | [Set up ZITADEL with Docker Compose](https://zitadel.com/docs/self-hosting/deploy/compose) |
+| Keycloak | `start --optimized` + PostgreSQL, memory per the official 2GB limit recommendation | [Running Keycloak in a container](https://www.keycloak.org/server/containers) |
+| Ory Hydra | Official docker-compose + PostgreSQL DSN | [Ory Hydra docs](https://www.ory.sh/docs/hydra/self-hosted/deploy-hydra) |
+| Zitadel | Official compose (`setup mode` initialization + PostgreSQL) | [Set up ZITADEL with Docker Compose](https://zitadel.com/docs/self-hosting/deploy/compose) |
 
-每家竞品的 `setup.sh` 头部注释必须附官方文档链接；偏离官方默认的每一项（如连接池对齐）单独注释理由。
+Each competitor's `setup.sh` header comment must link the official documentation; every deviation from the official defaults (e.g., connection pool alignment) is annotated individually with its rationale.
 
-**JVM 预热豁免**：Keycloak 的 JIT/GC 需要更长预热。warmup 对 Keycloak 延长到 60s（其余三家与 Fulla 自测口径一致取 5s，测量时长统一 10s），在结果中标注——这不是偏袒，是给 JIT 编译时间，否则测的是"未编译的解释执行"。
+**JVM warmup exemption**: Keycloak's JIT/GC needs a longer warmup. Warmup is extended to 60 s for Keycloak (the other three keep 5 s, aligned with fulla's self-test methodology; the measurement duration is a uniform 10 s) and noted in the results — this is not favoritism, it is giving the JIT time to compile; otherwise what gets measured is "uncompiled interpreted execution".
 
-### D3 — 场景映射：功能等价，不是路径等价
+### D3 — Scenario mapping: functional equivalence, not path equivalence
 
-各产品端点路径不同，映射到**同一功能**的端点（§四矩阵）。关键约束：
+Endpoint paths differ per product; map to endpoints with the **same function** (§4 matrix). Key constraints:
 
-- **S3 introspect 的 Ory 特例**：Hydra 的 introspect 在 admin 端口（4445）而非 public 端口，且生产部署中 admin 端口通常不对外。为公平，四家都测 introspect 但**在 COMPARISON.md 中标注 Ory 的 admin-port 语义差异**。
-- **认证方式**：client_credentials 用各产品的标准 client 认证（Basic 或 post，按其声明）。
-- **Zitadel S2 特例（JWT profile）**：Zitadel 的官方 M2M 路径是 Service User + private_key_jwt（token 端点**不支持** Basic 认证的 client_credentials）。wrk Lua 无法签名 JWT，故 setup 阶段用 python（pyjwt + cryptography，WSL 已具备）预签 client_assertion 池，exp 覆盖整个跑数窗口；若 Zitadel 强制 jti 单用则每档重签（等价 S5 的 --reissue 机制）。COMPARISON.md 附录注明"JWT profile 是 Zitadel 官方推荐的机器认证，功能等价"。
+- **S3 introspect, the Ory special case**: Hydra's introspect sits on the admin port (4445) rather than the public port, and in production deployments the admin port is usually not exposed. For fairness, all four products test introspect, but **COMPARISON.md annotates Ory's admin-port semantic difference**.
+- **Authentication method**: client_credentials uses each product's standard client authentication (Basic or post, per its declaration).
+- **Zitadel S2 special case (JWT profile)**: Zitadel's official M2M path is Service User + private_key_jwt (the token endpoint does **not** support client_credentials with Basic authentication). wrk Lua cannot sign JWTs, so the setup phase pre-signs a client_assertion pool with python (pyjwt + cryptography, already available in WSL), with exp covering the entire run window; if Zitadel enforces single-use jti, re-sign per step (equivalent to S5's --reissue mechanism). A COMPARISON.md appendix notes "the JWT profile is Zitadel's officially recommended machine authentication; it is functionally equivalent".
 
-### D4 — 排除 S4 auth_code：wrk 不可驱动
+### D4 — Excluding S4 auth_code: not wrk-drivable
 
-Fulla 的 S4 是 `login → token` 两步 form POST（headless 可驱动）。但：
-- **Keycloak** auth_code 需要走其登录页 HTML 表单 + JS
-- **Ory Hydra** 需要外部 login/consent app 配合（Hydra 本身无登录 UI）
-- **Zitadel** 有自己的登录会话流
+fulla's S4 is a two-step form POST `login → token` (headless-drivable). But:
+- **Keycloak** auth_code requires its login page's HTML form + JS
+- **Ory Hydra** requires an external login/consent app (Hydra itself has no login UI)
+- **Zitadel** has its own login session flow
 
-统一驱动需要真实浏览器（Playwright），测的是"登录页渲染"而非"token 签发"。**首期排除 S4，COMPARISON.md 注明限制**；若后续需要，用"预签发 code + 单步 token 交换"近似（各产品预签发方式不同，复杂度高，Phase 0.6 再议）。
+Driving all of these uniformly would require a real browser (Playwright), and what would be measured is "login page rendering", not "token issuance". **S4 is excluded from the first iteration, with the limitation noted in COMPARISON.md**; if needed later, approximate it with "pre-issued code + single-step token exchange" (each product's pre-issuance method differs and the complexity is high — revisit in Phase 0.6).
 
-### D5 — 竞品 token 池必须由其自身签发（不能 SQL 直插）
+### D5 — Competitor token pools must be issued by the products themselves (no direct SQL inserts)
 
-Fulla 自测的 S3/S6 用 SQL 预种 token（`gen-tokens.py`）。**竞品不行**：
-- Keycloak 的 access token 是签名的 JWT，哈希/密钥格式私有
-- Hydra/Zitadel 同理
+fulla's self-tests pre-seed tokens for S3/S6 via SQL (`gen-tokens.py`). **Not possible for competitors**:
+- Keycloak's access tokens are signed JWTs with private hash/key formats
+- Hydra/Zitadel likewise
 
-**方案**：每家竞品的 `setup.sh` 通过其**自身的 token 端点**批量签发 token，把活跃 token 写入 token 池文件，Lua 场景脚本复用同一套 token-pool 逻辑（线程切片，复用 `s3-introspect.lua` 模式）。
+**Approach**: Each competitor's `setup.sh` issues tokens in bulk through **its own token endpoint**, writes the live tokens into a token-pool file, and the Lua scenario scripts reuse the same token-pool logic (thread slicing, reusing the `s3-introspect.lua` pattern).
 
-**池规模（v1.1 修正——两类池口径不同）**：
-- **S3/S6 池（可复用）**：token 只读验证不消耗，N=2000 足够；批量签发本身约 1–2 分钟（并行 xargs -P8 更快）。
-- **S5 池（单发单耗）**：每个 refresh token 用一次即失效，池必须 ≥ 该档 QPS × 测量时长 × 1.3 余量。Fulla 自测的实测口径：20,000 池 ÷ 10s ≈ 1,982 QPS（池刚好覆盖测量窗口）。竞品每档前须**重发池**（`run-scenario.sh` 新增 `--reissue "<cmd>"` 钩子，等价自测的 SQL `--reseed`，但走各家 API）。
-- **RT 不能来自 client_credentials**：RFC 6749 §4.4.3 规定该 grant 不得签发 refresh token。竞品 RT 池须经用户上下文流程获取——Keycloak 用 ROPC（direct access grants）；Hydra 用 accept 流（见 M2）；Zitadel 用 Session API/auth_code（见 M2）。
+**Pool size (v1.1 revision — the two pool types have different bases)**:
+- **S3/S6 pool (reusable)**: Tokens are only read-validated, never consumed; N=2000 suffices; bulk issuance itself takes ~1–2 minutes (parallel xargs -P8 is faster).
+- **S5 pool (single-issued, single-consumed)**: Every refresh token is invalidated after a single use; the pool must be ≥ that step's QPS × measurement duration × a 1.3 margin. fulla's self-test measured basis: 20,000 pool ÷ 10 s ≈ 1,982 QPS (the pool exactly covers the measurement window). Competitors must **re-issue the pool** before every step (`run-scenario.sh` gains a `--reissue "<cmd>"` hook, equivalent to the self-test's SQL `--reseed` but going through each product's API).
+- **RTs cannot come from client_credentials**: RFC 6749 §4.4.3 forbids issuing refresh tokens under that grant. Competitor RT pools must be obtained through user-context flows — Keycloak via ROPC (direct access grants); Hydra via the accept flow (see M2); Zitadel via the Session API/auth_code (see M2).
 
-### D6 — GC 抖动 = 长跑 P99 时间序列（Fulla 核心差异化证据）
+### D6 — GC jitter = long-run P99 time series (fulla's core differentiation evidence)
 
-单次 30s 跑看不出 GC 周期。设计专门的**长跑测试**：
+A single 30 s run cannot reveal GC cycles. A dedicated **long-run test** is designed:
 
 ```
-每家：c=32 固定，持续 5 分钟，场景钉 S6 userinfo
-（v1.1 修正：S5 不可用——池会耗尽；S2 有写放大——Fulla 每请求落库一条 token，
-5 分钟 ~8k QPS ≈ 240 万行，对四家工作负载构成不对称；S6 是读路径、token 池可复用、
-四家功能等价，是最公平的载波。Hydra 若 S6 标 N/A 则降级 S2 并在结果中标注。）
-采集：每 10s 窗口记录一次该窗口的 P99（wrk 不支持原生分段 → 30 个串行 10s 段近似）
-输出：P99 随时间的曲线（JSON 数组）
-预期：Keycloak 出现周期性 P99 尖峰（GC STW）；Ory 出现 Go GC 小尖峰；Fulla 平线
+Per product: c=32 fixed, sustained for 5 minutes, scenario pinned to S6 userinfo
+(v1.1 revision: S5 is unusable — the pool would be exhausted; S2 has write
+amplification — fulla persists one token row to the DB per request, so at 5
+minutes ~8k QPS ≈ 2.4M rows, an asymmetric workload across the four products;
+S6 is a read path, its token pool is reusable, and all four products are
+functionally equivalent — the fairest carrier. If S6 is marked N/A for Hydra,
+fall back to S2 and note it in the results.)
+Sampling: record each 10 s window's P99 once (wrk has no native segmentation
+→ approximated by 30 serial 10 s segments)
+Output: a P99-over-time curve (JSON array)
+Expected: Keycloak shows periodic P99 spikes (GC STW); Ory shows small Go GC
+spikes; fulla stays flat
 ```
 
-实现：`benchmarks/competitors/run-gc-jitter.sh`——循环调用 wrk `-d10s` 30 次串联，每段 parse 出 P99 存数组。**这是对外叙事最有力的一张图**（"零 GC 抖动"的可视化证据）。
+Implementation: `benchmarks/competitors/run-gc-jitter.sh` — loops wrk `-d10s` 30 times in series, parsing each segment's P99 into an array. **This is the single most compelling chart for the external narrative** (visual evidence of "zero GC jitter").
 
-### D7 — 内存口径统一：容器全栈 RSS + 标注逻辑层
+### D7 — Unified memory basis: full-stack container RSS + annotated logical layer
 
-Phase 0 承重验证发现 Fulla 容器 RSS ~2.4GB（含 Drogon 连接池/共享库 COW）与"50–120MB"声称口径不匹配。对比方案统一口径：
+Phase 0 load-bearing validation found fulla's container RSS is ~2.4GB (including the Drogon connection pool/shared-library COW), which does not match the "50–120MB" claimed figure. The comparison plan unifies the basis:
 
-| 口径 | 采集 | 用途 |
+| Basis | Collection | Use |
 |------|------|------|
-| 容器全栈 RSS | `docker stats` 稳态采样（复用 observe 脚本） | **对比表主口径**——四家同口径可比 |
-| 进程 PSS（可选） | `smem` / `/proc/*/smaps_rollup` | 消除 COW 共享页重复计数的补充口径 |
+| Full-stack container RSS | steady-state `docker stats` sampling (reusing the observe scripts) | **Primary basis for the comparison table** — comparable across all four products on the same basis |
+| Process PSS (optional) | `smem` / `/proc/*/smaps_rollup` | Supplementary basis eliminating double counting of COW shared pages |
 
-在 COMPARISON.md 明确写"全栈容器 RSS，含各自运行时+连接池"，避免口径争议。
+COMPARISON.md explicitly states "full-stack container RSS, including each product's own runtime + connection pool" to avoid basis disputes.
 
 ---
 
-## 四、对比场景矩阵
+## 4. Comparison Scenario Matrix
 
-### 4.1 场景 × 竞品端点映射（已按官方文档核实）
+### 4.1 Scenario × competitor endpoint mapping (verified against official documentation)
 
-| 场景 | 功能 | Fulla | Keycloak | Ory Hydra | Zitadel |
+| Scenario | Function | fulla | Keycloak | Ory Hydra | Zitadel |
 |------|------|-----------|----------|-----------|---------|
-| **S1** discovery | OIDC 发现文档 | `GET /.well-known/openid-configuration` | `GET /realms/{r}/.well-known/openid-configuration` | `GET /.well-known/openid-configuration` (public :4444) | `GET /.well-known/openid-configuration` |
-| **S2** client_credentials | 机器间 token | `POST /oauth2/token` | `POST /realms/{r}/protocol/openid-connect/token` | `POST /oauth2/token` (public :4444) | `POST /oauth/v2/token` |
-| **S3** introspect | token 内省 | `POST /oauth2/introspect` | `POST /realms/{r}/protocol/openid-connect/token/introspect` | `POST /admin/oauth2/introspect` (admin :4445) ⚠ | `POST /oauth/v2/introspect` |
-| **S5** refresh_token | token 刷新 | `POST /oauth2/token` (refresh) | `POST /realms/{r}/protocol/openid-connect/token` (refresh) | `POST /oauth2/token` (refresh) | `POST /oauth/v2/token` (refresh) |
-| **S6** userinfo | 用户信息 | `GET /oauth2/userinfo` | `GET /realms/{r}/protocol/openid-connect/userinfo` | `GET /userinfo` (public :4444) | `GET /oidc/v1/userinfo` |
-| ~~S4~~ auth_code | 用户登录 | ~~`login→token`~~ | ~~登录页不可 headless 驱动~~ | ~~需外部 consent app~~ | ~~登录会话流~~ |
+| **S1** discovery | OIDC discovery document | `GET /.well-known/openid-configuration` | `GET /realms/{r}/.well-known/openid-configuration` | `GET /.well-known/openid-configuration` (public :4444) | `GET /.well-known/openid-configuration` |
+| **S2** client_credentials | machine-to-machine token | `POST /oauth2/token` | `POST /realms/{r}/protocol/openid-connect/token` | `POST /oauth2/token` (public :4444) | `POST /oauth/v2/token` |
+| **S3** introspect | token introspection | `POST /oauth2/introspect` | `POST /realms/{r}/protocol/openid-connect/token/introspect` | `POST /admin/oauth2/introspect` (admin :4445) ⚠ | `POST /oauth/v2/introspect` |
+| **S5** refresh_token | token refresh | `POST /oauth2/token` (refresh) | `POST /realms/{r}/protocol/openid-connect/token` (refresh) | `POST /oauth2/token` (refresh) | `POST /oauth/v2/token` (refresh) |
+| **S6** userinfo | user information | `GET /oauth2/userinfo` | `GET /realms/{r}/protocol/openid-connect/userinfo` | `GET /userinfo` (public :4444) | `GET /oidc/v1/userinfo` |
+| ~~S4~~ auth_code | user login | ~~`login→token`~~ | ~~login page not headless-drivable~~ | ~~external consent app required~~ | ~~login session flow~~ |
 
-> ⚠ Ory introspect 的 admin-port 语义差异在结果中标注。Keycloak realm 名、Hydra public/admin 双端口、Zitadel 的 instance domain 都在各自 setup 脚本中固定为常量。
+> ⚠ Ory's admin-port semantic difference for introspect is noted in the results. The Keycloak realm name, Hydra's public/admin dual ports, and Zitadel's instance domain are all fixed as constants in their respective setup scripts.
 
-端点出处：
-- Keycloak: [OpenID Connect endpoints](https://www.keycloak.org/docs/latest/securing_apps/)（`/realms/{realm}/protocol/openid-connect/*`）
-- Ory Hydra: [API docs](https://www.ory.sh/docs/hydra/reference/api)（public :4444 / admin :4445）
+Endpoint sources:
+- Keycloak: [OpenID Connect endpoints](https://www.keycloak.org/docs/latest/securing_apps/) (`/realms/{realm}/protocol/openid-connect/*`)
+- Ory Hydra: [API docs](https://www.ory.sh/docs/hydra/reference/api) (public :4444 / admin :4445)
 - Zitadel: [OpenID Connect Endpoints](https://zitadel.com/docs/apis/openidoauth/endpoints)
 
-### 4.2 指标矩阵
+### 4.2 Metric matrix
 
-| 指标 | 采集方式 | 对比表列 |
+| Metric | Collection method | Comparison-table column |
 |------|---------|---------|
-| 稳态 QPS（err&lt;0.01% 最高档） | wrk 阶梯 + parse-wrk.py | ✅ |
-| P50 / P95 / P99（稳态档） | wrk `--latency` | ✅ |
-| 错误率 | wrk non-2xx | ✅（门槛列） |
-| 冷启动（→health 200） | 各家等价计时脚本 | ✅ |
-| 稳态容器 RSS | docker stats 采样 | ✅ |
-| GC 抖动（5min P99 曲线） | run-gc-jitter.sh | ✅（专项小节） |
-| driver CPU | run-scenario.sh 现有采样 | ✅（可信度标注） |
+| Steady-state QPS (highest step with err&lt;0.01%) | wrk ladder + parse-wrk.py | ✅ |
+| P50 / P95 / P99 (steady-state step) | wrk `--latency` | ✅ |
+| Error rate | wrk non-2xx | ✅ (threshold column) |
+| Cold start (→health 200) | equivalent timing script per product | ✅ |
+| Steady-state container RSS | docker stats sampling | ✅ |
+| GC jitter (5-min P99 curve) | run-gc-jitter.sh | ✅ (dedicated section) |
+| Driver CPU | existing run-scenario.sh sampling | ✅ (credibility annotation) |
 
 ---
 
-## 五、测试策略
+## 5. Test Strategy
 
-### 5.1 执行顺序（单机串行，防互相干扰）
+### 5.1 Execution order (single machine, serial, to prevent mutual interference)
 
 ```
-1. Fulla    — 同 session 重跑（v1.1 修正：gcjitter/RSS/冷启动是 AC1/AC2 的必采项，
-                  Phase 0 未采过 gcjitter；且 R7 要求四家同一 session 连续跑以消除跨日
-                  环境漂移。2026-08-12 入仓数据保留为历史基线，同 session 新数据用于对比）
-2. Keycloak     — setup → 阶梯 → 长跑 → 冷启动 → teardown
-3. Ory Hydra    — 同上
-4. Zitadel      — 同上
-每家之间 docker compose down -v + 确认无残留容器/卷/网络
+1. fulla    — rerun in the same session (v1.1 revision: gcjitter/RSS/cold start are mandatory
+                  items for AC1/AC2; Phase 0 never sampled gcjitter; and R7 requires all four
+                  products to run back-to-back in the same session to eliminate cross-day
+                  environment drift. The 2026-08-12 in-repo data is kept as a historical
+                  baseline; fresh same-session data is used for the comparison)
+2. Keycloak     — setup → ladder → long run → cold start → teardown
+3. Ory Hydra    — same as above
+4. Zitadel      — same as above
+Between products: docker compose down -v + assert no leftover containers/volumes/networks
 ```
 
-`run-comparison.sh --fresh` 全串行执行；`--only keycloak` 支持单家补跑。
+`run-comparison.sh --fresh` runs everything serially; `--only keycloak` supports re-running a single product.
 
-### 5.2 竞品 setup 约定（每家一个 setup.sh）
+### 5.2 Competitor setup conventions (one setup.sh per product)
 
-每个 `setup.sh` 必须：
-1. 启动该竞品 + PostgreSQL（对齐连接池，见 D1）
-2. 等待健康（各家的 ready 探针：Keycloak `/realms/master`、Hydra `/health/ready`、Zitadel `/debug/healthz`）
-3. 初始化配置（realm/client/用户——用各家 CLI 或 admin API）
-4. **批量签发 token 池**（D5：N 次 client_credentials 请求 → `access_tokens.txt`）
-5. warmup 校验（一个 token 请求确认管线通）
+Every `setup.sh` must:
+1. Start the competitor + PostgreSQL (connection pool aligned, see D1)
+2. Wait for health (each product's ready probe: Keycloak `/realms/master`, Hydra `/health/ready`, Zitadel `/debug/healthz`)
+3. Initialize configuration (realm/client/user — via each product's CLI or admin API)
+4. **Bulk-issue the token pool** (D5: N client_credentials requests → `access_tokens.txt`)
+5. Warmup validation (one token request to confirm the pipeline works)
 
-### 5.3 长跑 GC 抖动（D6）
+### 5.3 Long-run GC jitter (D6)
 
-参数：`c = 各家稳态拐点档`，30 × 10s 段（共 5 分钟），段间无间隔。
-输出：`results/<date>-<sha>-<product>-gcjitter.json`（P99 数组 + 段时间戳）。
+Parameters: `c = the concurrency step at each product's steady-state knee`, 30 × 10 s segments (5 minutes total), no gaps between segments.
+Output: `results/<date>-<sha>-<product>-gcjitter.json` (P99 array + segment timestamps).
 
-### 5.4 冷启动
+### 5.4 Cold start
 
-各家独立计时：`docker compose up -d <idp>` → 轮询 ready 探针 200。
-记录两模式（含/不含 DB 预热）与自测 `measure-cold-start.sh` 对齐。
+Timed independently per product: `docker compose up -d <idp>` → poll the ready probe for 200.
+Recorded in two modes (with/without DB warm-up), aligned with the self-test `measure-cold-start.sh`.
 
-### 5.5 环境元数据
+### 5.5 Environment metadata
 
-结果 JSON 的 `env` 块沿用 schema v1，新增 `product` / `product_version` 字段（parse-wrk.py 加一个透传参数），COMPARISON.md 表头列出版本。
+The `env` block of the result JSONs follows schema v1, gaining `product` / `product_version` fields (parse-wrk.py gains one pass-through parameter); the COMPARISON.md table header lists the versions.
 
 ---
 
-## 六、验收标准（可勾选）
+## 6. Acceptance Criteria (checkable)
 
-> ✅ 2026-08-17 全部通过（M0–M3 交付，四产品同 session 实测 2026-08-17，COMPARISON.md 由 gen-comparison.py 生成）。
-> 🔄 2026-08-21 全量重跑刷新（同一设施，Fulla 换性能优化后基准档——wave-1/2 + LTO，见 G1 交付注）：**五场景全部领先**（此前 S5/S6 落后——S5 系测量预算伪影已修口径、S6 经 wave-2 用户/角色缓存反超）；GC 节新增跨产品环境噪声互证（四家同款尖峰）。调研报告 §3.1 已同步引用新表。
+> ✅ All passed 2026-08-17 (M0–M3 delivered; the four products measured same-session on 2026-08-17; COMPARISON.md generated by gen-comparison.py).
+> 🔄 Full rerun refresh 2026-08-21 (same infrastructure, fulla on an optimized baseline step — wave-1/2 + LTO, see the G1 delivery note): **all five scenarios ahead** (previously behind on S5/S6 — S5's measurement-budget artifact has had its basis fixed, and S6 overtook via the wave-2 user/role cache); the GC section adds cross-product environmental-noise cross-validation (identical spikes on all four). Survey report §3.1 now cites the new table.
 
-| # | 验收项 | 衡量 | 状态 |
+| # | Acceptance item | Measured by | Status |
 |---|--------|------|------|
-| AC1 | **四家同口径对比表**：S1/S2/S3/S5/S6 × \{QPS, P99, RSS, 冷启动\} 入仓 `benchmarks/competitors/results/COMPARISON.md`，每行带产品版本号 | COMPARISON.md | ✅ |
-| AC2 | **GC 抖动曲线**：四家 5 分钟 P99 时间序列 JSON + 对比小节（Fulla 是否平线、Keycloak 是否有周期尖峰） | gcjitter JSON + 小节 | ✅（结论与预期相反，见 G4 注记：GC 语言全平线、Fulla 有环境层秒级尖峰——已在报告与研究报告中诚实修订） |
-| AC3 | **可复现**：`run-comparison.sh` 一键串行跑四家；README 含环境要求与复现步骤 | 复现指引 | ✅（`benchmarks/competitors/README.md`） |
-| AC4 | **公平性声明**：每家竞品的配置来源（官方文档链接）、偏离默认的每一项、warmup 差异（Keycloak 60s）均显式标注 | COMPARISON.md 附录 + setup.sh 注释 | ✅ |
-| AC5 | **诚实修订**：调研报告 §3.1 竞品列更新为"同环境实测"，§3.2 卖点若被证伪则收敛 | research.md 更新 | ✅（S5/S6 与 GC 抖动主张按实测收敛，见 §3.1/3.2 修订） |
-| AC6 | **S4 排除声明**：COMPARISON.md 注明 auth_code 场景的方法限制 | 限制小节 | ✅（附录 B.1） |
+| AC1 | **Four-product like-for-like comparison table**: S1/S2/S3/S5/S6 × \{QPS, P99, RSS, cold start\} committed to `benchmarks/competitors/results/COMPARISON.md`, each row carrying the product version | COMPARISON.md | ✅ |
+| AC2 | **GC jitter curves**: four products' 5-minute P99 time-series JSON + comparison section (is fulla flat; does Keycloak show periodic spikes) | gcjitter JSON + section | ✅ (conclusion opposite to expectation, see the G4 note: the GC languages are all flat and fulla shows environment-level second-scale spikes — honestly revised in the report and the research report) |
+| AC3 | **Reproducible**: `run-comparison.sh` runs all four products serially with one command; the README covers environment requirements and reproduction steps | Reproduction guide | ✅ (`benchmarks/competitors/README.md`) |
+| AC4 | **Fairness statement**: each competitor's configuration source (official documentation links), every deviation from the defaults, and the warmup difference (Keycloak 60 s) are all explicitly annotated | COMPARISON.md appendix + setup.sh comments | ✅ |
+| AC5 | **Honest revision**: survey report §3.1 competitor column updated to "same-environment measurements"; §3.2 claims converge if falsified | research.md update | ✅ (the S5/S6 and GC-jitter claims converged per the measurements, see the §3.1/3.2 revisions) |
+| AC6 | **S4 exclusion statement**: COMPARISON.md notes the method limitation for the auth_code scenario | Limitations section | ✅ (appendix B.1) |
 
-### 实施勘误记录（v1.2，2026-08-17 落地时修订；v1.3 增补 2026-08-18 两项）
+### Implementation errata (v1.2, revised during the 2026-08-17 implementation; v1.3 adds two items on 2026-08-18)
 
-实施过程中偏离本设计 v1.1 的决策，全部为公平性/可行性修正：
+Decisions made during implementation that deviate from this design v1.1 — all of them fairness/feasibility corrections:
 
-1. **Zitadel 版本 v2.71.19 → v4.17.1**：v2.71 已落后两个大版本（当前稳定线 v4，与 Keycloak 26 / Hydra 26 同代），且 v4 为 eventstore/投影性能重写。测旧版会失真贬低 Zitadel，不可辩护。首次尝试的 `v1.80.0-v2.9-amd64` tag 实为 v1 时代 CockroachDB-only 镜像，废弃。
-2. **Zitadel S2 认证路径修正**：设计 D3 原表述"client_assertion（JWT profile）"在 v2.71/v4 实测均不可用——Zitadel token 端点对机器用户的 client_credentials 只走 Basic-secret（每请求哈希），官方 M2M 路径是 **RFC 7523 jwt-bearer 授权**（`grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=…`）。S2/S3 的等价性标注已按此更新。
-3. **Zitadel S3 认证换私钥**：#6220 官方建议——secret 认证每请求做密码哈希（CPU 瓶颈）；改用 OIDC app + private_key_jwt。实测对比：Basic 路径 S3 无法过错误门，私钥路径 2.9k QPS 零错误。
-4. **投影平复门**：mint ~2000 token 后立即开压，Zitadel CQRS 投影追赶会使 S1 出现 500 风暴（c=16 达 99.99% 错误）。run-all 前置 discovery 冒烟门（clean 才开跑），消除该伪影。
-5. **S5 Zitadel = N/A**（DG-2 提前裁决）：机器用户无 refresh token（RFC 6749 §4.4.3）、password grant 已移除、Session API→auth_code 属用户交互流（D4 同类排除理由）。限制小节注明。
-6. **docker-stats.sh 竖线 glob 回归修复**：bash 5.2 下 `case $x in $GLOB)`（GLOB 含 `|`）不再展开为多分支——Fulla 侧 RSS 采样自 M0 参数化起一直空采；改为拆分逐个匹配。该回归同时解释了 v1.1 后 Fulla RSS 数据缺失。
-7. **Fulla S2 scope 跟随 #43**：seed 摒弃 legacy `read/write`，bench 校验与 s2 lua 改用 `tokens:read`（同码同测，非口径变化）。
-8. **（v1.3）四产品 PG 15 → 17 同步升级**（2026-08-18，f789bda）：设计基线为"与自测相同 tag 的 `postgres:15-alpine`"。偏离动机：D1 同环境公平——维持四产品同 PG 大版本；Fulla 服务端 libpq 已是 17.x，client 17/server 15 的错位消除。Fulla 自身 15 vs 17 A/B 在噪声带内（无自身吞吐诉求）。deploy/ 的 compose 与 Helm 同步到 17（存量卷升级 runbook 见 `docs/operate/postgresql-major-upgrade.md`，CHANGELOG 已标 BREAKING）。
-9. **（v1.3）Fulla Redis 池 25 → 64**（2026-08-18，快赢 8838ac6）：设计 §5.2 连接池口径按 pool=25 对齐；实施时 cache-on 要求池 ≥ 预期并发（pool 20 时 S6 全连接超时 -18%），bench overlay 调至 64。竞品各按自家官方默认池口径运行（在 COMPARISON.md 公平性附录注明）。
-
----
-
-## 七、实施计划（4 个 milestone，每步带验收标准）
-
-> v1.1：M0 为评审新增前置——共享设施的参数化改造（向后兼容，不带新 env 时行为不变）。
-
-### M0 — 共享设施参数化（前置，~0.5 天）
-
-| # | 步骤 | 内容 | 验收标准 |
-|---|------|------|---------|
-| M0.1 | `run-scenario.sh` 参数化 | (a) `READY_PATH` env（默认 `/health/ready`）——健康门探针可换竞品探针；(b) `RESULTS_DIR` env（默认 `benchmarks/results`）；(c) `WRK_LIB_DIR` 导出改为 `${WRK_LIB_DIR:-$BENCH_DIR/lib}`（竞品 lua 指向自家 lib）；(d) `BENCH_PRODUCT`/`BENCH_PRODUCT_VERSION` env 透传给 parse-wrk.py；(e) 通用 `--reissue "<cmd>"` 钩子：每档 warmup 前与 measured 前各执行一次（竞品 S5 用 API 重发 token 池，替代 Fulla 的 SQL `--reseed`）；(f) `--observe` 拆为 `--observe-stats`（仅 docker-stats）与 `--observe-metrics`（仅 scrape-metrics；竞品无 `/metrics` 不用） | **AC-M0.1a** 不带任何新 env 跑 Fulla S1 单档（c=2, -d10s）：行为与改造前一致（JSON schema、默认值、输出路径全不变）；**AC-M0.1b** `READY_PATH=<任意 200 路径> RESULTS_DIR=<tmp> BENCH_PRODUCT=x` 时健康门走新路径、JSON 落新目录且 env.product=x；**AC-M0.1c** `--reissue "touch $TMP/marker"` 冒烟：每档产生两个 marker（warmup 前+measured 前） |
-| M0.2 | `parse-wrk.py` 透传 | `--product`/`--product-version` CLI 参数 → env 块新增 `product`/`product_version` 字段（缺省 `fulla`/空） | **AC-M0.2** wrk 样例文本经管道解析，JSON 含两字段且值正确；不传参时缺省值不破坏现有聚合 |
-| M0.3 | `docker-stats.sh` 容器过滤参数化 | `CONTAINER_GLOB` env（默认保持 `*fulla-backend*|*fulla-postgres*|*fulla-redis*` 语义） | **AC-M0.3** `CONTAINER_GLOB='*keycloak*'` 采样时输出含 keycloak 容器行、不含 fulla 行 |
-| M0.4 | schema 文档同步 | `result-schema.md` env 块补 `product`/`product_version` 字段说明 | 文档字段表与实现一致（对照检查） |
-
-### M1 — Keycloak 对比（最重，先啃硬骨头，~2 天）
-
-配置基线（D2）：`quay.io/keycloak/keycloak:<pin 版本>` + `start --optimized` + `--memory 2G`（官方容器建议），PostgreSQL 用与自测**相同 image tag** 的 `postgres:15-alpine`，端口 8080。
-
-| # | 步骤 | 内容 | 验收标准 |
-|---|------|------|---------|
-| M1.1 | `docker-compose.yml` | keycloak + postgres；healthcheck 打 `/realms/master`；卷/网络显式前缀 `kc-bench-` | **AC-M1.1a** `up -d` 后探针 200；**AC-M1.1b** `down -v` 后 `docker ps -a`/`docker volume ls`/`docker network ls` 无 kc-bench 残留 |
-| M1.2 | `setup.sh` | 等健康 → `kcadm.sh` 建 realm `bench`、client `bench-svc`（confidential + service account + introspection 权限）、user `bench-user`（direct grant）→ **校准跑**（c=8 单档 S2/S5/S6 估 QPS）→ 按 `池 = QPS×10s×1.3` 生成 RT 池（ROPC 批量签发，xargs -P8 并行）+ AT 池 ≥2000（S3/S6 复用）→ warmup 验证一发 token 请求 | **AC-M1.2a** `set -euo pipefail`，任何 kcadm/curl 失败即非零退出；**AC-M1.2b** 结尾自检：两个池文件行数 ≥ 期望、单发 client_credentials 得 200；**AC-M1.2c** 幂等：`down -v` 后重跑 setup 成功 |
-| M1.3 | `scenarios/`（5 个 lua） | s1/s2/s3/s5/s6 按 §4.1 端点改写；S2 用 Basic（bench-svc）；S3 Basic + AT 池（线程切片，复用 s3 模式）；S5 RT one-shot 池；S6 Bearer AT 池 | **AC-M1.3** 每个场景 `wrk c=2 -d5s` 冒烟：非 2xx=0、socket 错误=0（S5 允许池尾 nil 关连接，但不得有 invalid_grant） |
-| M1.4 | 阶梯数据 | `WARMUP_S=60 DURATION_S=10` 阶梯 2→128 × 5 场景 → 35 个 JSON；S2 档挂 `--observe-stats` 采 RSS | **AC-M1.4a** 35 JSON 全带 `product=keycloak` + 版本；**AC-M1.4b** 每档 driver CPU &lt;80% 或 JSON 标 `limited=true`；**AC-M1.4c** RSS tsv 落盘且含 keycloak+postgres 行 |
-| M1.5 | GC 抖动 | `run-gc-jitter.sh`：S6 c=32，30×10s 段（D6） | **AC-M1.5** JSON 含 30 个 P99 数据点 + 段起始时间戳；无段失败 |
-| M1.6 | 冷启动 | 两模式：A=全新卷完整初始化（含 realm/client 建立）；B=预初始化卷仅重启 keycloak 容器 | **AC-M1.6** 2 个 JSON（mode A/B），含秒数与 RSS 峰值 |
-| M1.7 | `teardown.sh` | down -v + 残留断言 | 同 AC-M1.1b |
-| M1.8 | 首版两方对比 | Fulla 同 session 重跑（§5.1）+ Keycloak 数据 → 草稿对比表 | **AC-M1.8** 5 场景 × `QPS / P50/P95/P99 / RSS / 冷启动` 行齐、版本列齐 |
-
-### M2 — Ory Hydra + Zitadel（~3 天）
-
-**Hydra**：无内建用户体系。S5/S6 的用户 token 用官方 mock 模式 headless 驱动：`GET /oauth2/auth`（login 跳转）→ admin API `POST /admin/oauth2/auth/requests/login/accept` + `consent/accept` → code → token，纯 curl 可驱动（无需浏览器）。
-**Zitadel**：S2 走 JWT profile 预签 assertion 池（D3 特例）；S3 用 API client + Basic；S5/S6 优先 v2 Session API 建 password 会话 → auth_code 换用户 token。
-
-| # | 步骤 | 验收标准 |
-|---|------|---------|
-| M2.1 | Hydra compose（hydra v2 + PG，public 4444 / admin 4445）+ setup（client create + accept 流驱动签池）| 同 M1.1/M1.2 模式：探针 `/health/ready` 200；池文件行数自检；任何 curl/jq 失败非零退出 |
-| M2.2 | Hydra scenarios + 阶梯 + gcjitter + 冷启动 | 同 M1.3–M1.6 验收；S3 JSON/结果带 admin-port 标注 |
-| M2.3 | Zitadel compose（`setup` mode 初始化 + `start` mode 运行）+ setup（机器用户 JSON key、API client、人类用户） | 同 M1.1/M1.2；setup 两阶段（init/start）可分别重入 |
-| M2.4 | Zitadel scenarios + 阶梯 + gcjitter + 冷启动 | 同 M1.3–M1.6；S2 结果注明 JWT-profile 认证等价性 |
-
-**决策门（M2 内）**：
-- **DG-1**：Hydra accept 流若 curl 驱动不成（如强制 JS），S5/S6 标 N/A。判据：setup 能稳定取得带 `openid` scope 的用户 token。
-- **DG-2**：Zitadel Session API→auth_code 若 2 个工作日内驱动不成，S5/S6 标 N/A（S1/S2/S3 保底），限制小节写明。
-
-### M3 — 汇总 + 诚实修订（~1 天）
-
-| # | 步骤 | 验收标准 |
-|---|------|---------|
-| M3.1 | `gen-comparison.py` 聚合器 | 读四家 JSON 全自动生成 COMPARISON.md：主表（5 场景 × QPS/P50/P95/P99/RSS/冷启动 × 版本列）、GC 抖动小节、公平性附录（配置出处 + 偏离项 + warmup 差异）、限制小节（S4 排除、Ory admin-port、Zitadel JWT-profile、WSL2 声明）。**AC-M3.1**：无手填数字；缺某家某场景时显式 N/A 不缺行 |
-| M3.2 | `run-comparison.sh` 编排器 | `--fresh` 全串行（每家之间清场+残留断言）+ `--only <product>` 补跑 + 末尾自动调聚合器。**AC-M3.2**：一条命令从空环境到 COMPARISON.md |
-| M3.3 | research.md §3.1/§3.2 修订 | 竞品列改"同环境实测"；卖点按实测收敛。**AC-M3.3**：每个数字可溯源到入仓 JSON |
-| M3.4 | 文档收尾 | benchmarks/README.md 增 competitors 指引；本文档 §六验收勾选 | AC1–AC6 全勾 |
+1. **Zitadel version v2.71.19 → v4.17.1**: v2.71 was two major versions behind (the current stable line is v4, the same generation as Keycloak 26 / Hydra 26), and v4 is an eventstore/projection performance rewrite. Testing the old version would distort and disparage Zitadel — indefensible. The first-attempted `v1.80.0-v2.9-amd64` tag turned out to be a v1-era CockroachDB-only image; discarded.
+2. **Zitadel S2 authentication path corrected**: Design D3's original wording "client_assertion (JWT profile)" did not work in v2.71/v4 testing — Zitadel's token endpoint handles client_credentials for machine users via Basic-secret only (password hashing per request); the official M2M path is the **RFC 7523 jwt-bearer grant** (`grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=…`). The S2/S3 equivalence annotations were updated accordingly.
+3. **Zitadel S3 authentication switched to a private key**: official advice in #6220 — secret authentication password-hashes on every request (a CPU bottleneck); switched to an OIDC app + private_key_jwt. Measured comparison: the Basic path could not pass S3's error gate; the private-key path reached 2.9k QPS with zero errors.
+4. **Projection settling gate**: Starting the load immediately after minting ~2000 tokens lets Zitadel's CQRS projections fall behind, causing an S1 500-storm (up to 99.99% errors at c=16). run-all now has a discovery smoke gate up front (only starts when clean), eliminating the artifact.
+5. **S5 Zitadel = N/A** (DG-2 early ruling): machine users have no refresh tokens (RFC 6749 §4.4.3), the password grant has been removed, and Session API→auth_code is a user-interaction flow (the same exclusion rationale as D4). Noted in the limitations section.
+6. **docker-stats.sh pipe-glob regression fixed**: under bash 5.2, `case $x in $GLOB)` (with `|` inside GLOB) no longer expands into multiple branches — fulla-side RSS sampling had been silently empty since the M0 parameterization; changed to split-and-match individually. This regression also explains the missing fulla RSS data after v1.1.
+7. **fulla S2 scope follows #43**: the seed drops legacy `read/write`; the bench validation and the s2 lua use `tokens:read` (same code, same test — not a basis change).
+8. **(v1.3) Four products upgraded PG 15 → 17 in sync** (2026-08-18, f789bda): The design baseline was "the same `postgres:15-alpine` tag as the self-test". Deviation motive: D1 same-environment fairness — keeping all four products on the same PG major version; the fulla server's libpq was already 17.x, removing the client 17/server 15 skew. fulla's own 15 vs 17 A/B is within the noise band (no self-interested throughput motive). deploy/'s compose and Helm moved to 17 in sync (the existing-volume upgrade runbook is at `docs/operate/postgresql-major-upgrade.md`; the CHANGELOG is marked BREAKING).
+9. **(v1.3) fulla Redis pool 25 → 64** (2026-08-18, quick win 8838ac6): The design's §5.2 connection-pool basis was aligned at pool=25; during implementation, cache-on required pool ≥ the expected concurrency (with pool 20, S6 hit all-connection timeouts, -18%), so the bench overlay was raised to 64. Competitors run at their own official default pool basis (noted in the COMPARISON.md fairness appendix).
 
 ---
 
-## 八、目录结构设计（仅设计）
+## 7. Implementation Plan (4 milestones, each step with acceptance criteria)
+
+> v1.1: M0 added at review — parameterization of the shared infrastructure (backward compatible; behavior is unchanged when the new env vars are absent).
+
+### M0 — Shared infrastructure parameterization (prerequisite, ~0.5 day)
+
+| # | Step | Content | Acceptance criteria |
+|---|------|------|---------|
+| M0.1 | `run-scenario.sh` parameterization | (a) `READY_PATH` env (default `/health/ready`) — the health gate's probe can be swapped for a competitor probe; (b) `RESULTS_DIR` env (default `benchmarks/results`); (c) the `WRK_LIB_DIR` export becomes `${WRK_LIB_DIR:-$BENCH_DIR/lib}` (competitor luas point at their own lib); (d) `BENCH_PRODUCT`/`BENCH_PRODUCT_VERSION` env passed through to parse-wrk.py; (e) a generic `--reissue "<cmd>"` hook: executed once before each step's warmup and once before measured (competitor S5 re-issues the token pool via API, replacing fulla's SQL `--reseed`); (f) `--observe` split into `--observe-stats` (docker-stats only) and `--observe-metrics` (scrape-metrics only; unused for competitors without `/metrics`) | **AC-M0.1a** Running fulla S1 as a single step (c=2, -d10s) without any new env behaves identically to before the change (JSON schema, defaults, and output paths all unchanged); **AC-M0.1b** With `READY_PATH=<any 200 path> RESULTS_DIR=<tmp> BENCH_PRODUCT=x`, the health gate uses the new path, the JSON lands in the new directory, and env.product=x; **AC-M0.1c** `--reissue "touch $TMP/marker"` smoke: two markers per step (pre-warmup + pre-measured) |
+| M0.2 | `parse-wrk.py` pass-through | `--product`/`--product-version` CLI args → new `product`/`product_version` fields in the env block (defaults `fulla`/empty) | **AC-M0.2** A wrk sample text parsed via pipe yields a JSON containing both fields with correct values; without the args, the defaults do not break the existing aggregation |
+| M0.3 | `docker-stats.sh` container-filter parameterization | `CONTAINER_GLOB` env (default keeps the `*fulla-backend*|*fulla-postgres*|*fulla-redis*` semantics) | **AC-M0.3** Sampling with `CONTAINER_GLOB='*keycloak*'` outputs keycloak container rows and no fulla rows |
+| M0.4 | Schema documentation sync | the `result-schema.md` env block gains `product`/`product_version` field descriptions | The documentation's field table matches the implementation (cross-checked) |
+
+### M1 — Keycloak comparison (the heaviest; hardest nut first, ~2 days)
+
+Configuration baseline (D2): `quay.io/keycloak/keycloak:<pinned version>` + `start --optimized` + `--memory 2G` (the official container recommendation), PostgreSQL on the **same image tag** as the self-test — `postgres:15-alpine`, port 8080.
+
+| # | Step | Content | Acceptance criteria |
+|---|------|------|---------|
+| M1.1 | `docker-compose.yml` | keycloak + postgres; healthcheck hits `/realms/master`; volumes/networks explicitly prefixed `kc-bench-` | **AC-M1.1a** After `up -d`, the probe returns 200; **AC-M1.1b** After `down -v`, `docker ps -a`/`docker volume ls`/`docker network ls` show no kc-bench leftovers |
+| M1.2 | `setup.sh` | Wait for health → `kcadm.sh` creates realm `bench`, client `bench-svc` (confidential + service account + introspection permissions), user `bench-user` (direct grants) → **calibration run** (c=8 single-step S2/S5/S6 to estimate QPS) → generate the RT pool per `pool = QPS×10s×1.3` (bulk-issued via ROPC, parallel with xargs -P8) + AT pool ≥2000 (S3/S6 reuse) → warmup: verify one token request | **AC-M1.2a** `set -euo pipefail`; any kcadm/curl failure exits non-zero; **AC-M1.2b** Final self-check: both pool files have ≥ the expected line counts and a single client_credentials returns 200; **AC-M1.2c** Idempotent: after `down -v`, rerunning setup succeeds |
+| M1.3 | `scenarios/` (5 luas) | s1/s2/s3/s5/s6 rewritten per the §4.1 endpoints; S2 uses Basic (bench-svc); S3 Basic + AT pool (thread slicing, reusing the s3 pattern); S5 RT one-shot pool; S6 Bearer AT pool | **AC-M1.3** Each scenario `wrk c=2 -d5s` smoke: non-2xx=0, socket errors=0 (S5 tolerates pool-tail nil-closed connections, but there must be no invalid_grant) |
+| M1.4 | Ladder data | `WARMUP_S=60 DURATION_S=10`, ladder 2→128 × 5 scenarios → 35 JSONs; the S2 step attaches `--observe-stats` for RSS | **AC-M1.4a** All 35 JSONs carry `product=keycloak` + the version; **AC-M1.4b** Per step, driver CPU &lt;80% or the JSON is flagged `limited=true`; **AC-M1.4c** The RSS tsv is written and contains keycloak+postgres rows |
+| M1.5 | GC jitter | `run-gc-jitter.sh`: S6 c=32, 30×10 s segments (D6) | **AC-M1.5** The JSON contains 30 P99 data points + segment start timestamps; no failed segments |
+| M1.6 | Cold start | Two modes: A = full initialization on a fresh volume (including realm/client creation); B = pre-initialized volume, restarting only the keycloak container | **AC-M1.6** 2 JSONs (modes A/B), containing seconds and peak RSS |
+| M1.7 | `teardown.sh` | down -v + leftover assertion | Same as AC-M1.1b |
+| M1.8 | First two-way comparison | fulla same-session rerun (§5.1) + Keycloak data → draft comparison table | **AC-M1.8** 5 scenarios × `QPS / P50/P95/P99 / RSS / cold start` rows complete, version columns complete |
+
+### M2 — Ory Hydra + Zitadel (~3 days)
+
+**Hydra**: No built-in user system. User tokens for S5/S6 are driven headless via the official mock pattern: `GET /oauth2/auth` (login redirect) → admin API `POST /admin/oauth2/auth/requests/login/accept` + `consent/accept` → code → token; drivable with pure curl (no browser needed).
+**Zitadel**: S2 uses the JWT-profile pre-signed assertion pool (D3 special case); S3 uses an API client + Basic; S5/S6 prefer the v2 Session API to create a password session → auth_code exchanged for user tokens.
+
+| # | Step | Acceptance criteria |
+|---|------|---------|
+| M2.1 | Hydra compose (hydra v2 + PG, public 4444 / admin 4445) + setup (client create + accept-flow-driven pool issuance)| Same pattern as M1.1/M1.2: `/health/ready` probe 200; pool-file line-count self-check; any curl/jq failure exits non-zero |
+| M2.2 | Hydra scenarios + ladder + gcjitter + cold start | Same acceptance as M1.3–M1.6; the S3 JSON/results carry the admin-port annotation |
+| M2.3 | Zitadel compose (`setup` mode initialization + `start` mode run) + setup (machine-user JSON key, API client, human user) | Same as M1.1/M1.2; the setup's two phases (init/start) are individually re-entrant |
+| M2.4 | Zitadel scenarios + ladder + gcjitter + cold start | Same as M1.3–M1.6; the S2 results note the JWT-profile authentication equivalence |
+
+**Decision gates (within M2)**:
+- **DG-1**: If Hydra's accept flow cannot be curl-driven (e.g., mandatory JS), S5/S6 are marked N/A. Criterion: the setup can reliably obtain a user token carrying the `openid` scope.
+- **DG-2**: If Zitadel's Session API→auth_code cannot be driven within 2 working days, S5/S6 are marked N/A (S1/S2/S3 as the fallback), noted in the limitations section.
+
+### M3 — Aggregation + honest revision (~1 day)
+
+| # | Step | Acceptance criteria |
+|---|------|---------|
+| M3.1 | `gen-comparison.py` aggregator | Reads all four products' JSONs and fully auto-generates COMPARISON.md: main table (5 scenarios × QPS/P50/P95/P99/RSS/cold start × version columns), GC-jitter section, fairness appendix (configuration sources + deviation items + warmup differences), limitations section (S4 exclusion, Ory admin-port, Zitadel JWT-profile, WSL2 statement). **AC-M3.1**: no hand-entered numbers; a missing product/scenario renders an explicit N/A, never a missing row |
+| M3.2 | `run-comparison.sh` orchestrator | `--fresh` runs everything serially (cleanup + leftover assertion between products) + `--only <product>` re-runs + auto-invokes the aggregator at the end. **AC-M3.2**: one command from an empty environment to COMPARISON.md |
+| M3.3 | research.md §3.1/§3.2 revision | The competitor column becomes "same-environment measurements"; the claims converge per the measurements. **AC-M3.3**: every number is traceable to an in-repo JSON |
+| M3.4 | Documentation wrap-up | benchmarks/README.md gains the competitors guide; this document's §6 acceptance checked off | AC1–AC6 all checked |
+
+---
+
+## 8. Directory Layout Design (design only)
 
 ```
 benchmarks/competitors/
-├── README.md                      # 复现指引（环境/顺序/限制）
-├── run-comparison.sh              # 串行跑全部（或 --only <product>）
-├── run-gc-jitter.sh               # 5 分钟 P99 时间序列（D6）
+├── README.md                      # Reproduction guide (environment/order/limitations)
+├── run-comparison.sh              # Runs everything serially (or --only <product>)
+├── run-gc-jitter.sh               # 5-minute P99 time series (D6)
 ├── keycloak/
-│   ├── docker-compose.yml         # Keycloak + PG（对齐 D1）
-│   ├── setup.sh                   # start --optimized + kcadm 初始化 + token 池
+│   ├── docker-compose.yml         # Keycloak + PG (aligned per D1)
+│   ├── setup.sh                   # start --optimized + kcadm init + token pool
 │   ├── teardown.sh
-│   ├── lib/generated/             # setup 产物：token 池文件（WRK_LIB_DIR 指向此处）
-│   └── scenarios/                 # s1/s2/s3/s5/s6.lua（端点按 §4.1）
+│   ├── lib/generated/             # setup outputs: token pool files (WRK_LIB_DIR points here)
+│   └── scenarios/                 # s1/s2/s3/s5/s6.lua (endpoints per §4.1)
 ├── ory/
-│   ├── docker-compose.yml         # Hydra(+Kratos 如需) + PG
-│   ├── setup.sh                   # hydra client create + token 池
+│   ├── docker-compose.yml         # Hydra(+Kratos if needed) + PG
+│   ├── setup.sh                   # hydra client create + token pool
 │   ├── teardown.sh
 │   └── scenarios/
 ├── zitadel/
 │   ├── docker-compose.yml
-│   ├── setup.sh                   # setup mode 初始化 + token 池
+│   ├── setup.sh                   # setup mode init + token pool
 │   ├── teardown.sh
 │   └── scenarios/
 └── results/
-    ├── <date>-<sha>-<product>-<scenario>-c<conn>.json   # 同 schema v1
+    ├── <date>-<sha>-<product>-<scenario>-c<conn>.json   # schema v1
     ├── <date>-<sha>-<product>-gcjitter.json
-    └── COMPARISON.md              # 汇总对比表（gen-comparison.py 生成，M3）
+    └── COMPARISON.md              # Aggregated comparison table (generated by gen-comparison.py, M3)
 
-# 聚合器放共享 reporting/（与 parse-wrk.py 同层）：
+# The aggregator lives in the shared reporting/ (same level as parse-wrk.py):
 benchmarks/reporting/gen-comparison.py
 ```
 
-**复用不复制**：`run-scenario.sh` / `parse-wrk.py` / `observe/` 直接引用 `benchmarks/fulla/` 与 `benchmarks/reporting/` 的现有实现（通过路径参数或环境变量），不为竞品复制第二份 runner。
+**Reuse, don't duplicate**: `run-scenario.sh` / `parse-wrk.py` / `observe/` directly reference the existing implementations in `benchmarks/fulla/` and `benchmarks/reporting/` (via path parameters or environment variables); no second runner copy is made for competitors.
 
 ---
 
-## 九、风险与缓解
+## 9. Risks and Mitigations
 
-| 风险 | 等级 | 影响 | 缓解 |
+| Risk | Level | Impact | Mitigation |
 |------|------|------|------|
-| **竞品社区质疑配置不公平** | 高 | 对外数据被推翻，信誉受损 | D2 官方推荐配置 + AC4 全量标注偏离项；发布前可请竞品社区 review setup 脚本 |
-| **Keycloak JIT/GC 预热不足，数字偏低被指不公平** | 高 | Keycloak 数字虚低 | warmup 延长 60s + 长跑前置 1 分钟丢弃段 |
-| **Hydra 无内建用户，S6 不可测** | 中 | 场景覆盖缺口 | Hydra 配最小 login/consent mock app（官方 brownfield 模式）；若复杂度超预期，S6 对 Hydra 标 N/A |
-| **S5 竞品池规模不足/重发太慢** | 中 | S5 数据失真或 setup 超时 | 校准跑定池规模（QPS×10s×1.3）；xargs -P8 并行签发；--reissue 每档重发（D5 v1.1） |
-| **Zitadel token 端点不支持 Basic client_credentials** | 中 | S2 无法按统一 Basic 口径测 | JWT profile 预签 assertion 池（官方推荐路径，pyjwt 签发）；COMPARISON 注明认证等价性（D3 v1.1） |
-| **Zitadel Session API→auth_code 驱动失败** | 中 | S5/S6 缺口 | 决策门 DG-2：2 个工作日不成标 N/A，S1/S2/S3 保底 |
-| **竞品 token 池签发慢（2000 次 API 调用）** | 低 | setup 时间长 | 并行签发（xargs -P8）；或降池到 500（S3/S6 池可复用，量够） |
-| **Fulla 某维度不领先** | 中 | 卖点叙事受损 | 这正是设施价值——诚实收敛到领先维度（演进方案 §二原则 1 的既定预案） |
-| **单机串行跑，环境漂移（系统更新/温度）** | 中 | 四家数据不同批不可比 | 同一 session 内连续跑完；每家结果带时间戳；复跑取中位数 |
-| **wrk 打不满 Go/Java 服务（driver 受限）** | 低 | 数字是下限 | 沿用 AC4 driver CPU 门；超 80% 标注 |
+| **Competitor communities challenge the configuration as unfair** | High | External data overturned, reputation damaged | D2 official recommended configuration + AC4 full annotation of deviation items; competitor communities can be invited to review the setup scripts before publication |
+| **Keycloak JIT/GC under-warmed, low numbers called unfair** | High | Keycloak's numbers artificially low | Warmup extended to 60 s + the long run discards the first minute of segments |
+| **Hydra has no built-in users, S6 untestable** | Medium | Scenario coverage gap | Equip Hydra with a minimal login/consent mock app (the official brownfield pattern); if the complexity exceeds expectations, S6 is marked N/A for Hydra |
+| **S5 competitor pool undersized / reissue too slow** | Medium | S5 data distorted or the setup times out | The calibration run sizes the pool (QPS×10s×1.3); parallel issuance via xargs -P8; --reissue re-issues per step (D5 v1.1) |
+| **Zitadel token endpoint lacks Basic client_credentials support** | Medium | S2 cannot be measured on the unified Basic basis | JWT-profile pre-signed assertion pool (the officially recommended path, signed with pyjwt); COMPARISON notes the authentication equivalence (D3 v1.1) |
+| **Zitadel Session API→auth_code driving fails** | Medium | S5/S6 gap | Decision gate DG-2: mark N/A if not working within 2 working days; S1/S2/S3 as the fallback |
+| **Slow competitor token pool issuance (2000 API calls)** | Low | Long setup time | Parallel issuance (xargs -P8); or reduce the pool to 500 (the S3/S6 pool is reusable — that is enough) |
+| **fulla not leading on some dimension** | Medium | Selling-point narrative damaged | That is precisely the infrastructure's value — converge honestly onto the leading dimensions (the established contingency in Evolution Plan §2 principle 1) |
+| **Single-machine serial runs, environment drift (OS updates/temperature)** | Medium | The four products' data come from different batches and are not comparable | Run back-to-back within one session; timestamp every product's results; take the median across reruns |
+| **wrk cannot saturate the Go/Java services (driver-limited)** | Low | The numbers are lower bounds | Keep the AC4 driver CPU gate; annotate above 80% |
 
 ---
 
-## 附录 A：与上游文档的关系
+## Appendix A: Relationship to Upstream Documents
 
-| 上游 | 关系 |
+| Upstream | Relationship |
 |------|------|
-| 基准设施设计（内部档案，已随 productization-evolution 目录转为本地维护） | 本文档是其 N1（Phase 0.5 竞品对比）的展开；复用其 runner/parser/schema/observe |
-| [演进方案]（productization-evolution-plan：本地维护档案） §三 Phase 0 P0 第 2 项 | 本文档是该工作项的落地设计 |
-| 调研报告（内部档案） §3.1 | 竞品列的**替换数据源**；M3 据实修订 |
-| `benchmarks/results/SUMMARY.md` | Fulla 侧基线（同环境自测，2026-08-12） |
+| Benchmark infrastructure design (internal archive, moved to local maintenance with the productization-evolution directory) | This document expands its N1 (Phase 0.5 competitor comparison); it reuses that design's runner/parser/schema/observe |
+| [Evolution Plan] (productization-evolution-plan: locally maintained archive) §3 Phase 0 P0 item 2 | This document is the implementation design for that work item |
+| Survey report (internal archive) §3.1 | The **replacement data source** for the competitor column; M3 revises it per the facts |
+| `benchmarks/results/SUMMARY.md` | fulla-side baseline (same-environment self-test, 2026-08-12) |
 
-## 附录 B：决策记录
+## Appendix B: Decision Record
 
-| 决策 | 选择 | 备选与否决理由 |
+| Decision | Choice | Alternatives and rejection rationale |
 |------|------|---------------|
-| 对比对象 | Keycloak / Ory / Zitadel | Auth0（SaaS 不可自托管）否决 |
-| 场景范围 | S1/S2/S3/S5/S6 | S4（登录流不可 headless 驱动）排除，详见 D4 |
-| 配置基线 | 官方推荐生产配置 | 极限调优（军备竞赛无公信力）与默认 dev 配置（不公平）均否决 |
-| token 池 | 各家 API 自签发 | SQL 直插（签名格式私有）否决，详见 D5 |
-| 内存口径 | 容器全栈 RSS（主）+ PSS（补充） | 单一口径必有一方吃亏，双口径并列标注 |
-| warmup/measure 口径（v1.1） | 5s/10s，Keycloak warmup 60s | 与入仓自测数据一致；原文"其余四家 10s"与实际数据（5s/10s）不符，已修正 |
-| GC 抖动载波场景（v1.1） | S6 userinfo，c=32 固定 | S5（池耗尽）与 S2（Fulla 每请求写库、负载构成不对称）否决，详见 D6 |
-| Fulla 数据口径（v1.1） | 同 session 重跑 | "复用旧数据"与 AC2（gcjitter 必采）+ R7（同 session 消漂移）矛盾，已修正 |
-| S5 竞品池（v1.1） | 每档 API 重发（--reissue），池=QPS×10s×1.3 | 固定 2000 池（单发单耗会耗尽）否决；RT 不取自 client_credentials（RFC 6749 §4.4.3 禁止） |
+| Comparison targets | Keycloak / Ory / Zitadel | Auth0 (SaaS, not self-hostable) rejected |
+| Scenario scope | S1/S2/S3/S5/S6 | S4 (login flow not headless-drivable) excluded, see D4 |
+| Configuration baseline | Officially recommended production configuration | Extreme tuning (an arms race with no credibility) and default dev configuration (unfair) both rejected |
+| Token pool | Self-issued via each product's API | Direct SQL insertion (private signature formats) rejected, see D5 |
+| Memory basis | Full-stack container RSS (primary) + PSS (supplementary) | A single basis necessarily disadvantages one side; both bases are presented side by side with annotation |
+| Warmup/measure basis (v1.1) | 5 s/10 s, Keycloak warmup 60 s | Aligned with the in-repo self-test data; the original text's "10 s for the other four" did not match the actual data (5 s/10 s) and was corrected |
+| GC-jitter carrier scenario (v1.1) | S6 userinfo, c=32 fixed | S5 (pool exhaustion) and S2 (fulla writes to the DB per request; asymmetric workload) rejected, see D6 |
+| fulla data basis (v1.1) | Same-session rerun | "Reusing the old data" contradicted AC2 (gcjitter mandatory) + R7 (same session eliminates drift) and was corrected |
+| S5 competitor pool (v1.1) | API reissue per step (--reissue), pool = QPS×10s×1.3 | A fixed 2000 pool (single-use, single-consumption — would be exhausted) rejected; RTs not taken from client_credentials (forbidden by RFC 6749 §4.4.3) |

--- a/docs/contribute/admin-e2e-testing-guide.md
+++ b/docs/contribute/admin-e2e-testing-guide.md
@@ -1,107 +1,110 @@
-# Playwright E2E 自动化测试接入指南
+# Playwright E2E Automated Testing Integration Guide
 
-> 基于 OAuth2 Admin 项目实践总结，面向其他前端项目的 Playwright E2E 测试接入参考。
-
----
-
-## 目录
-
-1. [核心原理](#1-核心原理)
-2. [项目初始化](#2-项目初始化)
-3. [Mock API 层设计](#3-mock-api-层设计)
-4. [测试文件组织](#4-测试文件组织)
-5. [测试编写模式](#5-测试编写模式)
-6. [进阶技巧](#6-进阶技巧)
-7. [CI/CD 集成](#7-cicd-集成)
-8. [常见问题](#8-常见问题)
+> Summarized from the OAuth2 Admin project's practices, as a reference for adopting Playwright E2E testing in other frontend projects.
 
 ---
 
-## 1. 核心原理
+## Table of Contents
 
-### 1.1 为什么选择请求拦截而不是真实后端
+1. [Core Principles](#1-core-principles)
+2. [Project Setup](#2-project-setup)
+3. [Mock API Layer Design](#3-mock-api-layer-design)
+4. [Test File Organization](#4-test-file-organization)
+5. [Test Writing Patterns](#5-test-writing-patterns)
+6. [Advanced Techniques](#6-advanced-techniques)
+7. [CI/CD Integration](#7-cicd-integration)
+8. [FAQ](#8-faq)
 
-| 方案 | 优点 | 缺点 |
+---
+
+## 1. Core Principles
+
+### 1.1 Why request interception instead of a real backend
+
+| Approach | Pros | Cons |
 |------|------|------|
-| **请求拦截 Mock** | 无需后端依赖、执行快(&lt;5s)、稳定不 flaky、可自由控制响应 | 不验证前后端集成 |
-| **真实后端** | 验证端到端集成 | 需要数据库/缓存/服务、慢(分钟级)、环境依赖多、数据隔离难 |
-| **MSW (Mock Service Worker)** | 浏览器层拦截、更贴近真实 | 配置复杂、需要 Service Worker 支持 |
+| **Request interception mocks** | No backend dependency, fast execution (&lt;5s), stable and non-flaky, full control over responses | Does not verify frontend-backend integration |
+| **Real backend** | Verifies end-to-end integration | Requires database/cache/services, slow (minutes), many environment dependencies, hard data isolation |
+| **MSW (Mock Service Worker)** | Intercepts at the browser layer, closer to real behavior | Complex configuration, requires Service Worker support |
 
-本项目选择 **Playwright 原生 `page.route()` 请求拦截**，理由：
-- 零额外依赖（Playwright 内置）
-- API 简洁直观
-- 拦截发生在网络层之前，性能最好
-- 支持精确匹配 URL 模式和 HTTP 方法
-- 支持在单个测试中覆盖全局 Mock
+This project uses **Playwright's native `page.route()` request interception**, for the following reasons:
 
-### 1.2 请求拦截工作流程
+- Zero extra dependencies (built into Playwright)
+- Clean and intuitive API
+- Interception happens before the network layer, delivering the best performance
+- Supports precise URL pattern and HTTP method matching
+- Supports overriding the global mocks within a single test
+
+### 1.2 How request interception works
 
 ```
-┌──────────────┐      HTTP 请求       ┌──────────────────┐
-│  前端应用代码  │ ───────────────────→ │  page.route()    │
-│  (浏览器)     │                      │  URL 模式匹配     │
-│              │ ←─────────────────── │  route.fulfill() │
-└──────────────┘     Mock 响应         └──────────────────┘
-                                          ↑ 不经过网络层
-                                     (无真实 HTTP 连接)
+┌──────────────┐     HTTP request     ┌──────────────────┐
+│  Frontend    │ ───────────────────→ │  page.route()    │
+│  app code    │                      │  URL pattern     │
+│  (browser)   │ ←─────────────────── │  route.fulfill() │
+└──────────────┘    Mock response     └──────────────────┘
+                                          ↑ bypasses the
+                                    network layer entirely
+                                    (no real HTTP connection)
 ```
 
-Playwright 的 `page.route()` 在浏览器网络层拦截请求，**请求不会离开浏览器进程**。这意味着：
-- 不需要启动后端服务
-- 不需要网络连接
-- 响应是即时的，无延迟
-- 测试完全确定性，无网络 flaky
+Playwright's `page.route()` intercepts requests at the browser's network layer, so **requests never leave the browser process**. This means:
 
-### 1.3 三层架构
+- No backend service needs to be running
+- No network connection required
+- Responses are immediate, with zero latency
+- Tests are fully deterministic, with no network flakiness
+
+### 1.3 Three-layer architecture
 
 ```
 tests/e2e/
 ├── helpers/
-│   └── mock-api.ts          ← Layer 1: Mock 数据 + 拦截器
-├── auth.spec.ts             ← Layer 2: 测试用例
+│   └── mock-api.ts          ← Layer 1: mock data + interceptors
+├── auth.spec.ts             ← Layer 2: test cases
 ├── applications.spec.ts
 └── ...
 
-playwright.config.ts         ← Layer 3: Playwright 配置
+playwright.config.ts         ← Layer 3: Playwright configuration
 ```
 
-| 层次 | 职责 | 修改频率 |
+| Layer | Responsibility | Change frequency |
 |------|------|---------|
-| **Mock 层** | 定义 Mock 数据常量 + `setupAuthenticatedMocks()` 全局拦截函数 | 后端 API 变更时 |
-| **测试层** | 编写具体测试用例，调用 Mock 层提供的函数 | 新功能/新页面时 |
-| **配置层** | Playwright 运行参数、浏览器、webServer | 项目初始化时 |
+| **Mock layer** | Defines mock data constants + the `setupAuthenticatedMocks()` global interception function | When the backend API changes |
+| **Test layer** | Contains the actual test cases and calls functions provided by the mock layer | When new features/pages are added |
+| **Config layer** | Playwright runtime options, browsers, webServer | At project setup |
 
 ---
 
-## 2. 项目初始化
+## 2. Project Setup
 
-### 2.1 安装依赖
+### 2.1 Install dependencies
 
 ```bash
 npm install -D @playwright/test
 npx playwright install chromium
 ```
 
-仅需 Chromium，无需安装 WebKit/Firefox。E2E 测试的目标是验证功能逻辑，不是跨浏览器兼容性。
+Chromium alone is enough; there is no need to install WebKit/Firefox. The goal of E2E tests is to verify functional logic, not cross-browser compatibility.
 
-### 2.2 Playwright 配置
+### 2.2 Playwright configuration
 
-创建 `playwright.config.ts`：
+Create `playwright.config.ts`:
 
 ```typescript
 import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
-  testDir: './tests/e2e',        // 测试文件目录
-  fullyParallel: true,            // 全并行执行（测试间无依赖时开启）
-  forbidOnly: !!process.env.CI,   // CI 禁止 test.only（防止误提交）
-  retries: process.env.CI ? 2 : 0, // CI 重试 2 次（抗 flaky）
-  workers: process.env.CI ? 1 : undefined, // CI 单 worker（避免资源竞争）
-  reporter: 'html',               // HTML 测试报告
+  testDir: './tests/e2e',        // test file directory
+  fullyParallel: true,            // run fully in parallel (enable when tests have no interdependencies)
+  forbidOnly: !!process.env.CI,   // forbid test.only on CI (prevents accidental commits)
+  retries: process.env.CI ? 2 : 0, // retry twice on CI (mitigates flakiness)
+  workers: process.env.CI ? 1 : undefined, // single worker on CI (avoids resource contention)
+  reporter: 'html',               // HTML test report
 
   use: {
-    baseURL: 'http://localhost:5174',  // 应用基础 URL（配合 page.goto() 使用）
-    trace: 'on-first-retry',           // 失败重试时记录 trace（调试用）
+    baseURL: 'http://localhost:5174',  // application base URL (used with page.goto())
+    trace: 'on-first-retry',           // record a trace on failed retries (for debugging)
   },
 
   projects: [
@@ -112,25 +115,25 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',              // 自动启动 dev server
-    url: 'http://localhost:5174/',       // 等待此 URL 可访问
-    reuseExistingServer: !process.env.CI, // 本地复用已运行的 server
-    timeout: 30000,                      // 启动超时 30s
+    command: 'npm run dev',              // start the dev server automatically
+    url: 'http://localhost:5174/',       // wait until this URL is reachable
+    reuseExistingServer: !process.env.CI, // reuse an already-running server locally
+    timeout: 30000,                      // 30s startup timeout
   },
 })
 ```
 
-**关键配置说明：**
+**Key configuration notes:**
 
-| 配置项 | 作用 | 推荐值 |
+| Option | Purpose | Recommended value |
 |--------|------|--------|
-| `baseURL` | `page.goto('/path')` 时自动拼接此前缀 | 开发服务器地址 |
-| `webServer` | 自动启动/复用 dev server | 开发模式 + CI 模式区分 |
-| `trace` | 失败时生成 trace 文件，可用 `npx playwright show-trace` 调试 | `on-first-retry` |
-| `fullyParallel` | 多个 test 文件并行执行 | `true`（Mock 模式下安全） |
-| `retries` | 失败重试次数 | CI: 2, 本地: 0 |
+| `baseURL` | Prefix automatically prepended when calling `page.goto('/path')` | Dev server address |
+| `webServer` | Starts/reuses the dev server automatically | Distinct settings for dev mode vs CI mode |
+| `trace` | Generates a trace file on failure, inspectable with `npx playwright show-trace` | `on-first-retry` |
+| `fullyParallel` | Runs multiple test files in parallel | `true` (safe with mocking) |
+| `retries` | Number of retries on failure | CI: 2, local: 0 |
 
-### 2.3 package.json 脚本
+### 2.3 package.json scripts
 
 ```json
 {
@@ -142,50 +145,50 @@ export default defineConfig({
 }
 ```
 
-### 2.4 目录结构
+### 2.4 Directory structure
 
 ```
 your-project/
 ├── playwright.config.ts
 ├── package.json
-├── src/                        ← 应用源码
+├── src/                        ← application source
 └── tests/
     └── e2e/
         ├── helpers/
-        │   └── mock-api.ts     ← Mock 数据 + 拦截函数
-        ├── auth.spec.ts        ← 认证相关测试
-        ├── page-a.spec.ts      ← 页面 A 测试
-        └── page-b.spec.ts      ← 页面 B 测试
+        │   └── mock-api.ts     ← mock data + interception functions
+        ├── auth.spec.ts        ← authentication-related tests
+        ├── page-a.spec.ts      ← page A tests
+        └── page-b.spec.ts      ← page B tests
 ```
 
 ---
 
-## 3. Mock API 层设计
+## 3. Mock API Layer Design
 
-Mock API 层是整个测试体系的**核心**。设计好这一层，编写测试用例会非常简单。
+The mock API layer is the **core** of the entire testing system. Design this layer well and writing test cases becomes straightforward.
 
-### 3.1 文件结构
+### 3.1 File structure
 
-`tests/e2e/helpers/mock-api.ts` 分为三个部分：
+`tests/e2e/helpers/mock-api.ts` consists of three parts:
 
 ```
-Part 1: Mock 数据常量    →  定义所有 API 的假数据
-Part 2: setupAuthenticatedMocks()  →  注册全局路由拦截
-Part 3: 辅助函数         →  loginAsAdmin() 等常用操作
+Part 1: Mock data constants       →  fake data for all APIs
+Part 2: setupAuthenticatedMocks() →  registers global route interception
+Part 3: Helper functions          →  common operations such as loginAsAdmin()
 ```
 
-### 3.2 Mock 数据常量
+### 3.2 Mock data constants
 
-**原则：数据尽量真实，字段与后端 API 响应一致。**
+**Principle: keep the data as realistic as possible, with fields matching the backend API responses.**
 
 ```typescript
-// ✅ 好的设计：字段名、类型与真实 API 一致
+// ✅ Good design: field names and types match the real API
 export const MOCK_USERS = [
   {
     id: '550e8400-e29b-41d4-a716-446655440000',
     username: 'admin',
     email: 'admin@example.com',
-    email_verified: true,    // boolean，不是字符串
+    email_verified: true,    // boolean, not a string
     mfa_enabled: true,
   },
   {
@@ -197,27 +200,28 @@ export const MOCK_USERS = [
   },
 ]
 
-// ❌ 不好的设计：字段名随意、数据不真实
+// ❌ Bad design: arbitrary field names, unrealistic data
 export const users = [
-  { uid: 1, name: 'a', mail: 'a@b' },  // 字段名不匹配真实 API
+  { uid: 1, name: 'a', mail: 'a@b' },  // field names don't match the real API
 ]
 ```
 
-**为什么需要多组数据？**
+**Why multiple data sets?**
 
-Mock 数据至少准备两种状态，覆盖不同的 UI 表现：
-- `email_verified: true` + `false` → 测试"已验证"和"待验证"Badge
-- `mfa_enabled: true` + `false` → 测试"已开启"和"未开启"Badge
+Prepare at least two states in the mock data to cover different UI presentations:
 
-### 3.3 路由拦截：setupAuthenticatedMocks()
+- `email_verified: true` + `false` → test the "verified" and "pending verification" badges
+- `mfa_enabled: true` + `false` → test the "enabled" and "disabled" badges
 
-这是最关键的函数，负责拦截前端发出的所有 API 请求。
+### 3.3 Route interception: setupAuthenticatedMocks()
+
+This is the most critical function; it intercepts every API request the frontend makes.
 
 ```typescript
 import { Page } from '@playwright/test'
 
 export async function setupAuthenticatedMocks(page: Page) {
-  // 拦截规则：** 是通配符，匹配任何 origin
+  // Interception rule: ** is a wildcard that matches any origin
   await page.route('**/api/users', async (route) => {
     await route.fulfill({
       status: 200,
@@ -228,16 +232,16 @@ export async function setupAuthenticatedMocks(page: Page) {
 }
 ```
 
-**URL 匹配模式说明：**
+**URL matching patterns:**
 
-| 模式 | 匹配范围 | 示例 |
+| Pattern | What it matches | Example |
 |------|---------|------|
-| `**/api/users` | 任何 origin + 路径精确匹配 | `http://localhost:5174/api/users` ✅ |
-| `**/api/admin/logs**` | 路径前缀匹配（含查询参数） | `/api/admin/logs?page=2` ✅ |
-| `**/api/admin/clients/*` | 路径 + 单段通配 | `/api/admin/clients/vue-client` ✅ |
-| `**/api/admin/clients/*/reset-secret` | 多段路径混合 | `/api/admin/clients/vue-client/reset-secret` ✅ |
+| `**/api/users` | Any origin + exact path match | `http://localhost:5174/api/users` ✅ |
+| `**/api/admin/logs**` | Path prefix match (including query parameters) | `/api/admin/logs?page=2` ✅ |
+| `**/api/admin/clients/*` | Path + single-segment wildcard | `/api/admin/clients/vue-client` ✅ |
+| `**/api/admin/clients/*/reset-secret` | Multi-segment path combination | `/api/admin/clients/vue-client/reset-secret` ✅ |
 
-**同一个 URL，不同 HTTP 方法：**
+**Same URL, different HTTP methods:**
 
 ```typescript
 await page.route('**/api/admin/clients', async (route) => {
@@ -246,34 +250,34 @@ await page.route('**/api/admin/clients', async (route) => {
   } else if (route.request().method() === 'POST') {
     await route.fulfill({ status: 201, body: JSON.stringify({ client_id: 'new-123' }) })
   } else {
-    // 未预期的方法，交给下一个 handler 或真实网络
+    // Unexpected method: pass to the next handler or the real network
     await route.continue()
   }
 })
 ```
 
-**子资源路由优先级：**
+**Sub-resource route priority:**
 
-Playwright 路由匹配按注册顺序，**更具体的路由应先注册**：
+Playwright matches routes in registration order, so **more specific routes should be registered first**:
 
 ```typescript
-// ✅ 正确：更具体的路由先注册
-await page.route('**/api/admin/clients/*/reset-secret', ...)  // 先匹配
-await page.route('**/api/admin/clients/*', ...)                // 后匹配（兜底）
+// ✅ Correct: register more specific routes first
+await page.route('**/api/admin/clients/*/reset-secret', ...)  // matched first
+await page.route('**/api/admin/clients/*', ...)                // matched later (fallback)
 
-// 实际上 Playwright 的通配符匹配有隐式优先级
-// 但在 handler 内主动判断更安全：
+// In practice, Playwright's wildcard matching has an implicit priority,
+// but explicitly checking inside the handler is safer:
 await page.route('**/api/admin/clients/*', async (route) => {
   const url = route.request().url()
   if (url.includes('/scopes') || url.includes('/reset-secret')) {
-    await route.continue()  // 跳过，让更具体的 handler 处理
+    await route.continue()  // skip; let a more specific handler deal with it
     return
   }
-  // ... 处理 DELETE / GET / PUT
+  // ... handle DELETE / GET / PUT
 })
 ```
 
-### 3.4 辅助函数：loginAsAdmin()
+### 3.4 Helper function: loginAsAdmin()
 
 ```typescript
 export async function loginAsAdmin(page: Page) {
@@ -281,23 +285,24 @@ export async function loginAsAdmin(page: Page) {
   await page.fill('input[type="text"]', 'admin')
   await page.fill('input[type="password"]', 'admin')
   await page.click('button[type="submit"]')
-  await page.waitForURL('**/dashboard')  // 等待登录成功跳转
+  await page.waitForURL('**/dashboard')  // wait for the successful-login redirect
 }
 ```
 
-**设计要点：**
-- 通过 UI 操作完成登录（模拟真实用户行为）
-- 依赖 `setupAuthenticatedMocks()` 已拦截认证 API
-- `waitForURL` 确保登录完成，后续测试处于已认证状态
+**Design notes:**
 
-### 3.5 适配其他项目的 Mock 模板
+- Logs in through UI interactions (simulating a real user)
+- Relies on `setupAuthenticatedMocks()` having intercepted the authentication APIs
+- `waitForURL` guarantees the login has completed, so subsequent tests run in an authenticated state
+
+### 3.5 Mock template for adapting to other projects
 
 ```typescript
-// === helpers/mock-api.ts 模板 ===
+// === helpers/mock-api.ts template ===
 
 import { Page } from '@playwright/test'
 
-// ---- Part 1: Mock 数据 ----
+// ---- Part 1: mock data ----
 
 export const CURRENT_USER = {
   id: '1',
@@ -311,10 +316,10 @@ export const MOCK_ITEMS = [
   { id: '2', title: 'Item B', status: 'inactive' },
 ]
 
-// ---- Part 2: 全局路由拦截 ----
+// ---- Part 2: global route interception ----
 
 export async function setupAuthenticatedMocks(page: Page) {
-  // 认证相关
+  // Authentication
   await page.route('**/auth/login', async (route) => {
     await route.fulfill({
       status: 200,
@@ -331,7 +336,7 @@ export async function setupAuthenticatedMocks(page: Page) {
     })
   })
 
-  // 业务数据
+  // Business data
   await page.route('**/api/items', async (route) => {
     if (route.request().method() === 'GET') {
       await route.fulfill({
@@ -351,7 +356,7 @@ export async function setupAuthenticatedMocks(page: Page) {
     }
   })
 
-  // 单项操作（GET / PUT / DELETE）
+  // Single-item operations (GET / PUT / DELETE)
   await page.route('**/api/items/*', async (route) => {
     if (route.request().method() === 'DELETE') {
       await route.fulfill({ status: 204 })
@@ -365,7 +370,7 @@ export async function setupAuthenticatedMocks(page: Page) {
   })
 }
 
-// ---- Part 3: 辅助函数 ----
+// ---- Part 3: helper functions ----
 
 export async function loginAs(page: Page, username = 'admin', password = 'admin') {
   await page.goto('/login')
@@ -378,35 +383,35 @@ export async function loginAs(page: Page, username = 'admin', password = 'admin'
 
 ---
 
-## 4. 测试文件组织
+## 4. Test File Organization
 
-### 4.1 命名规范
+### 4.1 Naming conventions
 
 ```
 tests/e2e/
   ├── helpers/
-  │   └── mock-api.ts         ← 固定命名，所有测试共享
-  ├── auth.spec.ts             ← 认证/登录相关
-  ├── {page-name}.spec.ts      ← 每个页面一个文件
-  └── navigation.spec.ts       ← 全局导航/布局
+  │   └── mock-api.ts         ← fixed name, shared by all tests
+  ├── auth.spec.ts             ← authentication/login related
+  ├── {page-name}.spec.ts      ← one file per page
+  └── navigation.spec.ts       ← global navigation/layout
 ```
 
-**一个页面 = 一个 spec 文件**，按功能域划分，不按操作类型划分。
+**One page = one spec file**, organized by functional domain rather than by operation type.
 
-### 4.2 test.describe 分组
+### 4.2 test.describe grouping
 
 ```typescript
-test.describe('页面/功能名称', () => {
-  // beforeEach: 统一 setup
+test.describe('Page/Feature name', () => {
+  // beforeEach: shared setup
   test.beforeEach(async ({ page }) => {
     await setupAuthenticatedMocks(page)
     await loginAsAdmin(page)
-    // 导航到目标页面
+    // navigate to the target page
     await page.click('nav a:has-text("Target Page")')
     await page.waitForURL('**/target-page')
   })
 
-  // 测试用例按：渲染 → 数据 → 交互 → 边界 排列
+  // Test cases ordered: rendering → data → interaction → edge cases
   test('displays page title', ...)
   test('shows data from API', ...)
   test('button click triggers action', ...)
@@ -414,37 +419,37 @@ test.describe('页面/功能名称', () => {
 })
 ```
 
-### 4.3 测试用例命名
+### 4.3 Test case naming
 
-使用**陈述句**描述预期行为，而非操作步骤：
+Use **declarative sentences** that describe expected behavior, not operation steps:
 
 ```typescript
-// ✅ 好：描述预期结果
+// ✅ Good: describes the expected outcome
 test('displays users list with correct columns', ...)
 test('shows error on login failure', ...)
 test('delete button removes item from list', ...)
 
-// ❌ 不好：描述操作步骤
+// ❌ Bad: describes operation steps
 test('clicks button and checks result', ...)
 test('test 1', ...)
 ```
 
 ---
 
-## 5. 测试编写模式
+## 5. Test Writing Patterns
 
-### 5.1 标准测试流程（beforeEach 模式）
+### 5.1 Standard test flow (the beforeEach pattern)
 
-**最常用的模式**，90% 的测试都遵循这个流程：
+**The most common pattern** — 90% of tests follow this flow:
 
 ```typescript
 test.describe('User Management', () => {
   test.beforeEach(async ({ page }) => {
-    // Step 1: 注册全局 Mock
+    // Step 1: register global mocks
     await setupAuthenticatedMocks(page)
-    // Step 2: 模拟登录
+    // Step 2: simulate login
     await loginAsAdmin(page)
-    // Step 3: 导航到目标页面
+    // Step 3: navigate to the target page
     await page.click('nav a:has-text("Users")')
     await page.waitForURL('**/users')
   })
@@ -456,7 +461,7 @@ test.describe('User Management', () => {
 })
 ```
 
-**流程图：**
+**Flow diagram:**
 
 ```
 beforeEach:
@@ -464,79 +469,79 @@ beforeEach:
        ↓
   loginAsAdmin(page)
        ↓
-  导航到目标页面 + waitForURL
+  navigate to the target page + waitForURL
        ↓
   ═══════════════════════════
-  ↓  test case 1 执行      ↓
-  ↓  test case 2 执行      ↓
-  ↓  ...                   ↓
+  ↓  test case 1 runs     ↓
+  ↓  test case 2 runs     ↓
+  ↓  ...                  ↓
   ═══════════════════════════
 ```
 
-### 5.2 页面渲染验证
+### 5.2 Verifying page rendering
 
-验证页面正确显示数据：
+Verify that the page displays data correctly:
 
 ```typescript
 test('displays users list with correct columns', async ({ page }) => {
-  // 验证标题
+  // Verify the title
   await expect(page.locator('h2')).toContainText('Users')
-  // 验证表头
+  // Verify the table headers
   await expect(page.locator('th:has-text("Username")')).toBeVisible()
   await expect(page.locator('th:has-text("Email")')).toBeVisible()
-  // 验证数据行（来自 Mock 数据）
+  // Verify data rows (from the mock data)
   const tableBody = page.locator('tbody')
   await expect(tableBody.getByRole('cell', { name: 'admin', exact: true })).toBeVisible()
 })
 ```
 
-### 5.3 表单交互测试
+### 5.3 Form interaction tests
 
-验证表单填写、提交、响应：
+Verify form filling, submission, and responses:
 
 ```typescript
 test('creates a new application and shows secret', async ({ page }) => {
-  // 1. 触发弹窗
+  // 1. Open the dialog
   await page.click('button:has-text("Create Application")')
-  // 2. 验证弹窗出现
+  // 2. Verify the dialog appears
   await expect(page.locator('h3:has-text("Create Application")')).toBeVisible()
-  // 3. 填写表单
+  // 3. Fill in the form
   await page.fill('input[placeholder="My App"]', 'Test Application')
   await page.selectOption('select', 'CONFIDENTIAL')
-  // 4. 提交
+  // 4. Submit
   await page.locator('.fixed button[type="submit"]').click()
-  // 5. 验证结果
+  // 5. Verify the result
   await expect(page.locator('h3:has-text("Client Secret")')).toBeVisible()
   await expect(page.locator('.font-mono.select-all')).toContainText('generated-secret-abc123xyz')
 })
 ```
 
-### 5.4 Modal/对话框测试
+### 5.4 Modal/dialog tests
 
 ```typescript
 test('opens and closes role assignment modal', async ({ page }) => {
-  // 打开
+  // Open
   await page.click('button:has-text("Assign Roles")')
   await expect(page.locator('h3:has-text("Assign Roles")')).toBeVisible()
 
-  // 关闭
+  // Close
   await page.click('button:has-text("Cancel")')
   await expect(page.locator('h3:has-text("Assign Roles")')).not.toBeVisible()
 })
 
-// 原生 confirm 对话框处理
+// Handling native confirm dialogs
 test('delete with confirmation', async ({ page }) => {
-  page.on('dialog', (dialog) => dialog.accept())  // 自动接受 confirm
+  page.on('dialog', (dialog) => dialog.accept())  // auto-accept the confirm
   await page.click('button:has-text("Delete")')
   await expect(page.locator('h2')).toContainText('Applications')
 })
 ```
 
-### 5.5 分页测试
+### 5.5 Pagination tests
 
 ```typescript
 test('pagination sends correct page parameter', async ({ page }) => {
-  // 构造足够多的数据以启用"下一页"
+  // Build enough data to enable the "Next" button
   const manyItems = Array.from({ length: 50 }, (_, i) => ({
     id: i + 1, title: `Item ${i}`, status: 'active',
   }))
@@ -551,12 +556,12 @@ test('pagination sends correct page parameter', async ({ page }) => {
     })
   })
 
-  // 导航触发重新加载
+  // Navigate away and back to trigger a reload
   await page.click('nav a:has-text("Dashboard")')
   await page.click('nav a:has-text("Items")')
   await page.waitForURL('**/items')
 
-  // 点击下一页
+  // Click Next
   const nextBtn = page.locator('button:has-text("Next")')
   await expect(nextBtn).not.toBeDisabled()
   await nextBtn.click()
@@ -565,20 +570,20 @@ test('pagination sends correct page parameter', async ({ page }) => {
 })
 ```
 
-### 5.6 导航测试
+### 5.6 Navigation tests
 
 ```typescript
 test('sidebar navigation works for all pages', async ({ page }) => {
-  // 验证导航项可见
+  // Verify nav items are visible
   await expect(page.locator('nav a:has-text("Dashboard")')).toBeVisible()
   await expect(page.locator('nav a:has-text("Users")')).toBeVisible()
 
-  // 点击并验证 URL + 页面标题
+  // Click and verify URL + page title
   await page.click('nav a:has-text("Users")')
   await expect(page).toHaveURL(/\/users/)
   await expect(page.locator('h2')).toContainText('Users')
 
-  // 返回验证
+  // Navigate back and verify
   await page.click('nav a:has-text("Dashboard")')
   await expect(page).toHaveURL(/\/dashboard/)
 })
@@ -586,27 +591,27 @@ test('sidebar navigation works for all pages', async ({ page }) => {
 
 ---
 
-## 6. 进阶技巧
+## 6. Advanced Techniques
 
-### 6.1 覆盖全局 Mock（测试异常场景）
+### 6.1 Overriding global mocks (testing error scenarios)
 
-这是本方案最强大的特性：**在单个测试中覆盖全局 Mock，无需修改 setupAuthenticatedMocks()**。
+This is the most powerful feature of this approach: **override the global mocks within a single test, without modifying setupAuthenticatedMocks()**.
 
-**原理：** `page.route()` 后注册的 handler 优先匹配。后注册的会覆盖先注册的同 URL 模式。
+**How it works:** handlers registered later via `page.route()` are matched first. A later registration overrides an earlier one for the same URL pattern.
 
 ```typescript
 test.describe('Dashboard', () => {
   test.beforeEach(async ({ page }) => {
-    await setupAuthenticatedMocks(page)  // 全局 Mock：health 返回 ok
+    await setupAuthenticatedMocks(page)  // global mocks: health returns ok
     await loginAsAdmin(page)
   })
 
   test('displays healthy status', async ({ page }) => {
-    await expect(page.locator('text=Healthy')).toBeVisible()  // 使用全局 Mock
+    await expect(page.locator('text=Healthy')).toBeVisible()  // uses the global mock
   })
 
   test('shows unhealthy status when backend is down', async ({ page }) => {
-    // 关键：在全局 Mock 之后注册，覆盖全局的 health 响应
+    // Key point: registered after the global mocks, overriding the global health response
     await page.route('**/health/ready', async (route) => {
       await route.fulfill({
         status: 200,
@@ -615,21 +620,21 @@ test.describe('Dashboard', () => {
       })
     })
 
-    await loginAsAdmin(page)  // 重新登录以触发 health check
+    await loginAsAdmin(page)  // log in again to trigger the health check
     await expect(page.locator('text=Unhealthy')).toBeVisible()
   })
 })
 ```
 
-**常见覆盖场景：**
+**Common override scenarios:**
 
 ```typescript
-// 场景 1：API 返回错误
+// Scenario 1: API returns an error
 await page.route('**/oauth2/login', async (route) => {
   await route.fulfill({ status: 401, body: JSON.stringify({ error: 'invalid_credentials' }) })
 })
 
-// 场景 2：API 返回空数据
+// Scenario 2: API returns empty data
 await page.route('**/api/admin/clients', async (route) => {
   if (route.request().method() === 'GET') {
     await route.fulfill({ status: 200, body: JSON.stringify({ clients: [] }) })
@@ -638,7 +643,7 @@ await page.route('**/api/admin/clients', async (route) => {
   }
 })
 
-// 场景 3：非管理员用户
+// Scenario 3: non-admin user
 await page.route('**/oauth2/userinfo', async (route) => {
   await route.fulfill({
     status: 200,
@@ -646,7 +651,7 @@ await page.route('**/oauth2/userinfo', async (route) => {
   })
 })
 
-// 场景 4：MFA 要求
+// Scenario 4: MFA required
 await page.route('**/oauth2/login', async (route) => {
   await route.fulfill({
     status: 200,
@@ -655,15 +660,15 @@ await page.route('**/oauth2/login', async (route) => {
 })
 ```
 
-### 6.2 捕获请求体验证
+### 6.2 Capturing and verifying request bodies
 
-验证前端发送的请求参数是否正确：
+Verify that the parameters the frontend sends are correct:
 
 ```typescript
 test('assigns roles with correct request body', async ({ page }) => {
   let requestBody: any = null
 
-  // 覆盖全局 Mock，同时捕获请求体
+  // Override the global mock and capture the request body at the same time
   await page.route('**/api/admin/users/*/roles', async (route) => {
     requestBody = JSON.parse(route.request().postData() || '{}')
     await route.fulfill({
@@ -672,23 +677,23 @@ test('assigns roles with correct request body', async ({ page }) => {
     })
   })
 
-  // 执行操作
+  // Perform the action
   await page.locator('button:has-text("Assign Roles")').first().click()
   await page.fill('input[placeholder="admin, user"]', 'admin, editor')
   await page.click('button:has-text("Save Roles")')
 
-  // 验证请求体
+  // Verify the request body
   expect(requestBody).toEqual({ roles: ['admin', 'editor'] })
 })
 ```
 
-### 6.3 空状态测试
+### 6.3 Empty-state tests
 
-验证列表为空时的 UI 表现：
+Verify the UI presentation when the list is empty:
 
 ```typescript
 test('shows empty state when no items exist', async ({ page }) => {
-  // 覆盖 Mock 返回空列表
+  // Override the mock to return an empty list
   await page.route('**/api/items', async (route) => {
     if (route.request().method() === 'GET') {
       await route.fulfill({ status: 200, body: JSON.stringify({ items: [] }) })
@@ -697,24 +702,25 @@ test('shows empty state when no items exist', async ({ page }) => {
     }
   })
 
-  // 导航走再回来，触发数据重新加载
+  // Navigate away and back to trigger a data reload
   await page.click('nav a:has-text("Dashboard")')
   await page.click('nav a:has-text("Items")')
   await page.waitForURL('**/items')
 
-  // 验证空状态提示
+  // Verify the empty-state prompt
   await expect(page.locator('text=No items yet')).toBeVisible()
   await expect(page.locator('button:has-text("Create your first item")')).toBeVisible()
 })
 ```
 
-**为什么需要"导航走再回来"？**
+**Why "navigate away and back"?**
 
-因为 `beforeEach` 中已经导航到了目标页面，数据已经加载。覆盖 Mock 后需要触发组件重新挂载数据重新获取。两个方法：
-1. 导航到其他页面再回来（推荐，模拟真实用户操作）
-2. `await page.reload()`（简单，但有些组件可能不重新请求）
+Because `beforeEach` has already navigated to the target page and the data is loaded, overriding the mock requires forcing the component to remount and re-fetch the data. Two approaches:
 
-### 6.4 验证请求查询参数
+1. Navigate to another page and back (recommended; simulates real user behavior)
+2. `await page.reload()` (simple, but some components may not re-request)
+
+### 6.4 Verifying request query parameters
 
 ```typescript
 test('filter sends correct parameters', async ({ page }) => {
@@ -724,11 +730,11 @@ test('filter sends correct parameters', async ({ page }) => {
     await route.fulfill({ status: 200, body: JSON.stringify({ items: [] }) })
   })
 
-  // 执行筛选操作
+  // Perform the filter operation
   await page.selectOption('select[name="status"]', 'active')
   await page.click('button:has-text("Filter")')
 
-  // 验证 URL 参数
+  // Verify the URL parameters
   const url = new URL(capturedUrl)
   expect(url.searchParams.get('status')).toBe('active')
 })
@@ -736,9 +742,9 @@ test('filter sends correct parameters', async ({ page }) => {
 
 ---
 
-## 7. CI/CD 集成
+## 7. CI/CD Integration
 
-### 7.1 GitHub Actions 示例
+### 7.1 GitHub Actions example
 
 ```yaml
 name: E2E Tests
@@ -771,38 +777,38 @@ jobs:
           path: playwright-report/
 ```
 
-### 7.2 CI 配置要点
+### 7.2 CI configuration notes
 
-| 配置 | CI 值 | 本地值 | 原因 |
+| Option | CI value | Local value | Reason |
 |------|-------|-------|------|
-| `workers` | 1 | 自动(多) | CI 资源有限，避免竞争 |
-| `retries` | 2 | 0 | CI 网络不稳定，重试抗 flaky |
-| `reuseExistingServer` | `false` | `true` | CI 必须启动新 server |
-| `forbidOnly` | `true` | `false` | 防止 `test.only` 被提交 |
+| `workers` | 1 | auto (multiple) | CI resources are limited; avoids contention |
+| `retries` | 2 | 0 | CI networks are unstable; retries mitigate flakiness |
+| `reuseExistingServer` | `false` | `true` | CI must start a fresh server |
+| `forbidOnly` | `true` | `false` | Prevents `test.only` from being committed |
 
 ---
 
-## 8. 常见问题
+## 8. FAQ
 
-### Q1: 测试偶尔失败（flaky）怎么办？
+### Q1: What if tests fail intermittently (flaky)?
 
-1. 检查是否用了 `page.waitForTimeout()` — 改用 `waitForSelector` / `waitForURL` / `expect().toBeVisible()`
-2. 检查 Mock 是否有条件竞争 — 确保所有 API 都被拦截，没有未 Mock 的请求
-3. 开启 `trace: 'on-first-retry'`，用 `npx playwright show-trace` 分析失败
+1. Check whether you use `page.waitForTimeout()` — switch to `waitForSelector` / `waitForURL` / `expect().toBeVisible()`
+2. Check the mocks for race conditions — make sure every API is intercepted and no request is left unmocked
+3. Enable `trace: 'on-first-retry'` and analyze failures with `npx playwright show-trace`
 
-### Q2: 某个请求没被拦截怎么办？
+### Q2: What if a request is not intercepted?
 
-- 检查 URL 模式是否匹配（`**` 通配符范围）
-- 打开浏览器开发者工具，看实际请求的完整 URL
-- 在 handler 内加 `console.log(route.request().url())` 调试
+- Check that the URL pattern matches (the scope of the `**` wildcard)
+- Open the browser DevTools and inspect the full URL of the actual request
+- Add `console.log(route.request().url())` inside the handler to debug
 
-### Q3: 如何测试文件上传？
+### Q3: How do I test file uploads?
 
 ```typescript
-// 监听 file chooser 事件
+// Listen for the filechooser event
 const [fileChooser] = await Promise.all([
   page.waitForEvent('filechooser'),
-  page.click('button:has-text("Upload")'),  // 触发文件选择
+  page.click('button:has-text("Upload")'),  // triggers the file selection
 ])
 await fileChooser.setFiles({
   name: 'test.csv',
@@ -811,126 +817,128 @@ await fileChooser.setFiles({
 })
 ```
 
-### Q4: 如何在不启动 dev server 的情况下测试？
+### Q4: How do I run tests without auto-starting the dev server?
 
-修改 `playwright.config.ts`，移除 `webServer` 配置，手动启动 dev server 后运行测试：
+Edit `playwright.config.ts`, remove the `webServer` configuration, start the dev server manually, then run the tests:
 
 ```bash
-# 终端 1
+# Terminal 1
 npm run dev
 
-# 终端 2
+# Terminal 2
 npm run test:e2e
 ```
 
-### Q5: Mock 模式和真实后端测试如何共存？
+### Q5: How do mock-mode and real-backend tests coexist?
 
 ```
 tests/
 ├── e2e/
 │   ├── helpers/
-│   │   ├── mock-api.ts      ← Mock 模式
-│   │   └── api-client.ts    ← 真实 API 调用
-│   ├── auth.spec.ts          ← Mock 测试
+│   │   ├── mock-api.ts      ← mock mode
+│   │   └── api-client.ts    ← real API calls
+│   ├── auth.spec.ts          ← mock tests
 │   └── ...
 └── integration/
-    └── full-flow.spec.ts     ← 真实后端集成测试
+    └── full-flow.spec.ts     ← real-backend integration tests
 ```
 
-使用不同的 `playwright.config.ts`：
-- `playwright.config.ts` — Mock 模式（日常开发、每次提交）
-- `playwright.integration.config.ts` — 真实后端（发布前、 nightly）
+Use separate `playwright.config.ts` files:
+
+- `playwright.config.ts` — mock mode (daily development, every commit)
+- `playwright.integration.config.ts` — real backend (pre-release, nightly)
 
 ---
 
-## 9. 后端集成测试故障排查
+## 9. Backend Integration Test Troubleshooting
 
-### 问题：测试脚本第二次运行时全部失败
+### Problem: the test script fails entirely on its second run
 
-**症状**：
+**Symptoms**:
 ```
 POST http://localhost:5174/oauth2/login 401 (Unauthorized)
 ```
 
-后端日志：
+Backend logs:
 ```
 WARN  Account locked for user: admin until 1779441748
 INFO  [METRIC] oauth2_login_failures_total reason=bad_credentials
 ```
 
-**原因**：
-OAuth2 系统实现了账号锁定机制。当登录失败次数达到阈值时，账号会被临时锁定：
-- 5次失败 → 锁定1分钟
-- 10次失败 → 锁定5分钟
-- 15次失败 → 锁定30分钟
-- 20次以上 → 锁定1小时
+**Cause**:
+The OAuth2 system implements an account lockout mechanism. Once the number of failed logins reaches a threshold, the account is temporarily locked:
 
-**解决方案**：
+- 5 failures → 1-minute lockout
+- 10 failures → 5-minute lockout
+- 15 failures → 30-minute lockout
+- 20+ failures → 1-hour lockout
 
-#### 方案1：使用自动清理的测试脚本
+**Solutions**:
 
-后端测试脚本（如 `test-admin-endpoints.ps1`）已经在结束时自动重置账号锁定状态。
+#### Option 1: use a test script with automatic cleanup
 
-对于本地PostgreSQL数据库，需要配置数据库密码：
+The backend test scripts (for example `test-admin-endpoints.ps1`) already reset the account lockout state automatically when they finish.
+
+For a local PostgreSQL database, you need to configure the database password:
 
 ```powershell
-# 编辑测试脚本，找到清理部分，设置密码
-$env:PGPASSWORD = "your_password"  # 修改为实际密码
+# Edit the test script, find the cleanup section, and set the password
+$env:PGPASSWORD = "your_password"  # change to the actual password
 ```
 
-#### 方案2：手动重置账号锁定
+#### Option 2: manually reset the account lockout
 
 ```powershell
-# 使用重置脚本
+# Use the reset script
 $env:PGPASSWORD = "your_password"
 .\scripts\backend\reset-account-lockout.ps1
 $env:PGPASSWORD = $null
 
-# 或直接使用SQL
+# Or use SQL directly
 psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET failed_login_count = 0, locked_until = 0 WHERE username='admin';"
 ```
 
-#### 方案3：等待锁定自动解除
+#### Option 3: wait for the lockout to expire
 
-根据失败次数，等待相应的时间后账号会自动解锁。
+Depending on the number of failures, the account unlocks automatically after the corresponding time.
 
-**预防措施**：
+**Preventive measures**:
 
-1. **使用专用测试账号**：不要在测试中使用生产admin账号
-2. **确保凭证正确**：检查测试脚本中的用户名和密码
-3. **测试后自动清理**：在测试脚本末尾添加清理代码
+1. **Use a dedicated test account**: never use the production admin account in tests
+2. **Make sure credentials are correct**: check the username and password in the test script
+3. **Clean up automatically after testing**: append cleanup code at the end of the test script
 
-详细说明请参考：[账号锁定机制](operate/account-lockout.md)
+For details, see [Account lockout mechanism](operate/account-lockout.md).
 
 ---
 
-## 附录 A: 从零接入检查清单
+## Appendix A: From-scratch adoption checklist
 
-将此清单用于新项目的 E2E 测试接入：
+Use this checklist when adopting E2E testing in a new project:
 
 - [ ] `npm install -D @playwright/test`
 - [ ] `npx playwright install chromium`
-- [ ] 创建 `playwright.config.ts`
-- [ ] 创建 `tests/e2e/helpers/mock-api.ts`
-- [ ] 定义 Mock 数据常量（与后端 API 响应结构一致）
-- [ ] 实现 `setupAuthenticatedMocks(page)` — 拦截所有认证 + 业务 API
-- [ ] 实现 `loginAsAdmin(page)` — UI 登录辅助函数
-- [ ] 创建第一个测试文件（建议从 auth 开始）
-- [ ] 添加 `package.json` 脚本
-- [ ] 配置 CI pipeline
+- [ ] Create `playwright.config.ts`
+- [ ] Create `tests/e2e/helpers/mock-api.ts`
+- [ ] Define mock data constants (matching the backend API response structure)
+- [ ] Implement `setupAuthenticatedMocks(page)` — intercept all authentication + business APIs
+- [ ] Implement `loginAsAdmin(page)` — a UI login helper
+- [ ] Create the first test file (auth is a good starting point)
+- [ ] Add `package.json` scripts
+- [ ] Configure the CI pipeline
 
-## 附录 B: Admin 前端 E2E 测试统计
+## Appendix B: Admin frontend E2E test statistics
 
-| 指标 | 数值 |
+| Metric | Value |
 |------|------|
-| 测试文件 | 16 |
-| 测试用例 | 174 |
-| 执行时间 | ~1 分钟 |
-| 后端依赖 | 无（全 Mock） |
-| 浏览器 | Chromium |
-| 并行执行 | 是 |
-| Mock API 端点 | 15+ |
+| Test files | 16 |
+| Test cases | 174 |
+| Execution time | ~1 minute |
+| Backend dependency | None (fully mocked) |
+| Browser | Chromium |
+| Parallel execution | Yes |
+| Mocked API endpoints | 15+ |
 
 ---
 
-> 本文档基于 fulla Admin 前端项目实践总结。项目源码：`frontends/admin/tests/e2e/`
+> This document summarizes practices from the fulla Admin frontend project. Project source: `frontends/admin/tests/e2e/`

--- a/docs/contribute/ci-cd-guide.md
+++ b/docs/contribute/ci-cd-guide.md
@@ -1,43 +1,43 @@
-# CI/CD 流水线指南 (CI/CD Guide)
+# CI/CD Pipeline Guide (CI/CD Guide)
 
-本文档说明项目的持续集成与持续交付（CI/CD）机制，基于 **GitHub Actions**。
+This document describes the project's continuous integration and continuous delivery (CI/CD) mechanism, built on **GitHub Actions**.
 
 ---
 
-## 1. 流水线概览
+## 1. Pipeline Overview
 
-CI 配置位于 `.github/workflows/ci.yml`，由三个 fail-fast 串联的 Job（含一条可复用工作流矩阵）组成：
+The CI configuration lives in `.github/workflows/ci.yml` and consists of three fail-fast, chained jobs (including a reusable-workflow matrix):
 
 ```
-Push/PR 到 master (及 workflow_dispatch)
+Push/PR to master (and workflow_dispatch)
         │
         ├── FAST gate
-        │     ├── static-checks (ubuntu-22.04) — 源码级守卫：
+        │     ├── static-checks (ubuntu-22.04) — source-level guards:
         │     │     arch-guard / migration-check / api-diff /
-        │     │     测试命名 / manage 脚本对等 / OpenAPI 校验 /
-        │     │     OpenAPI 治理门（三层一致性 + 版本同步）
-        │     └── frontend (_frontend.yml) — 前端属性测试
+        │     │     test naming / manage-script parity / OpenAPI checks /
+        │     │     OpenAPI governance gate (three-layer consistency + version sync)
+        │     └── frontend (_frontend.yml) — frontend property tests
         │
-        ├── openapi-governance (openapi-governance.yml, PR 触发) —
-        │     oasdiff 破坏性变更门（base vs PR 的 openapi.yaml；
-        │     豁免清单 tools/openapi-governance/oasdiff-breaking-ignore.md）
+        ├── openapi-governance (openapi-governance.yml, PR-triggered) —
+        │     oasdiff breaking-change gate (base vs PR openapi.yaml;
+        │     exemption list tools/openapi-governance/oasdiff-breaking-ignore.md)
         │
         ├── MAIN gate
-        │     └── build-test (_build-test.yml × {linux, windows, macos} 矩阵)
-        │           ├── 安装系统依赖 / Conan
-        │           ├── 配置并构建 (Conan + cmake --preset，带缓存)
-        │           ├── [linux] 启动 Postgres/Redis 容器并等待就绪
-        │           ├── [linux] 初始化数据库 Schema
-        │           ├── 运行 ctest + 命名发布门禁
-        │           └── [失败时] 上传测试日志 Artifact
+        │     └── build-test (_build-test.yml × {linux, windows, macos} matrix)
+        │           ├── install system dependencies / Conan
+        │           ├── configure and build (Conan + cmake --preset, with cache)
+        │           ├── [linux] start Postgres/Redis containers and wait until ready
+        │           ├── [linux] initialize the database schema
+        │           ├── run ctest + release naming gate
+        │           └── [on failure] upload test-log artifacts
         │
         └── RELEASE gate
-              └── sdk-smoke (_sdk-smoke.yml) — 全栈 find_package 冒烟
+              └── sdk-smoke (_sdk-smoke.yml) — full-stack find_package smoke test
 ```
 
 ---
 
-## 2. 触发条件
+## 2. Triggers
 
 ```yaml
 on:
@@ -52,93 +52,94 @@ concurrency:
   cancel-in-progress: true
 ```
 
-- **Push to master**：每次合并到 master 后自动触发全量检查。
-- **Pull Request**：每次 PR 创建/更新时在合并前自动触发，作为门禁检查。
-- **workflow_dispatch**：支持手动触发。
-- **并发控制**：同一分支的新运行会取消其进行中的旧运行。
+- **Push to master**: every merge to master automatically triggers the full check suite.
+- **Pull Request**: triggered automatically on PR creation/update, serving as a pre-merge gate check.
+- **workflow_dispatch**: manual triggering is supported.
+- **Concurrency control**: a new run for the same branch cancels any in-progress older run.
 
 ---
 
-## 3. 核心 Job 详解：`build-test`
+## 3. Core Job in Depth: `build-test`
 
-`build-test` 是一条可复用工作流（`_build-test.yml`），由 `ci.yml` 以 `{linux, windows, macos}` 矩阵调用，三个平台执行同一套 Conan + `cmake --preset` 构建与 CTest 测试，仅在需要时通过矩阵输入启用数据库。
+`build-test` is a reusable workflow (`_build-test.yml`) invoked by `ci.yml` as a `{linux, windows, macos}` matrix. All three platforms run the same Conan + `cmake --preset` build and CTest suite; the database is enabled via matrix inputs only where needed.
 
-### 3.1 Service Containers（仅 linux 矩阵腿）
+### 3.1 Service Containers (linux matrix leg only)
 
-CI 在 Linux 矩阵腿中用 Docker 容器启动 Postgres 和 Redis，并通过真实查询（非仅 `pg_isready`）确保就绪：
+In the Linux matrix leg, CI starts Postgres and Redis in Docker containers and confirms readiness with real queries (not just `pg_isready`):
 
-| Service | 镜像 | 端口 | 密码 |
+| Service | Image | Port | Password |
 |---|---|---|---|
 | PostgreSQL | `postgres:17-alpine` | `5432` | `123456` |
-| Redis | `redis:7-alpine` | `6379` | 无（CI 环境简化配置）|
+| Redis | `redis:7-alpine` | `6379` | None (simplified CI configuration)|
 
-> PostgreSQL 镜像与 deploy 默认（`postgres:17-alpine`，2026-08-18 起）对齐——CI 覆盖的
-> 就是部署目标大版本（含 V025 分区/V026 等 migration 在 17 上的行为）。
+> The PostgreSQL image matches the deploy default (`postgres:17-alpine`, since 2026-08-18) — CI therefore covers
+> the major version actually deployed (including how migrations such as V025 partitioning / V026 behave on 17).
 
-> **WARNING** **注意**：CI 中 Redis 无密码，因此测试配置通过环境变量 `FULLA_REDIS_PASSWORD=""` 覆盖。Windows/macOS 矩阵腿 `use_database=false`，改用内存存储配置（`config.ci.json`）。
+> **WARNING**: Redis runs without a password in CI, so the test configuration overrides it with the environment variable `FULLA_REDIS_PASSWORD=""`. The Windows/macOS matrix legs use `use_database=false` and fall back to the in-memory storage configuration (`config.ci.json`).
 
-### 3.2 构建缓存策略
+### 3.2 Build Cache Strategy
 
-为加速 CI 构建速度，对 Conan 依赖做缓存：
+To speed up CI builds, Conan dependencies are cached:
 
-| 缓存 | 缓存键 | 内容 |
+| Cache | Cache key | Contents |
 |---|---|---|
-| **Conan 依赖缓存** | `conan-{OS}-v1-cpp17-{conanfile.py + conan.lock hash}` | `~/.conan2` 目录（第三方依赖，含 Drogon）|
+| **Conan dependency cache** | `conan-{OS}-v1-cpp17-{conanfile.py + conan.lock hash}` | The `~/.conan2` directory (third-party dependencies, including Drogon)|
 
-初次构建约需 **15-20 分钟**；缓存命中后降至 **3-5 分钟**。
+A cold build takes roughly **15-20 minutes**; with a cache hit this drops to **3-5 minutes**.
 
-### 3.3 数据库初始化
+### 3.3 Database Initialization
 
-测试前执行 migration 脚本初始化数据库：
+Before testing, migration scripts initialize the database:
 
 ```bash
-# 按顺序执行所有 migration 文件
+# Run all migration files in order
 for f in apps/server/migrations/V*.sql; do
     psql -h localhost -U fulla_user -d fulla_db -f "$f"
 done
 
-# 执行 seed 数据（开发/测试环境）
+# Load seed data (dev/test environments)
 for f in apps/server/seed/*.sql; do
     psql -h localhost -U fulla_user -d fulla_db -f "$f"
 done
 ```
 
-> **注意**: 旧的 `sql/001_*.sql` ~ `sql/004_*.sql` 文件已废弃并删除，所有 schema 定义统一在 `apps/server/migrations/` 目录中管理。
+> **Note**: the legacy `sql/001_*.sql` through `sql/004_*.sql` files are deprecated and removed; all schema definitions are now managed centrally under `apps/server/migrations/`.
 
-### 3.4 测试执行
+### 3.4 Test Execution
 
 ```bash
 ctest -V -C Release --output-on-failure --timeout 120
 ```
 
-- `-V` : 详细输出
-- `--output-on-failure` : 失败时打印测试标准输出
-- `--timeout 120` : 单个测试最长 2 分钟
+- `-V` : verbose output
+- `--output-on-failure` : print test stdout on failure
+- `--timeout 120` : each test gets at most 2 minutes
 
-### 3.5 失败日志上传
+### 3.5 Failure Log Upload
 
-测试失败时，CI 会自动打包并上传以下内容作为 Artifact（保留 7 天）：
-- `build/Testing/` — CTest 测试报告
-- `apps/server/logs/` — 应用运行日志
+When tests fail, CI automatically packages and uploads the following as artifacts (retained for 7 days):
 
----
-
-## 4. 镜像构建与签名
-
-CI 流水线本身不构建 Docker 镜像。容器镜像的多架构构建、推送 GHCR、cosign 签名与 syft SBOM 由 `release.yml` 在打 SemVer Tag（`vX.Y.Z`）时完成。详见 [Releases & Supply Chain Security](https://github.com/voidvec/fulla#releases--supply-chain-security)。
+- `build/Testing/` — CTest test reports
+- `apps/server/logs/` — application runtime logs
 
 ---
 
-## 5. 本地复现 CI 环境
+## 4. Image Build and Signing
 
-如需本地模拟 CI 行为：
+The CI pipeline itself does not build Docker images. Multi-arch container image builds, GHCR pushes, cosign signing, and syft SBOMs are handled by `release.yml` when a SemVer tag (`vX.Y.Z`) is pushed. See [Releases & Supply Chain Security](https://github.com/voidvec/fulla#releases--supply-chain-security).
+
+---
+
+## 5. Reproducing the CI Environment Locally
+
+To simulate CI behavior locally:
 
 ```powershell
-# 1. 启动基础设施（CI 中使用 Service Container，本地用 Docker）
+# 1. Start the infrastructure (CI uses service containers; locally, use Docker)
 docker run -d -p 5432:5432 -e POSTGRES_USER=fulla_user -e POSTGRES_PASSWORD=123456 -e POSTGRES_DB=fulla_db postgres:17-alpine
 docker run -d -p 6379:6379 redis:7-alpine
 
-# 2. 初始化数据库
+# 2. Initialize the database
 $env:PGPASSWORD = "123456"
 Get-ChildItem "apps\server\migrations\V*.sql" | Sort-Object Name | ForEach-Object {
     psql -h localhost -U fulla_user -d fulla_db -f $_.FullName
@@ -147,7 +148,7 @@ Get-ChildItem "apps\server\seed\*.sql" | ForEach-Object {
     psql -h localhost -U fulla_user -d fulla_db -f $_.FullName
 }
 
-# 3. 构建并运行测试（build.bat 走 Conan + cmake --preset，Release 落到 build/windows-msvc）
+# 3. Build and run tests (build.bat uses Conan + cmake --preset; Release lands in build/windows-msvc)
 .\scripts\backend\build.bat -release
 cd build\windows-msvc
 $env:FULLA_REDIS_PASSWORD = ""
@@ -156,23 +157,23 @@ ctest -V -C Release --output-on-failure
 
 ---
 
-## 6. 多平台矩阵
+## 6. Multi-Platform Matrix
 
-多平台 CI 已合并进 `ci.yml` 的 `build-test` Job，通过 `include` 矩阵在同一套可复用工作流（`_build-test.yml`）上跑三个平台。
+Multi-platform CI has been consolidated into the `build-test` job in `ci.yml`; an `include` matrix runs all three platforms on the same reusable workflow (`_build-test.yml`).
 
 ### Quick Reference
 
-- **Workflow File:** `.github/workflows/ci.yml`（调用 `_build-test.yml`）
+- **Workflow File:** `.github/workflows/ci.yml` (invokes `_build-test.yml`)
 - **Platforms:** Linux (ubuntu-22.04), Windows (windows-2022), macOS (macos-14)
 - **Trigger:** Push to master, pull requests, manual workflow dispatch
 - **Runtime:** ~15-20 minutes cold cache, ~3-5 minutes warm cache per platform
 
 ### Platform-Specific Features
 
-每个平台的差异仅通过矩阵输入表达（无复制粘贴的流水线）：
+Per-platform differences are expressed entirely through matrix inputs (no copy-pasted pipelines):
 
-- **Linux:** 系统依赖经 apt 安装；用 Docker 容器跑 PostgreSQL/Redis；执行数据库初始化与命名发布门禁
-- **Windows:** Conan 依赖管理，MSVC 2022 编译器；内存存储配置（`use_ci_config`），无外部 DB
-- **macOS:** Homebrew（仅 `brew update`）；arm64 构建（`-s arch=armv8`，runner 为 `macos-14`）；内存存储配置
+- **Linux:** system dependencies installed via apt; PostgreSQL/Redis run in Docker containers; performs database initialization and the release naming gate
+- **Windows:** Conan dependency management with the MSVC 2022 compiler; in-memory storage configuration (`use_ci_config`), no external DB
+- **macOS:** Homebrew (`brew update` only); arm64 builds (`-s arch=armv8`, runner is `macos-14`); in-memory storage configuration
 
 ---

--- a/docs/contribute/testing-guide.md
+++ b/docs/contribute/testing-guide.md
@@ -1,19 +1,19 @@
-# 测试策略与执行指南 (Testing Guide)
+# Testing Strategy and Execution Guide (Testing Guide)
 
-本文档说明项目的测试分层策略、各测试文件的覆盖范围，以及如何在本地执行全套测试。
+This document describes the project's test layering strategy, the coverage of each test file, and how to run the full test suite locally.
 
 ---
 
-## 1. 测试前置要求
+## 1. Test Prerequisites
 
-在运行测试前，请确保以下服务已就绪：
+Before running tests, make sure the following services are ready:
 
-| 服务 | 地址 | 说明 |
+| Service | Address | Notes |
 |---|---|---|
-| **PostgreSQL** | `localhost:5432` | 数据库名: `fulla_db` / 用户: `fulla_user` / 密码: `123456` |
-| **Redis** | `localhost:6379` | 密码: `123456`（与 `config.json` 一致）|
+| **PostgreSQL** | `localhost:5432` | Database: `fulla_db` / user: `fulla_user` / password: `123456` |
+| **Redis** | `localhost:6379` | Password: `123456` (consistent with `config.json`)|
 
-> **快速启动基础设施**：如果你使用 Docker，可以单独启动 postgres 和 redis 容器:
+> **Quick-start infrastructure**: if you use Docker, you can start the postgres and redis containers separately:
 > ```powershell
 > docker run -d -p 5432:5432 -e POSTGRES_USER=fulla_user -e POSTGRES_PASSWORD=123456 -e POSTGRES_DB=fulla_db postgres:17-alpine
 > docker run -d -p 6379:6379 redis:7-alpine redis-server --requirepass 123456
@@ -21,279 +21,272 @@
 
 ---
 
-## 2. 测试分层
+## 2. Test Layering
 
-测试编译为**两类可执行文件**：
+Tests are compiled into **two categories of executables**:
 
-1. **按库的 gtest 二进制文件**（Domain 层，纯单元测试，无 DB/无 Drogon）：
-   - `libs/common/test/fulla-common-test` — `ConfigManager`、`ErrorCatalog`、`Result`、值对象
-   - `libs/common/testing/test/fulla-common-testing-test` — 假实现（`FakeClock`/`FakeCryptoProvider`/`FakeLogger` 等）的确定性验证
+1. **Per-library gtest binaries** (Domain layer, pure unit tests, no DB / no Drogon):
+   - `libs/common/test/fulla-common-test` — `ConfigManager`, `ErrorCatalog`, `Result`, value objects
+   - `libs/common/testing/test/fulla-common-testing-test` — deterministic verification of fake implementations (`FakeClock`/`FakeCryptoProvider`/`FakeLogger`, etc.)
    - `libs/oauth2/test/fulla-oauth2-test` — `TokenService`/`AuthorizationService`/`ClientService`/`JwkManager`/`Pkce`/`ScopeDecisionEngine`/`TokenCrypto`
-   - `libs/identity/test/fulla-identity-test` — `AuthService`/`MfaService`/`TotpUtils`/`SessionManager`/`WebAuthnService`/社交登录（Google/WeChat/GitHub）
-   - 这些用 gtest（非 `DROGON_TEST`），由各 lib 的 `test/CMakeLists.txt` 通过 `gtest_discover_tests` 注册为独立 ctest 条目。
+   - `libs/identity/test/fulla-identity-test` — `AuthService`/`MfaService`/`TotpUtils`/`SessionManager`/`WebAuthnService`/social login (Google/WeChat/GitHub)
+   - These use gtest (not `DROGON_TEST`) and are registered as independent ctest entries by each lib's `test/CMakeLists.txt` via `gtest_discover_tests`.
 
-2. **主测试二进制文件 `tests/fulla-tests`**（`DROGON_TEST` 框架，包含所有需要 Drogon/DB 的层级）：
+2. **Main test binary `tests/fulla-tests`** (`DROGON_TEST` framework, contains all layers that require Drogon/DB):
 
-| 层级 | 目录 | 覆盖范围 | 外部依赖 |
+| Level | Directory | Coverage | External dependencies |
 |---|---|---|---|
-| **Level 1 — 单元测试** | `tests/unit/`（`config/`、`error/`、`utils/`、`validation/`、`plugin/`、`schema/`、`subject/`、`initorder/`） | 纯逻辑：错误信封、密码哈希、PKCE/CryptoUtils、RuleSet 校验、配置加载、OpenAPI 生成 | 无 |
-| **Level 2 — 契约测试** | `tests/contract/` | 跨后端（Postgres/Redis/Memory）的仓储契约一致性：`IClientRepository`/`IGrantRepository`/`ITokenRepository`/`IConsentRepository`/`IUserRepository` | Memory 必跑；Postgres/Redis 在 `getPostgresClientOrNull()`/`getRedisClientOrNull()` 返回空时自动 skip |
-| **Level 3 — 集成测试** | `tests/integration/`（`auth/`、`token/`、`storage/`、`concurrency/`、`error/`、`plugin/`） | 完整业务流程、并发竞态、错误信封、插件组装 | Postgres / Redis（memory-only 模式 `-DFULLA_MEMORY_TESTS_ONLY=ON` 下跑 Memory 子集） |
-| **Level 4 — 安全测试** | `tests/security/` | SQL 注入、XSS、命令注入、CORS、Token 安全、速率限制 | Postgres / Redis |
-| **Level 5 — E2E/功能** | `tests/e2e-backend/`、`tests/performance/` | OAuth2 完整流程、性能基准 | Postgres + Redis + Drogon App |
+| **Level 1 — Unit tests** | `tests/unit/` (`config/`, `error/`, `utils/`, `validation/`, `plugin/`, `schema/`, `subject/`, `initorder/`) | Pure logic: error envelopes, password hashing, PKCE/CryptoUtils, RuleSet validation, config loading, OpenAPI generation | None |
+| **Level 2 — Contract tests** | `tests/contract/` | Repository contract consistency across backends (Postgres/Redis/Memory): `IClientRepository`/`IGrantRepository`/`ITokenRepository`/`IConsentRepository`/`IUserRepository` | Memory always runs; Postgres/Redis are automatically skipped when `getPostgresClientOrNull()`/`getRedisClientOrNull()` return null |
+| **Level 3 — Integration tests** | `tests/integration/` (`auth/`, `token/`, `storage/`, `concurrency/`, `error/`, `plugin/`) | Full business flows, concurrency races, error envelopes, plugin assembly | Postgres / Redis (in memory-only mode `-DFULLA_MEMORY_TESTS_ONLY=ON`, the Memory subset runs) |
+| **Level 4 — Security tests** | `tests/security/` | SQL injection, XSS, command injection, CORS, token security, rate limiting | Postgres / Redis |
+| **Level 5 — E2E/functional** | `tests/e2e-backend/`, `tests/performance/` | Complete OAuth2 flows, performance benchmarks | Postgres + Redis + Drogon App |
 
-> 内存模式：配置 `-DFULLA_MEMORY_TESTS_ONLY=ON` 可在**无外部 DB** 时跑完整套件（Postgres/Redis 测试自动 skip）——这是 Windows CI 的做法。
+> Memory mode: configuring `-DFULLA_MEMORY_TESTS_ONLY=ON` lets the full suite run **without an external DB** (Postgres/Redis tests are automatically skipped) — this is how Windows CI does it.
 
-> 安全测试用例数、功能测试用例数与覆盖清单见各目录下的测试文件头注释；本节不再硬编码具体数量（数量随迭代增长，统一以 §7 的实测统计为准）。
+> For security test case counts, functional test case counts, and coverage lists, see the header comments of the test files in each directory; this section no longer hardcodes specific counts (counts grow with each iteration — the measured statistics in §7 are authoritative).
 
-### DROGON_TEST 断言书写规范 — `CHECK`/`REQUIRE` 内禁止裸布尔运算符 [#MUST]
+### DROGON_TEST assertion style — bare boolean operators are forbidden inside `CHECK`/`REQUIRE` [#MUST]
 
-drogon 的 `CHECK`/`REQUIRE` 是**宏不是函数**：`CHECK_INTERNAL__` 把表达式展开为
-`(drogon::test::internal::Decomposer() <= expr)`，而宏实参替换不加括号，所以**裸写的
-`a || b`（或 `a && b`）会重结合成 `(Decomposer() <= a) || b`**——结果静默错误，症状像
-"断言随机挂"。真实案例（PR #68 调试）：`CHECK(body.isMember("error") || body.isMember("code"))`
-失败，但 `LOG_INFO` 打出的原始 body 里明明有 `error` 键。
+drogon's `CHECK`/`REQUIRE` are **macros, not functions**: `CHECK_INTERNAL__` expands the expression to `(drogon::test::internal::Decomposer() <= expr)`, and macro argument substitution adds no parentheses, so a **bare `a || b` (or `a && b`) re-associates into `(Decomposer() <= a) || b`** — the result is silently wrong, with symptoms that look like "assertions randomly failing". Real case (PR #68 debugging): `CHECK(body.isMember("error") || body.isMember("code"))` failed, even though the raw body printed by `LOG_INFO` clearly contained the `error` key.
 
-**规则**：`CHECK(...)`/`REQUIRE(...)` 的顶层实参里出现 `||`/`&&` 时，必须满足其一：
+**Rule**: whenever `||`/`&&` appears in the top-level argument of `CHECK(...)`/`REQUIRE(...)`, one of the following must hold:
 
 ```cpp
-// ✅ 拆成两条断言（首选——失败信息更精确）
+// ✅ Split into two assertions (preferred — more precise failure messages)
 CHECK(body.isMember("error"));
 CHECK(body.isMember("code"));
 
-// ✅ 整体加括号（外层括号让链式表达式作为一个操作数绑定到 <=）
+// ✅ Wrap the whole expression in parentheses (outer parentheses bind the chained expression as a single operand to <=)
 CHECK((a != std::string::npos || b != std::string::npos));
 
-// ✅ 仓库既有先例：显式 (bool) 转换（tests/e2e-backend/oauth2_flows/FunctionalTest.cc）
+// ✅ Existing repo precedent: explicit (bool) cast (tests/e2e-backend/oauth2_flows/FunctionalTest.cc)
 CHECK((bool)(response.find("code=") != std::string::npos ||
              response.find("error") != std::string::npos));
 
-// ❌ 禁止：裸顶层布尔链（宏展开后语义被破坏）
+// ❌ Forbidden: bare top-level boolean chain (semantics broken after macro expansion)
 CHECK(body.isMember("error") || body.isMember("code"));
 ```
 
-说明：运算符嵌套在**调用/下标/子表达式括号内**（如 `CHECK(f(a || b))`、`CHECK(x == (a || b))`）
-不受影响——它在绑定给 `<=` 之前已求值。`CHECK_THROWS`/`REQUIRE_THROWS` 系列走 `EVAL__`
-路径，也不受影响。
+Note: operators nested **inside call/subscript/sub-expression parentheses** (e.g. `CHECK(f(a || b))`, `CHECK(x == (a || b))`) are unaffected — they are evaluated before being bound to `<=`. The `CHECK_THROWS`/`REQUIRE_THROWS` family goes through the `EVAL__` path and is also unaffected.
 
-**CI 强制**：`tools/test/scripts/drogon_macro_bool_check.py` 扫描 `tests/` 树并对违规
-报错（static-checks 步骤，与命名规范检查并列）；`--selftest` 可自验。
+**CI enforcement**: `tools/test/scripts/drogon_macro_bool_check.py` scans the `tests/` tree and fails on violations (a static-checks step, alongside the naming-convention check); `--selftest` can self-verify.
 
-### Level 4 补充明细 — 安全测试 (Security Tests)
+### Level 4 details — Security Tests
 
-| 测试文件 | 覆盖范围 |
+| Test file | Coverage |
 |---|---|
-| `SecurityTest.cc` | SQL 注入、XSS、命令注入、输入验证、CORS、Token 安全、速率限制、健康检查安全 |
+| `SecurityTest.cc` | SQL injection, XSS, command injection, input validation, CORS, token security, rate limiting, health-check security |
 
-覆盖要点：输入验证（注入/长度/空值）、认证授权（无效凭据、速率限制）、CORS 双向、敏感数据传递、Token 安全（无效/缺失授权码与 Refresh Token）、安全头（含 HSTS）、暴力破解防护、健康检查信息泄露。
+Coverage highlights: input validation (injection/length/null values), authentication and authorization (invalid credentials, rate limiting), CORS in both directions, sensitive-data transmission, token security (invalid/missing authorization codes and refresh tokens), security headers (including HSTS), brute-force protection, health-check information leakage.
 
-### Level 5 补充明细 — E2E / 功能测试 (Functional Tests)
+### Level 5 details — E2E / Functional Tests
 
-| 测试文件 | 覆盖范围 | 依赖 |
+| Test file | Coverage | Dependencies |
 |---|---|---|
-| `IntegrationE2ETest.cc` | 模拟完整 OAuth2 授权码流程：HTTP 请求 → 授权 → 登录 → 换 Token → UserInfo 验证 | Postgres + Redis + 运行中的 Drogon App |
-| `FunctionalTest.cc` | OAuth2 完整流程、错误处理、UTF-8/Emoji 字符、健康检查、RBAC、Token 生命周期、输入验证、速率限制 | Postgres + Redis |
+| `IntegrationE2ETest.cc` | Simulates the complete OAuth2 authorization code flow: HTTP request → authorize → login → token exchange → UserInfo verification | Postgres + Redis + a running Drogon App |
+| `FunctionalTest.cc` | Complete OAuth2 flows, error handling, UTF-8/Emoji characters, health checks, RBAC, token lifecycle, input validation, rate limiting | Postgres + Redis |
 
-覆盖要点：完整授权码流程、错误场景、UTF-8/Emoji 边界、RBAC 未授权路径、Token 生命周期异常路径、超长输入、速率限制检测、端点可用性。
+Coverage highlights: the complete authorization code flow, error scenarios, UTF-8/Emoji boundaries, RBAC unauthorized paths, token lifecycle exception paths, overlong input, rate-limit detection, endpoint availability.
 
-> 用例数量随版本演进，**以 `ctest -N` 实测为准**（当前全套基线见 §7）。
+> Test case counts evolve with each version — **the `ctest -N` measurement is authoritative** (see §7 for the current full-suite baseline).
 
 ---
 
-## 3. 执行方式
+## 3. How to Run
 
-### 方式一：通过 CTest（推荐）
+### Option 1: via CTest (recommended)
 
 ```powershell
-# 在构建完成后执行（目录为 build/<preset>，Windows Release 为 windows-msvc）
+# Run after the build completes (directory is build/<preset>; on Windows Release it is windows-msvc)
 cd build\windows-msvc
 ctest -C Release --output-on-failure --timeout 120
 ```
 
-> **输出策略**：默认仅打印失败用例的日志与末尾汇总（`成功数 / 失败数 / 总数`）。如需查看每个用例（含通过用例）的完整输出，加 `--verbose`（`-V`）；如需完全静默、只看汇总行，加 `-Q`。`manage.sh test-backend -q` / `manage.ps1 test-backend -q` 等价于 `-Q`。
+> **Output policy**: by default only the logs of failed test cases and the final summary (`passed / failed / total`) are printed. To see the full output of every test case (including passing ones), add `--verbose` (`-V`); for complete silence with only the summary line, add `-Q`. `manage.sh test-backend -q` / `manage.ps1 test-backend -q` is equivalent to `-Q`.
 
-### 方式二：直接运行测试可执行文件
+### Option 2: run the test executable directly
 
-测试可执行文件内部会自动启动 Drogon App 实例（`test_main.cc` 中通过信号量同步），**无需手动启动后端服务**。
+The test executable automatically starts a Drogon App instance internally (synchronized via a semaphore in `test_main.cc`); **there is no need to start the backend service manually**.
 
 ```powershell
 cd build\windows-msvc\tests\Release
 .\fulla-tests.exe
 ```
 
-### 方式三：使用 manage 脚本
+### Option 3: use the manage scripts
 
-`manage.ps1`（Windows）/ `manage.sh`（Linux/macOS）封装了与 CI 相同的构建+测试流程：
+`manage.ps1` (Windows) / `manage.sh` (Linux/macOS) wraps the same build + test pipeline used by CI:
 
 ```powershell
-# 构建并运行后端测试套件（与 manage.sh test-backend 等价）
+# Build and run the backend test suite (equivalent to manage.sh test-backend)
 .\manage.ps1 test-backend
 
-# 完整循环：构建 + 单元/集成测试 + 管理端点 API 测试
+# Full loop: build + unit/integration tests + admin endpoint API tests
 .\manage.ps1 full-test
 
-# 仅跑管理端点 / OAuth2 端点的 API 脚本
+# Run only the admin-endpoint / OAuth2-endpoint API scripts
 .\manage.ps1 test-admin-endpoints
 .\manage.ps1 test-oauth2-endpoints
 ```
 
 ---
 
-## 4. 测试输出示例
+## 4. Sample Test Output
 
 ```
 All tests passed (N assertions in M tests)
 ```
 
-如果出现失败，失败的测试名称和断言位置会被打印：
+If a failure occurs, the failed test name and assertion location are printed:
 ```
 In test case SomeTestName
   SomeTestFile.cc:63  FAILED:
     CHECK(c.has_optional())
 ```
 
-**常见失败原因**：
-- Redis 或 PostgreSQL 服务未启动 → 检查服务是否可达
-- Redis 密码不匹配 → 检查 `config.json` 中的 `passwd` 字段
-- 数据库未初始化 → 执行 `apps/server/migrations/` 目录下的迁移脚本（后端在 `FULLA_AUTO_MIGRATE=true` 时也会自动执行）
+**Common failure causes**:
+- Redis or PostgreSQL service not started → check that the services are reachable
+- Redis password mismatch → check the `passwd` field in `config.json`
+- Database not initialized → run the migration scripts under `apps/server/migrations/` (the backend also runs them automatically when `FULLA_AUTO_MIGRATE=true`)
 
 ---
 
-## 5. CI 中的测试
+## 5. Tests in CI
 
-每次 Push 到 `master` 或发起 PR 时，GitHub Actions CI 会自动执行：
+On every push to `master` or PR, GitHub Actions CI automatically:
 
-1. 启动 Postgres 和 Redis Service Container
-2. 初始化数据库 Schema
-3. 编译项目
-4. 运行 `ctest`
+1. Starts the Postgres and Redis service containers
+2. Initializes the database schema
+3. Builds the project
+4. Runs `ctest`
 
-详见 [CI/CD 指南](../contribute/ci-cd-guide)。
-
----
-
-## 6. 测试报告 (Test Reports)
-
-历史的安全/功能测试报告、Bug 状态分析与连接泄漏验证报告属于过程性档案，已随文档治理移出仓库（维护者本地保存）。当前测试状态以 CI 与本节口径为准：
-
-- **CI 全绿**是合入门槛（三平台矩阵，见 [CI/CD 指南](ci-cd-guide.md)）。
-- 安全与功能覆盖面见 §2 Level 4/5 明细；数量以 `ctest -N` 实测为准。
-- 历史报告中的结论性内容（如 April 快照中发现的安全缺陷）已修复并沉淀为回归测试用例。
+See the [CI/CD Guide](../contribute/ci-cd-guide) for details.
 
 ---
 
-## 7. 测试覆盖率总结
+## 6. Test Reports
 
-### 总体测试状态
+Historical security/functional test reports, bug status analyses, and connection-leak verification reports are process archives that were moved out of the repository as part of documentation governance (kept locally by maintainers). Current test status is defined by CI and the scope of this section:
 
-> 以下数字为**实测统计**（Windows MSVC Release 构建，无外部 DB，Postgres/Redis 测试 skip）。在带 Postgres+Redis 的环境（如 Linux CI 或本地 WSL+Docker）下，被 skip 的契约/集成测试会激活，ctest 条目数会进一步增加。
+- **A fully green CI** is the merge gate (three-platform matrix; see the [CI/CD Guide](ci-cd-guide.md)).
+- For security and functional coverage see the §2 Level 4/5 details; counts are authoritative per `ctest -N`.
+- Actionable findings from the historical reports (e.g. security defects found in the April snapshot) have been fixed and preserved as regression test cases.
 
-| 测试来源 | 通过 | 失败 | 总计 | 通过率 |
+---
+
+## 7. Test Coverage Summary
+
+### Overall test status
+
+> The numbers below are **measured statistics** (Windows MSVC Release build, no external DB, Postgres/Redis tests skipped). In an environment with Postgres+Redis (e.g. Linux CI or local WSL+Docker), the skipped contract/integration tests activate and the ctest entry count increases further.
+
+| Test source | Passed | Failed | Total | Pass rate |
 |---------|------|------|------|--------|
-| **按库 gtest 二进制**（2026-06 基线快照；当前全套 ctest 为 501，以 `ctest -N` 实测为准） | 364 | 0 | 364 | 100% |
-| **主测试二进制 ctest 条目**（含 Contract 标签 + OAuth2Tests 全量） | 450 | 0 | 450 | 100% |
+| **Per-library gtest binaries** (2026-06 baseline snapshot; the current full ctest count is 501 — the `ctest -N` measurement is authoritative) | 364 | 0 | 364 | 100% |
+| **Main test binary ctest entries** (including the Contract label + the full OAuth2Tests run) | 450 | 0 | 450 | 100% |
 
-> 注：两列数字有重叠关系——主二进制内含所有 `DROGON_TEST` 单元/集成测试（作为一个 `OAuth2Tests` 条目运行）；按库 gtest 二进制是 Domain 层的纯单元测试，独立编译运行。`450` 条 ctest 中 84 条带 `Contract` 标签（可用 `ctest -L Contract` 单独跑）。
+> Note: the two rows overlap — the main binary contains all `DROGON_TEST` unit/integration tests (run as a single `OAuth2Tests` entry), while the per-library gtest binaries are pure Domain-layer unit tests compiled and run independently. Of the `450` ctest entries, 84 carry the `Contract` label (run them alone with `ctest -L Contract`).
 
-### 代码覆盖率
+### Code coverage
 
-实测行覆盖率（gcov，gcc 13.3 Debug 构建，WSL Ubuntu 24.04，Postgres+Redis 激活；排除 ORM 自动生成的 `models/`；测量于 7ba8068，全部 5 个测试二进制均已执行）：
+Measured line coverage (gcov, gcc 13.3 Debug build, WSL Ubuntu 24.04, Postgres+Redis active; ORM-generated `models/` excluded; measured at 7ba8068 with all 5 test binaries executed):
 
-| 库 | 行覆盖 | 备注 |
+| Library | Line coverage | Notes |
 |---|---|---|
-| libs/common | 69.4% (318/458) | ErrorCatalog/ErrorTypes/ErrorContext/ConfigManager（由 per-lib gtest 二进制 `fulla-common-test` 驱动）；ConfigManager 环境相关分支与 ErrorCatalog 部分分支未覆盖 |
+| libs/common | 69.4% (318/458) | ErrorCatalog/ErrorTypes/ErrorContext/ConfigManager (driven by the per-lib gtest binary `fulla-common-test`); ConfigManager environment-related branches and some ErrorCatalog branches uncovered |
 | libs/identity | **96.9%** (590/609) | Auth/Mfa/WebAuthn/Social/Totp/Session |
-| libs/storage-memory | **97.1%** (431/444) | Memory 后端全方法覆盖（CI 必跑路径） |
+| libs/storage-memory | **97.1%** (431/444) | All methods of the Memory backend covered (the mandatory CI path) |
 | libs/oauth2 | **92.1%** (627/681) | TokenService/AuthService/ClientService/JwkManager/Pkce |
-| libs/storage-redis | 46.2% (306/663) | 契约测试覆盖 getClient/validate/grant/token/consent 主路径；Lua 脚本与 transaction CRUD 待补 |
-| libs/storage-postgres | 43.9% (727/1657) | 契约测试覆盖主路径；剩余盲区为事务/错误回退分支（需注入故障才能触发） |
-| libs/drogon | **53.5%** (4807/8978) | admin 0%→55-69%、admin 控制器 0%→91-100%；authorize/health/discovery/mfa/deviceauth/userselfservice/apidoc 控制器补强；社交 OAuth 控制器经 mock 注入补强（Google 38.3%、WeChat 30.6%、GitHub 32.5%）；WebAuthn 39.2%（非加密 stub，无需 authenticator） |
-| **整体** | **57.9%** (7806/13490) | 上表逐库求和（`scripts/measure_coverage.py` 的 OVERALL 即逐库之和）；从 48.5% 基线提升 +9.4pp |
+| libs/storage-redis | 46.2% (306/663) | Contract tests cover the getClient/validate/grant/token/consent main paths; Lua scripts and transaction CRUD still to be covered |
+| libs/storage-postgres | 43.9% (727/1657) | Contract tests cover the main paths; the remaining blind spots are transaction/error-fallback branches (require fault injection to trigger) |
+| libs/drogon | **53.5%** (4807/8978) | admin 0%→55-69%, admin controllers 0%→91-100%; authorize/health/discovery/mfa/deviceauth/userselfservice/apidoc controllers reinforced; social OAuth controllers reinforced via mock injection (Google 38.3%, WeChat 30.6%, GitHub 32.5%); WebAuthn 39.2% (non-crypto stub, no authenticator needed) |
+| **Overall** | **57.9%** (7806/13490) | Sum of the per-library rows above (the OVERALL of `scripts/measure_coverage.py` is exactly that per-library sum); +9.4pp improvement over the 48.5% baseline |
 
-> 上一轮基线为 48.5% (7091/14631)；本轮通过 admin 层 HTTP 集成测试 + 控制器补强 + 社交 OAuth/WebAuthn 的 mock 注入测试（`tests/common/SocialMockFixture.h` + `libs/identity/include/fulla/identity/testing/` 的共享 Fake）将整体提升到 57.9%。社交 OAuth 的 Google/WeChat/GitHub 均可经 mock 注入在 memory 模式下跑（注入路径不写 DB）；其中 GitHub happy-path 最初因 `issueTokensForUser` 直连 `getDbClient()` 无法在 memory 模式覆盖，随后已重构为经 `OAuth2Plugin::saveTokenPair` 存储抽象持久化（见 `SocialLoginHttpTest.cc` 的 `Integration_P0_GitHubLogin_FakeExchange_ReturnsTokens`），happy-path 现已可测（GitHubController 从 5.9% 提升到 32.5%）；WebAuthn 为非加密 stub，Postgres 模式下完整可测。注：此前文档的 58.8% 系旧逐库数字求和（其中 common 的 98.8% 为陈旧数据，现 `libs/common/src` 仅 4 个源文件 458 行，实测 69.4%）；本表已全部替换为 7ba8068 的实测值。剩余盲区：storage-postgres 事务/错误回退分支（需故障注入）。
+> The previous-round baseline was 48.5% (7091/14631); this round raised the overall figure to 57.9% through admin-layer HTTP integration tests + controller reinforcement + mock-injection tests for social OAuth/WebAuthn (`tests/common/SocialMockFixture.h` + the shared Fakes in `libs/identity/include/fulla/identity/testing/`). All of social OAuth's Google/WeChat/GitHub can run in memory mode via mock injection (the injection path writes no DB); the GitHub happy-path initially could not be covered in memory mode because `issueTokensForUser` called `getDbClient()` directly, and was subsequently refactored to persist through the `OAuth2Plugin::saveTokenPair` storage abstraction (see `Integration_P0_GitHubLogin_FakeExchange_ReturnsTokens` in `SocialLoginHttpTest.cc`), so the happy-path is now testable (GitHubController improved from 5.9% to 32.5%); WebAuthn is a non-crypto stub, fully testable in Postgres mode. Note: the 58.8% quoted by an earlier version of this document was a sum of stale per-library numbers (the 98.8% for common was outdated data — `libs/common/src` now has only 4 source files totaling 458 lines, measured at 69.4%); this table has been fully replaced with the values measured at 7ba8068. Remaining blind spots: storage-postgres transaction/error-fallback branches (require fault injection).
 
-#### ⚠ 实测覆盖率必须跑全部 5 个测试二进制
+#### ⚠ Measured coverage requires running all 5 test binaries
 
-实测数字依赖**全部 5 个测试二进制**都执行（仅跑主二进制 `fulla-tests` 会漏掉 4 个 per-lib gtest 二进制贡献的 domain 层覆盖率，common 会被低估到 ~60%）：
+The measured numbers depend on **all 5 test binaries** being executed (running only the main binary `fulla-tests` misses the domain-layer coverage contributed by the 4 per-lib gtest binaries, and common would be underestimated at ~60%):
 
-1. `libs/common/test/fulla-common-test`（40 用例）
-2. `libs/common/testing/test/fulla-common-testing-test`（43 用例）
-3. `libs/identity/test/fulla-identity-test`（130 用例）
-4. `libs/oauth2/test/fulla-oauth2-test`（151 用例）
-5. `tests/fulla-tests`（450 条 ctest，含所有 `DROGON_TEST` 单元/集成/契约/admin HTTP 测试）
+1. `libs/common/test/fulla-common-test` (40 test cases)
+2. `libs/common/testing/test/fulla-common-testing-test` (43 test cases)
+3. `libs/identity/test/fulla-identity-test` (130 test cases)
+4. `libs/oauth2/test/fulla-oauth2-test` (151 test cases)
+5. `tests/fulla-tests` (450 ctest entries, including all `DROGON_TEST` unit/integration/contract/admin HTTP tests)
 
-在 coverage 构建目录下依次运行这 5 个二进制后再聚合 `.gcda`。
+Run these 5 binaries in sequence under the coverage build directory, then aggregate the `.gcda` files.
 
-#### ⚠ gcovr 路径匹配 bug —— 用 `scripts/measure_coverage.py` 代替
+#### ⚠ gcovr path-matching bug — use `scripts/measure_coverage.py` instead
 
-`gcovr 8.6` 对部分文件（如 `ClientManagementService.cc`）会误报 **0%**：raw `gcov` 明确显示 `Lines executed:55.79% of 328`，但 gcovr 的 `--print-summary` 只列出文件名不带百分比（gcovr 的源路径匹配对含绝对路径 + Drogon 头文件的 `.gcov` 输出处理不一致）。这是 gcovr 的已知路径匹配问题，不是零计数 bug（gcov flush 工作正常，见下）。
+`gcovr 8.6` falsely reports **0%** for some files (e.g. `ClientManagementService.cc`): raw `gcov` clearly shows `Lines executed:55.79% of 328`, yet gcovr's `--print-summary` lists only the file name without a percentage (gcovr's source-path matching handles `.gcov` output containing absolute paths + Drogon headers inconsistently). This is a known gcovr path-matching issue, not a zero-count bug (gcov flushing works correctly; see below).
 
-**可靠的聚合方式**：`scripts/measure_coverage.py` 直接用 `gcov -j`（JSON 格式，每文件 `{file, lines[{count, unexecuted_block}]}`）聚合，绕过 gcovr 的文本路径匹配。用法：
+**Reliable aggregation**: `scripts/measure_coverage.py` aggregates directly with `gcov -j` (JSON format, per file `{file, lines[{count, unexecuted_block}]}`), bypassing gcovr's text path matching. Usage:
 
 ```bash
 cd <repo>
-# 先跑全部 5 个二进制（见上一节），再生成 JSON + 聚合：
+# First run all 5 binaries (see the previous section), then generate JSON + aggregate:
 find build/linux-coverage/libs -path "*/src/*" -name "*.gcda" ! -path "*/models/*" \
   | xargs -I{} bash -c 'cd "$(dirname {})" && gcov -j "$(basename {})" >/dev/null 2>&1'
 find build/linux-coverage/libs -path "*/src/*" -name "*.gcov.json.gz" ! -path "*/models/*" \
   | python3 scripts/measure_coverage.py
 ```
 
-gcovr 仍可用于生成逐文件 HTML 报告（`--html-details`），但**汇总百分比以 `scripts/measure_coverage.py` 为准**。
+gcovr is still usable for per-file HTML reports (`--html-details`), but **for summary percentages `scripts/measure_coverage.py` is authoritative**.
 
-#### 覆盖率工具链
+#### Coverage toolchain
 
-- `cmake/Coverage.cmake`（`oauth2_apply_gcov(target)`）给每个 first-party 库 + 测试可执行文件加 `-fprofile-arcs -ftest-coverage`，并显式链接 libgcov（仅 GCC；Clang 的 profile 运行时由 `-fprofile-arcs` 链接选项自动提供，无 libgcov）。
-- `tests/test_main.cc` 在两处 `std::_Exit()` 前显式调用 `__gcov_dump()`：因为 `_Exit` 绕过 `atexit`，libgcov 的计数器 flush 不会自动执行（否则 gcov 读到全 0 计数）。这是 Drogon 测试框架 fast-exit 与 gcov 的已知交互，需在测试 main 里手动补 flush。（注：4 个 per-lib gtest 二进制正常退出，不走 `_Exit`，因此它们不需要手动 flush。）
-- 覆盖率当前阶段性目标：60%（7ba8068 实测 57.9%）。剩余盲区集中在难以 HTTP 测试的分支：WebAuthn 典礼/加密深分支、UserSelfService（需逆向 auth 前置 filter）、storage-postgres 事务/错误回退分支（需故障注入）。社交 OAuth 控制器已可通过 `SocialMockFixture.h` 的 Fake 注入在 memory 模式下覆盖（GitHub happy-path 经 `saveTokenPair` 存储抽象重构后不再依赖 `getDbClient()`）。ORM 自动生成的 `libs/storage-postgres/src/models/*.cc` 已从分母排除。
+- `cmake/Coverage.cmake` (`oauth2_apply_gcov(target)`) adds `-fprofile-arcs -ftest-coverage` to every first-party library + test executable and explicitly links libgcov (GCC only; on Clang the profile runtime is provided automatically by the `-fprofile-arcs` link option, no libgcov).
+- `tests/test_main.cc` explicitly calls `__gcov_dump()` before both `std::_Exit()` sites: because `_Exit` bypasses `atexit`, libgcov's counter flush does not run automatically (otherwise gcov reads all-zero counts). This is a known interaction between the Drogon test framework's fast exit and gcov, requiring a manual flush in the test main. (Note: the 4 per-lib gtest binaries exit normally without `_Exit`, so they need no manual flush.)
+- Current phase target for coverage: 60% (57.9% measured at 7ba8068). The remaining blind spots concentrate in branches that are hard to test over HTTP: deep WebAuthn ceremony/crypto branches, UserSelfService (requires driving the auth pre-filter in reverse), storage-postgres transaction/error-fallback branches (require fault injection). Social OAuth controllers can now be covered in memory mode via the Fake injection of `SocialMockFixture.h` (the GitHub happy-path no longer depends on `getDbClient()` after the `saveTokenPair` storage-abstraction refactor). The ORM-generated `libs/storage-postgres/src/models/*.cc` files are excluded from the denominator.
 
 ---
 
-## 8. 手动验证与 API 测试 (Manual Validation)
+## 8. Manual Validation & API Testing (Manual Validation)
 
-除了自动化测试套件外，项目还提供了用于手动验证端点功能的工具和脚本。
+Beyond the automated test suite, the project also provides tools and scripts for manually validating endpoint functionality.
 
-### 8.1 PowerShell 自动化验证脚本
-项目提供了完整的 OAuth2 端点测试脚本：`scripts/backend/test-oauth2-endpoints.ps1`。
+### 8.1 PowerShell automation script
+The project ships a complete OAuth2 endpoint test script: `scripts/backend/test-oauth2-endpoints.ps1`.
 
-**使用方法：**
+**Usage:**
 ```powershell
-# 临时绕过执行策略运行测试
+# Run the test, temporarily bypassing the execution policy
 powershell -ExecutionPolicy Bypass -File scripts/backend/test-oauth2-endpoints.ps1
 ```
-该脚本会依次执行健康检查、登录、授权码交换、UserInfo 访问及管理员面板验证。
+The script runs, in order: a health check, login, authorization code exchange, UserInfo access, and admin panel verification.
 
-### 8.2 多环境 API 测试 (curl)
-不同的命令行工具对 curl 语法的支持不同：
+### 8.2 Multi-environment API testing (curl)
+Different command-line tools vary in their support for curl syntax:
 
-*   **PowerShell (推荐)**: 使用 `Invoke-RestMethod`。
-*   **Git Bash**: 支持标准的 Unix 单引号语法。
-*   **CMD**: 需要使用双引号并转义 `&` 符号为 `^&`。
+*   **PowerShell (recommended)**: use `Invoke-RestMethod`.
+*   **Git Bash**: supports standard Unix single-quote syntax.
+*   **CMD**: requires double quotes and escaping `&` as `^&`.
 
-**示例：登录并获取 JSON 响应**
+**Example: log in and get a JSON response**
 ```bash
-# Git Bash 示例
+# Git Bash example
 curl -X POST http://127.0.0.1:5555/oauth2/login \
   -d 'username=admin&password=admin&client_id=vue-client&redirect_uri=http://localhost:5173/callback&json=true'
 ```
 
 ---
 
-## 9. 故障排查 (Troubleshooting)
+## 9. Troubleshooting
 
-### 9.1 常见问题与对策
-*   **服务器无法启动**：检查端口 5555 是否被占用 (`netstat -ano | findstr :5555`)，并确保 `config.json` 路径正确。
-*   **登录失败 (400)**：确认用户名密码匹配，且数据库中存在该用户。检查 `redirect_uri` 是否与配置完全一致。
-*   **Token 交换失败**：授权码 (Code) 仅能使用一次且有有效期。确保 `client_id` 和 `client_secret` 正确。
-*   **PowerShell 脚本限制**：如提示“禁止运行脚本”，请使用 `-ExecutionPolicy Bypass` 参数。
+### 9.1 Common problems and remedies
+*   **Server fails to start**: check whether port 5555 is occupied (`netstat -ano | findstr :5555`) and make sure the `config.json` path is correct.
+*   **Login fails (400)**: confirm the username and password match and that the user exists in the database. Check that `redirect_uri` exactly matches the configuration.
+*   **Token exchange fails**: the authorization code can be used only once and has a validity window. Make sure `client_id` and `client_secret` are correct.
+*   **PowerShell script restriction**: if you see a "running scripts is disabled" message, use the `-ExecutionPolicy Bypass` parameter.
 
-### 9.2 调试技巧
-*   **日志级别**：排错时可在 `config.json` 中临时将 `log_level` 调为 `DEBUG`（甚至 `TRACE`）以获取详细输出，定位完成后调回 `INFO`。完整的六级语义与约定见 [observability.md §3.2](../operate/observability.md)。
-*   **实时日志**：使用 `Get-Content apps/server/logs/drogon.log -Wait -Tail 20` 监控运行状态。
+### 9.2 Debugging tips
+*   **Log level**: when troubleshooting, temporarily set `log_level` in `config.json` to `DEBUG` (or even `TRACE`) for verbose output, and back to `INFO` once the issue is located. For the full six-level semantics and conventions see [observability.md §3.2](../operate/observability.md).
+*   **Live logs**: use `Get-Content apps/server/logs/drogon.log -Wait -Tail 20` to monitor the running state.
 
 ---
 
-**相关文档**:
-- [Security Architecture](../architecture/security-architecture.md) - 安全加固与安全架构设计
-- [Data Consistency](../architecture/data-persistence.md) - 数据一致性和威胁模型
-- [API Reference](../domains/api-reference.md) - API 接口文档
+**Related documentation**:
+- [Security Architecture](../architecture/security-architecture.md) - security hardening and security architecture design
+- [Data Consistency](../architecture/data-persistence.md) - data consistency and the threat model
+- [API Reference](../domains/api-reference.md) - API interface documentation

--- a/docs/contribute/versioning-and-release.md
+++ b/docs/contribute/versioning-and-release.md
@@ -1,299 +1,334 @@
 # Versioning & Release Policy
 
-Fulla 的版本号方案、bump 判定规则、发布节奏、预发布与补丁通道，以及
-版本发布的标准操作流程（SOP）。
+fulla's version numbering scheme, bump decision rules, release cadence, pre-release
+and patch channels, and the standard operating procedure (SOP) for shipping a
+release.
 
-本文档是版本治理（governance）的单一出处。**版本工程的"怎么做"（CI 流水
-线、签名、SBOM）由 [`.github/workflows/release.yml`](../../.github/workflows/release.yml)
-实现；本文回答的是"何时发版、bump 什么、为什么"。** 二者冲突时，以本文为
-准并修流水线。
+This document is the single source of truth for versioning governance. **The "how"
+of release engineering (CI pipeline, signing, SBOM) is implemented by
+[`.github/workflows/release.yml`](https://github.com/voidvec/fulla/blob/master/.github/workflows/release.yml); this
+document answers "when to release, what to bump, and why".** When the two
+conflict, this document wins — fix the pipeline.
 
-> 相关文档：
-> - [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2 声明了 ABI / 源码级
->   SemVer 承诺与弃用流程，本文是其版本治理侧的展开。
-> - [CI/CD Guide](../contribute/ci-cd-guide) 描述 release 流水线在整体 CI 中的位置。
+> Related documents:
+> - [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2 declares the ABI /
+>   source-level SemVer commitments and the deprecation process; this document
+>   expands on their versioning-governance side.
+> - [CI/CD Guide](../contribute/ci-cd-guide) describes where the release pipeline
+>   sits in the overall CI.
 
 ---
 
-## 1. 版本号方案
+## 1. Version Numbering Scheme
 
 ### 1.1 SemVer 2.0.0
 
-Fulla 遵循 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)：
+fulla follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
 
 ```
 MAJOR.MINOR.PATCH[-prerelease]
    1  .  0 .  0  -rc.1
 ```
 
-| 段 | bump 依据（简述，详见 §2 决策表） | 兼容性承诺 |
+| Segment | Bump trigger (summary; see the decision table in §2) | Compatibility commitment |
 |---|---|---|
-| **MAJOR** | 破坏性变更（breaking change） | 无 —— 用户需改代码 |
-| **MINOR** | 新增功能、向后兼容 | 源码兼容 |
-| **PATCH** | 向后兼容的缺陷修复 | 源码兼容 |
-| **prerelease** | `-alpha.N` / `-beta.N` / `-rc.N` | 无承诺 |
+| **MAJOR** | Breaking change | None — users must change their code |
+| **MINOR** | New functionality, backwards compatible | Source compatible |
+| **PATCH** | Backwards-compatible defect fixes | Source compatible |
+| **prerelease** | `-alpha.N` / `-beta.N` / `-rc.N` | No commitment |
 
-> v1.x 的"源码兼容"边界由 [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2
-> 明确：仅覆盖 `libs/*/include/fulla/**` 公共头的**源码级 API**，不承诺
-> 二进制 ABI。
+> The boundary of "source compatible" for v1.x is defined by
+> [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2: it covers only the
+> **source-level API** of the public headers under `libs/*/include/fulla/**` and
+> makes no binary-ABI commitment.
 
-### 1.2 版本号单一来源（SSoT）
+### 1.2 Single source of truth for the version number (SSoT)
 
-| 组件 | 版本来源 | 同步校验 |
+| Component | Version source | Sync validation |
 |---|---|---|
-| C++ 库 + server | [`cmake/Version.cmake`](../../cmake/Version.cmake) 的 `MAJOR/MINOR/PATCH` | ✅ `tools/api-diff/api_diff.py` 交叉校验 `Version.cmake` / `CMakeLists.txt project(VERSION)` / `conanfile.py version` |
-| Docker 镜像 | 由 `release.yml` 从 `Version.cmake` 读取 | GHCR tag = `<version>` |
-| DB schema | `apps/server/migrations/V0NN_*.sql` 编号 | **不耦合产品版本**（见 §6） |
+| C++ libraries + server | `MAJOR/MINOR/PATCH` in [`cmake/Version.cmake`](https://github.com/voidvec/fulla/blob/master/cmake/Version.cmake) | ✅ `tools/api-diff/api_diff.py` cross-checks `Version.cmake` / `CMakeLists.txt project(VERSION)` / `conanfile.py version` |
+| Docker images | Read from `Version.cmake` by `release.yml` | GHCR tag = `<version>` |
+| DB schema | The numbering of `apps/server/migrations/V0NN_*.sql` | **Not coupled to the product version** (see §6) |
 
-**任何版本发布的第一步都是改 `cmake/Version.cmake`**；三处版本号漂移会被
-`api-diff` 在 `release.yml` 的 `version-check` job 拦截。
+**The first step of any release is editing `cmake/Version.cmake`**; version drift
+across the three locations is intercepted by `api-diff` in the `version-check`
+job of `release.yml`.
 
 ---
 
-## 2. 版本号 bump 决策表
+## 2. Version Bump Decision Table
 
-一个改动到底触发 MAJOR / MINOR / PATCH bump？按下表判定。**当多行命中时，
-取最高级别（MAJOR > MINOR > PATCH）。**
+Which bump does a change trigger — MAJOR / MINOR / PATCH? Decide with the table
+below. **When multiple rows match, take the highest level (MAJOR > MINOR >
+PATCH).**
 
-| 改动类型 | → MAJOR | → MINOR | → PATCH |
+| Change type | → MAJOR | → MINOR | → PATCH |
 |---|:---:|:---:|:---:|
-| SDK 公共头**删除 / 重命名 / 签名变更 / 默认实参变更**（api-diff 判为 BREAKING） | ✅ | | |
-| 公共 API **行为语义变更**（返回值含义、错误码、副作用、协议字段语义） | ✅ | | |
-| 最低 C++ 标准 / 编译器版本提升 | ✅ | | |
-| Drogon / Postgres / Redis **大版本**依赖升级 | ✅ | | |
-| 配置项**删除**或**改默认值且旧行为无法兼容** | ✅ | | |
-| DB schema 的**破坏性 migration**（删列 / 改类型无回填 / 重命名） | ✅ | | |
-| 新增 SDK API / 新 OAuth2 端点 / 新 OIDC claim | | ✅ | |
-| 已有 API 的**新增可选参数 / 字段**（带默认值） | | ✅ | |
-| 新增可选配置项（旧配置仍可工作） | | ✅ | |
-| 新增可选依赖 | | ✅ | |
-| 性能优化（不改公共 API） | | ✅ | |
-| `feat:` conventional commit（无 `!`） | | ✅ | |
-| `fix:` conventional commit —— API 行为回归到"正确" | | | ✅ |
-| 安全漏洞修复（CVE 类，不改 API） | | | ✅ |
-| 文档 / 测试 / CI 修复（若决定发版） | | | ✅ |
-| 纯 `docs: / test: / chore: / build: / ci:` 提交 | | | 不发版 |
+| SDK public header **removed / renamed / signature changed / default argument changed** (judged BREAKING by api-diff) | ✅ | | |
+| **Behavioral semantics change** of a public API (meaning of return values, error codes, side effects, protocol field semantics) | ✅ | | |
+| Raise of the minimum C++ standard / compiler version | ✅ | | |
+| **Major-version** dependency upgrade of Drogon / Postgres / Redis | ✅ | | |
+| Config option **removed**, or **default value changed with no compatible old behavior** | ✅ | | |
+| **Breaking migration** of the DB schema (column drop / type change without backfill / rename) | ✅ | | |
+| New SDK API / new OAuth2 endpoint / new OIDC claim | | ✅ | |
+| **New optional parameter / field** on an existing API (with default value) | | ✅ | |
+| New optional config option (old configs keep working) | | ✅ | |
+| New optional dependency | | ✅ | |
+| Performance optimization (no public API change) | | ✅ | |
+| `feat:` conventional commit (no `!`) | | ✅ | |
+| `fix:` conventional commit — API behavior regressing back to "correct" | | | ✅ |
+| Security vulnerability fix (CVE-type, no API change) | | | ✅ |
+| Docs / tests / CI fixes (if a release is decided) | | | ✅ |
+| Purely `docs: / test: / chore: / build: / ci:` commits | | | No release |
 
-### Conventional Commits → bump 自动映射
+### Conventional Commits → bump automatic mapping
 
-提交前缀与 bump 的默认映射（`!` 后缀或 `BREAKING CHANGE:` footer 强制升
-MAJOR）：
+The default mapping from commit prefix to bump (an `!` suffix or a
+`BREAKING CHANGE:` footer forces MAJOR):
 
 ```
 feat:     → MINOR      feat!:    → MAJOR
 fix:      → PATCH      fix!:     → MAJOR
 perf:     → PATCH      perf!:    → MAJOR
-refactor: → 不发版（除非 !）
-docs/test/chore/build/ci: → 不发版
+refactor: → no release (unless !)
+docs/test/chore/build/ci: → no release
 ```
 
-scope 不改变默认映射，但 maintainer 可按 scope 上调（见 §3）。`cliff.toml`
-的 commit parser 已与上表对齐。
+A scope does not change the default mapping, but a maintainer may raise the level
+based on the scope (see §3). The commit parser in `cliff.toml` is already aligned
+with the table above.
 
 ---
 
-## 3. 安全 hardening 的"灰色地带"——显式取舍声明
+## 3. The security-hardening "gray zone" — an explicit trade-off statement
 
-OAuth/OIDC 合规审计产生的一类改动特殊：它们**收紧了原本宽松的行为**（例：
-强制 redirect_uri https、强制 PKCE、CONFIDENTIAL 客户端 refresh grant 强制
-client_secret）。这类改动：
+One category of changes arising from OAuth/OIDC compliance audits is special:
+they **tighten previously lenient behavior** (e.g. enforcing https
+redirect_uri, enforcing PKCE, requiring client_secret for the refresh grant of
+CONFIDENTIAL clients). Such changes:
 
-- **严格 SemVer 视角**：是 breaking（依赖旧宽松行为的下游会断）。
-- **行业惯例**：多在 MINOR bump 内推进，Release Notes 显著标注。
+- **From a strict SemVer perspective**: breaking (downstreams relying on the old
+  lenient behavior break).
+- **Industry practice**: mostly shipped within a MINOR bump, prominently flagged
+  in the Release Notes.
 
-**Fulla 的取舍：**
+**fulla's trade-off:**
 
-> 安全 hardening 在 **MINOR** 内推进，**不强制 MAJOR**。理由：本项目此前的
-> "宽松行为"本身就是 spec 违规（bug），修复是回归正确，不是产品语义的有意
-> 改变。但每次此类改动**必须**在 Release Notes 的 **⚠️ Breaking (security
-> hardening)** 小节显式列出，并给出迁移指引。
+> Security hardening ships within a **MINOR** and does **not force a MAJOR**.
+> Rationale: the previous "lenient behavior" was itself a spec violation (a bug);
+> fixing it is a return to correctness, not an intentional change of product
+> semantics. But every such change **must** be explicitly listed in the
+> **⚠️ Breaking (security hardening)** section of the Release Notes, together
+> with migration guidance.
 
-这是**显式权衡**，不是含糊处理。若某次 hardening 的影响面经评估确实广泛
-（例：移除整个 grant type），仍应走 MAJOR + pre-release 通道（见 §5）。
+This is an **explicit trade-off**, not a vague compromise. If the impact of a
+particular hardening is assessed as genuinely broad (e.g. removing an entire
+grant type), it should still go through the MAJOR + pre-release channel
+(see §5).
 
 ---
 
-## 4. 发布节奏（cadence）
+## 4. Release Cadence
 
-采用**混合模式**：周期性 MINOR + 按需 PATCH + 紧急安全 hotfix。
+A **hybrid model**: periodic MINOR + on-demand PATCH + emergency security
+hotfix.
 
-| 事件 | 触发条件 |
+| Event | Trigger |
 |---|---|
-| **计划性 MINOR**（新功能） | 每 **4–6 周** 一次；或累计 ≥ 3 个 `feat:` commit 时 |
-| **PATCH**（bug fix） | 累计 ≥ 5 个 `fix:` commit；或有用户报告的 bug 已修复 |
-| **紧急安全 PATCH** | P0 / CVE 漏洞修复后**立即**（不等 cadence） |
-| **MAJOR** | 有 breaking change 累积时；必须走 pre-release 通道（§5） |
+| **Scheduled MINOR** (new features) | Every **4–6 weeks**; or when ≥ 3 `feat:` commits have accumulated |
+| **PATCH** (bug fix) | When ≥ 5 `fix:` commits have accumulated; or when a user-reported bug has been fixed |
+| **Emergency security PATCH** | **Immediately** after a P0 / CVE vulnerability fix (without waiting for the cadence) |
+| **MAJOR** | When breaking changes have accumulated; must go through the pre-release channel (§5) |
 
-节奏是**指引不是教条**：无值得发版的改动时跳过一个周期完全正常；反之 P0
-安全修复永远立即发版。
+The cadence is **guidance, not dogma**: skipping a cycle when nothing
+release-worthy changed is perfectly fine; conversely, a P0 security fix always
+ships immediately.
 
 ---
 
-## 5. Pre-release 通道
+## 5. Pre-release Channel
 
-正式 MAJOR 发布前走阶梯式预发布：
+Before an official MAJOR release, go through a staged pre-release ladder:
 
 ```
 v2.0.0-alpha.1 → alpha.2 → … → v2.0.0-beta.1 → … → v2.0.0-rc.1 → … → v2.0.0
 ```
 
-| 阶段 | 语义 | 接受的改动 |
+| Stage | Semantics | Accepted changes |
 |---|---|---|
-| `alpha.N` | 功能可能不全，CI 不保证通过 | 任何（含新功能、行为调整） |
-| `beta.N` | 功能冻结，征集反馈 | bug fix + 反馈驱动的非破坏调整 |
-| `rc.N` | 发布候选 | **仅** P0/P1 bug fix |
-| （去后缀） | 正式版 | 不接受新改动 |
+| `alpha.N` | Functionality may be incomplete; CI not guaranteed to pass | Anything (including new features, behavior adjustments) |
+| `beta.N` | Feature freeze, feedback gathering | Bug fixes + non-breaking feedback-driven adjustments |
+| `rc.N` | Release candidate | **Only** P0/P1 bug fixes |
+| (suffix removed) | Official release | No new changes accepted |
 
-**镜像 tag 规则**：
-- 正式版 → 打 `<version>` **和** `latest`
-- pre-release → **只打** `<version>`（如 `v2.0.0-rc.1`），**不打** `latest`
+**Image tag rules**:
+- Official release → tagged `<version>` **and** `latest`
+- pre-release → tagged **only** `<version>` (e.g. `v2.0.0-rc.1`), **not**
+  `latest`
 
-> **当前流水线状态**：`release.yml` 的 tag 触发模式 `v[0-9]+.[0-9]+.[0-9]+`
-> **不接受后缀**，故 pre-release tag 当前不会触发发版。启用 pre-release
-> 通道需扩展该正则以匹配 `v[0-9]+.[0-9]+.[0-9]+(-[a-z]+\.[0-9]+)?`，并在
-> `github-release` job 按 tag 是否含 `-` 决定是否标记 GitHub Release 为
-> "Pre-release" 且跳过 `latest` manifest 合并。这是本 policy 的**待实施
-> 改造项**（见 §11）。
-
----
-
-## 6. DB Schema 版本与产品版本解耦
-
-Fulla 用编号式 migration（`V001_*` … `V0NN_*`），编号独立递增。
-
-- **新增 migration（加表 / 加列 / 加索引）** = 向后兼容 → 触发 **MINOR** 评估。
-- **破坏性 migration（删列 / 改类型无回填 / 重命名）** → 触发 **MAJOR** 评估。
-- Schema 版本表只记录 migration 应用历史，**不**映射到 `MAJOR.MINOR.PATCH`。
+> **Current pipeline status**: the tag trigger pattern of `release.yml`,
+> `v[0-9]+.[0-9]+.[0-9]+`, **accepts no suffix**, so pre-release tags currently
+> do not trigger a release. Enabling the pre-release channel requires extending
+> that regex to match `v[0-9]+.[0-9]+.[0-9]+(-[a-z]+\.[0-9]+)?` and, in the
+> `github-release` job, deciding from whether the tag contains `-` whether to
+> mark the GitHub Release as "Pre-release" and skip the `latest` manifest merge.
+> This is a **pending pipeline change** of this policy (see §11).
 
 ---
 
-## 7. Release Branch 与 Patch Release
+## 6. DB Schema Versioning Is Decoupled from the Product Version
 
-当 v1.2.0 发布后，主线开发 v1.3.0。若 v1.2.0 发现 P0 漏洞：
+fulla uses numbered migrations (`V001_*` … `V0NN_*`) whose numbers increment
+independently.
+
+- **Additive migration (new table / new column / new index)** = backwards
+  compatible → triggers a **MINOR** assessment.
+- **Breaking migration (column drop / type change without backfill / rename)**
+  → triggers a **MAJOR** assessment.
+- The schema version table only records the migration application history and
+  does **not** map to `MAJOR.MINOR.PATCH`.
+
+---
+
+## 7. Release Branch and Patch Release
+
+After v1.2.0 is released, the mainline develops v1.3.0. If a P0 vulnerability
+is found in v1.2.0:
 
 ```
-master:  ──●──●──●──●──●──●──→  (开发 v1.3.0)
+master:  ──●──●──●──●──●──●──→  (developing v1.3.0)
                \
 release/1.2:    └──●(cherry-pick fix)──● tag v1.2.1
 ```
 
-**约定**：
-- 分支命名：`release/<MAJOR>.<MINOR>`（如 `release/1.2`）。
-- 该分支**只接受 cherry-pick 的 bug fix**，不接受新功能。
-- 每个 patch release 打一个 `v<MAJOR>.<MINOR>.<PATCH>` tag，触发 `release.yml`。
-- **维护窗口**：仅维护**最新一个** release branch 的 patch。上一个 branch
-  在新 minor 发布后 EOL（不提供 LTS —— 见 §8）。
+**Conventions**:
+- Branch naming: `release/<MAJOR>.<MINOR>` (e.g. `release/1.2`).
+- The branch **accepts only cherry-picked bug fixes**, no new features.
+- Each patch release cuts a `v<MAJOR>.<MINOR>.<PATCH>` tag, which triggers
+  `release.yml`.
+- **Maintenance window**: patches are maintained only for the **latest**
+  release branch. The previous branch is EOL once a new minor is released
+  (no LTS — see §8).
 
 ---
 
-## 8. LTS（长期支持）
+## 8. LTS (Long-Term Support)
 
-**当前阶段不提供 LTS。** 仅维护最新 minor 的 patch release。当下游用户规模
-增长、升级成本显现时再评估是否引入 LTS（如 Node.js / Kubernetes 模式）。
-
----
-
-## 9. `latest` tag 语义与生产部署
-
-- `:latest` 指向**最新正式版**（不含 pre-release）。
-- [`deploy/docker/docker-compose.prod.yml`](../../deploy/docker/docker-compose.prod.yml)
-  使用 `${FULLA_VERSION:-latest}`：部署便利的默认值。
-- ⚠️ **生产部署应显式 pin 到具体版本号**（`FULLA_VERSION=1.2.0`），
-  不要依赖 `latest` —— 它会在新版本发布时不可控地滚动。
+**No LTS at the current stage.** Only the latest minor's patch releases are
+maintained. Whether to introduce LTS (à la the Node.js / Kubernetes model) will
+be reconsidered when the downstream user base grows and upgrade costs become
+visible.
 
 ---
 
-## 10. 弃用流程（Deprecation）
+## 9. `latest` Tag Semantics and Production Deployment
 
-与 [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2 一致：
-
-1. 在当次 MINOR 发布时，用 `[[deprecated("Use X instead; removed in vN.0")]]`
-   标注被弃用的 API。
-2. Release Notes 的 **Deprecated** 段记录该弃用 + 迁移指引。
-3. **至少保留一个 MINOR 周期**（建议两个）。
-4. 在下一个 MAJOR 删除。
-
-非 SDK 的弃用（配置项、端点参数）遵循同样的"标注 → 过渡 → 删除"流程，
-标注方式用 Release Notes + 配置加载时的 LOG_WARNING。
+- `:latest` points to the **latest official release** (pre-releases excluded).
+- [`deploy/docker/docker-compose.prod.yml`](https://github.com/voidvec/fulla/blob/master/deploy/docker/docker-compose.prod.yml)
+  uses `${FULLA_VERSION:-latest}`: a default for deployment convenience.
+- ⚠️ **Production deployments should pin an explicit version number**
+  (`FULLA_VERSION=1.2.0`) instead of relying on `latest` — it rolls
+  uncontrollably whenever a new version is published.
 
 ---
 
-## 11. 版本发布标准操作流程（SOP）
+## 10. Deprecation Process
 
-### 11.1 正式版 MINOR / PATCH（从 master）
+Consistent with [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2:
+
+1. At the current MINOR release, annotate the deprecated API with
+   `[[deprecated("Use X instead; removed in vN.0")]]`.
+2. Record the deprecation + migration guidance in the **Deprecated** section of
+   the Release Notes.
+3. **Keep it for at least one MINOR cycle** (two recommended).
+4. Remove it in the next MAJOR.
+
+Non-SDK deprecations (config options, endpoint parameters) follow the same
+"annotate → transition → remove" process, using Release Notes plus a
+LOG_WARNING at config load time as the annotation mechanism.
+
+---
+
+## 11. Release Standard Operating Procedure (SOP)
+
+### 11.1 Official MINOR / PATCH (from master)
 
 ```sh
-# 1. 确认 master 绿（CI 全过）
+# 1. Confirm master is green (CI fully passing)
 git checkout master && git pull
 
-# 2. 更新版本号 SSoT
-#    编辑 cmake/Version.cmake 的 MINOR 或 PATCH
+# 2. Update the version number SSoT
+#    Edit MINOR or PATCH in cmake/Version.cmake
 
-# 3. 校验 API 表面（关键步骤）
+# 3. Validate the API surface (critical step)
 python3 tools/api-diff/api_diff.py
-#   - additive drift（新增头/新增声明）→ MINOR 允许，ratify:
+#   - additive drift (new headers / new declarations) → allowed for MINOR, ratify:
 #       python3 tools/api-diff/api_diff.py --update-baseline
-#   - breaking drift（删/改声明）→ 必须先确认 MAJOR 已 bump；
-#     若属"私有成员/include 重排"等不影响消费表面的改动，需 review 后:
+#   - breaking drift (removed / changed declarations) → MAJOR must be confirmed
+#     bumped first; for changes that do not affect the consumed surface (private
+#     members / include reordering, etc.), after review:
 #       python3 tools/api-diff/api_diff.py --force --update-baseline
 
-# 4. 生成 CHANGELOG 草稿，再手工策展
+# 4. Generate a CHANGELOG draft, then curate manually
 git cliff --unreleased --tag vX.Y.Z --prepend CHANGELOG.md
-#   手工编辑要点：
-#     - 归类到 Added / Fixed / Changed / Security / Deprecated / ⚠️ Breaking
-#     - 安全 hardening 进 ⚠️ Breaking (security hardening) 小节 + 迁移指引
-#     - 删除无信息量的条目
+#   Manual editing essentials:
+#     - Categorize into Added / Fixed / Changed / Security / Deprecated / ⚠️ Breaking
+#     - Put security hardening into the ⚠️ Breaking (security hardening) section + migration guidance
+#     - Drop entries with no information value
 
-# 5. 提交版本号 + baseline + CHANGELOG
+# 5. Commit the version number + baseline + CHANGELOG
 git add cmake/Version.cmake tools/api-diff/*.baseline CHANGELOG.md
 git commit -m "chore(release): vX.Y.Z"
 
-# 6. 打 tag 并推送 —— 触发 release.yml
+# 6. Tag and push — triggers release.yml
 git tag vX.Y.Z
 git push origin master --tags
 ```
 
-`release.yml` 自动完成：version-check → SDK tarball → 多架构镜像 → cosign
-签名 → SBOM → GitHub Release（含 git-cliff 生成的 notes + 验证指引）。
+`release.yml` completes automatically: version-check → SDK tarball →
+multi-arch images → cosign signing → SBOM → GitHub Release (with
+git-cliff-generated notes + verification guidance).
 
-### 11.2 紧急安全 PATCH（从 release branch）
+### 11.2 Emergency Security PATCH (from a release branch)
 
 ```sh
-# 1. 基于 release/<MAJOR>.<MINOR> 分支 cherry-pick fix commit
+# 1. Cherry-pick the fix commit onto the release/<MAJOR>.<MINOR> branch
 git checkout release/1.2
 git cherry-pick <fix-commit-sha>
 
-# 2. 在该分支上 bump PATCH（步骤同 11.1 的 2–6，但操作对象是 release branch）
+# 2. Bump PATCH on that branch (same steps 2–6 as 11.1, but targeting the release branch)
 ```
 
-### 11.3 MAJOR（走 pre-release 通道）
+### 11.3 MAJOR (via the pre-release channel)
 
 ```sh
-# 1. 在 master（或专用候选分支）上累积 breaking 改动
-# 2. bump MAJOR，依次打 prerelease tag：
-git tag v2.0.0-alpha.1 && git push --tags   # → alpha 阶段
-# ... 反馈迭代 ...
-git tag v2.0.0-beta.1  && git push --tags   # → beta 阶段
-git tag v2.0.0-rc.1    && git push --tags   # → rc 阶段（仅修 P0/P1）
-# 3. rc 通过后去掉后缀即正式版：
+# 1. Accumulate breaking changes on master (or a dedicated candidate branch)
+# 2. Bump MAJOR, then tag prereleases in sequence:
+git tag v2.0.0-alpha.1 && git push --tags   # → alpha stage
+# ... feedback iterations ...
+git tag v2.0.0-beta.1  && git push --tags   # → beta stage
+git tag v2.0.0-rc.1    && git push --tags   # → rc stage (only P0/P1 fixes)
+# 3. Once rc passes, drop the suffix for the official release:
 git tag v2.0.0         && git push --tags
-# 4. 正式版发布后创建 release/2.0 分支
+# 4. After the official release, create the release/2.0 branch
 git checkout -b release/2.0 v2.0.0 && git push origin release/2.0
 ```
 
-> ⚠️ §5 已述：pre-release tag 当前**不触发** `release.yml`。启用此通道前
-> 需先完成流水线改造（见 §12 待办）。
+> ⚠️ As stated in §5: pre-release tags currently do **not trigger**
+> `release.yml`. Complete the pipeline change (see the §12 backlog) before
+> enabling this channel.
 
 ---
 
-## 12. 待办（本 policy 与现状的差距）
+## 12. Backlog (Gaps Between This Policy and the Current State)
 
-| # | 项 | 解决的问题 |
+| # | Item | Problem it solves |
 |---|---|---|
-| **T1** | 写本文档（✅ 本文件） | 此前无成文 bump 规则 |
-| **T2** | 执行 v1.0.0 以来的首次正式发版（v1.0.1 或 v1.1.0） | 840 个 commit 堆积在 v1.0.0 后未释放 |
-| **T3** | 扩展 `release.yml` tag 触发模式 + `latest` 跳过逻辑，启用 pre-release 通道 | 当前 prerelease tag 不触发发版 |
-| **T4** | 在 prod 部署文档（`docker-deployment.md`）加 `latest` 警告交叉引用 | 默认 `latest` 对生产有滚动风险 |
-| **T5** | 定义 release branch 命名约定并在 README 加指针（首次实际需要时再立分支） | patch release 流程未实例化 |
+| **T1** | Write this document (✅ this file) | No written bump rules before |
+| **T2** | Execute the first official release since v1.0.0 (v1.0.1 or v1.1.0) | 840 commits piled up after v1.0.0, unreleased |
+| **T3** | Extend the `release.yml` tag trigger pattern + `latest` skip logic, enabling the pre-release channel | Prerelease tags currently do not trigger a release |
+| **T4** | Add a `latest` warning cross-reference to the prod deployment doc (`docker-deployment.md`) | The `latest` default poses a rolling-update risk in production |
+| **T5** | Define the release branch naming convention and add a pointer in the README (create the branch when first actually needed) | The patch release process is not yet instantiated |
 
-T1 是本文件；T2 是当务之急；T3–T5 可在对应场景首次出现时落地。
+T1 is this file; T2 is the immediate priority; T3–T5 can land when their
+scenarios first occur.

--- a/docs/documentation-governance.md
+++ b/docs/documentation-governance.md
@@ -1,187 +1,235 @@
-# 文档治理设计 v3 — 基于全文深读的内容裁决 · Docusaurus 内容源
+---
+sidebar_label: Documentation Governance
+---
 
-> 状态：v3（2026-08-26）。v1 目录级分类 → v2 四路全文深读的内容级裁决（file:line 证据）
-> → v3 落地终稿：IA 三层模型定稿（§四·A）、双语策略修订为中文主站、
-> Phase A/B 执行完毕 + 上站前内容质检（三区审计）完成。
-> 原则：**入库是给别人看的（stranger 能据此完成一件事）；留在本地是给维护者和 agent 看的。**
+# Documentation Governance v4 — Content Adjudication · Bilingual Docusaurus Site
 
-## 一、入库判据（不变）
+> Status: v4 (2026-08-27). v1 directory-level triage → v2 per-file content
+> adjudication from four parallel full-text reads (file:line evidence) →
+> v3 final IA (three-layer model, Phases A/B done, pre-launch quality pass)
+> → **v4: English-primary site with a zh-CN locale toggle** (docs/ is the
+> English canonical; the Chinese tree lives under website/i18n/zh-CN/),
+> Phase C deep-dives complete.
+> Principle: **what ships in the repo is for strangers (they can get one
+> thing done with it); what stays local is for maintainers and agents.**
 
-1. **可执行**：stranger 依此完成一件事（部署/集成/排查/贡献）；
-2. **可决策**：记录理解系统所必需的设计决策及理由（ADR）；
-3. **可信任**：对外承诺（安全策略、合规尽调、版本政策、测量报告与方法论）。
+## 1. In-repo criteria (unchanged)
 
-## 二、逐篇内容裁决（136 文件 + 根部文档）
+1. **Actionable**: a stranger can get one thing done (deploy / integrate /
+   troubleshoot / contribute);
+2. **Decision-worthy**: records design decisions and rationale needed to
+   understand the system (ADRs);
+3. **Trust-worthy**: outward commitments (security posture, compliance
+   audits, versioning policy, measurement reports and methodology).
 
-### 2.1 docs/backend/（23 篇 md + swagger-ui 静态资源）
+## 2. Per-file adjudication (136 files + root docs) — historical record
 
-| 文件 | 裁决 | 关键内容证据 |
+### 2.1 docs/backend/ (23 md files + swagger-ui static assets)
+
+| File | Verdict | Key evidence |
 |---|---|---|
-| architecture-overview.md | **SITE-READY** | 章节事实全部与现状吻合；建议补 identity 包与缓存装饰器一笔 |
-| ci-cd-guide.md | **SITE-READY** | 与 8 个实际 workflow 核对无硬伤；补 clients-sdk/security 两条一句话 |
-| docker-deployment.md | **SITE-READY** | 与 compose 实测全吻合；池参数按 bench 结论（64）更新 |
-| sdk-integration-guide.md | **SITE-READY** | 仅 L8 `.kiro` 来源路径失效需修 |
-| sdk-runtime-contract.md | **SITE-READY** | 仅 L7 `.kiro` 路径失效需修 |
-| versioning-and-release.md | **SITE-READY** | 治理单一出处；L294 "840 commits" 待办被版本重置超越需改写 |
-| api-reference.md | **REWRITE** | L226 end_session"不验签"已被 #78 推翻（同文错误表却收录 4006，自相矛盾）；L254 Google 路由错；§6 教旧 openapi.json 工作流与治理门冲突 |
-| configuration-guide.md | **REWRITE** | L38 PG15→17；L69 缓存层写成 "future"（已上线且 config.json:152 有配置块）；L132 end_session 旧语义；L176 JWKS 路径错；环境变量表仅 5 个远不全 |
-| data-persistence.md | **REWRITE** | §3 与 §6 对 Redis 存储是否弃用自相矛盾（L96 vs L205）；schema 停在 V002（现 V026）；`fulla:cache:` 键空间缺席；吸收 data-consistency 后补延迟双删一节 |
-| observability.md | **REWRITE** | 缺 #80 缓存失效指标；`oauth2_*` vs `fulla_*` 指标命名口径未澄清；审计示例 2026-01 陈旧 |
-| oidc-guide.md | **REWRITE** | L21/34 JWKS 路由错（实为 `/.well-known/jwks.json`，照抄会拿不到密钥）；缺 end_session/backchannel 集成义务、auth_time/acr/amr、官方 SDK 通道 |
-| rbac-guide.md | **REWRITE** | L62 "roles 进 JWT 未来支持"已实现（TokenService.cc:334）；完全缺 scope 层（V023 双闸模型）；手工 SQL 授予过时（有 admin API） |
-| security-architecture.md | **REWRITE** | L36 secret 传输说法违反 F-017（默认 Basic 头）；威胁表未覆盖 PR#85 已修威胁（#78 伪造登出/#79 缓存竞态/#54 软删除绕过） |
-| testing-guide.md | **REWRITE** | L274 测试数 364+450（实为 501）；L86-119 四月快照；L195-263 四份"[DOC]（已归档）"悬空引用 |
-| data-consistency.md | **MERGE → data-persistence** | 窄而正确，但缺 #79 延迟双删这一最新一致性内容 |
-| docker-guide.md | **MERGE → docker-deployment** | 与后者六成重叠；L19 容器命名 `oauth2-{service}` 漏改；保留其独有：命名规范表/调试容器/full_test_docker 脚本 |
-| google-guide.md + wechat-guide.md | **MERGE → social-login.md** | 同构孪生篇；google L45 无按钮 vs L53 点按钮自相矛盾；以 GitHub 已接线为主线索 |
-| plugin-integration.md | **MERGE → sdk-integration-guide** | 后者 §3 的 quickstart 子集 |
-| security-hardening.md | **MERGE → security-architecture** | 限流数字与 config.prod.json 全面不符（3/2/5 vs 文档 5/5/10）；四月快照与悬空引用删除；须注明 Hodor 仅 prod 启用 |
-| database-encoding-guide.md | **LOCAL** | 单机 SQL_ASCII 排查记录；含危险的 pg catalog DELETE 建议 |
-| documentation-standards.md | **LOCAL** | 仓库目录元规则，随 CONTRIBUTING 走；本治理落地时改写 |
-| ddd-domain-model.md | **ARCHIVE** | 自称"未经评审提案"；现状映射诚实，是未来演进底稿非现状文档 |
+| architecture-overview.md | **SITE-READY** | All facts matched reality; add a line on the identity package and cache decorator |
+| ci-cd-guide.md | **SITE-READY** | Verified against the 8 real workflows; add one-liners for clients-sdk/security |
+| docker-deployment.md | **SITE-READY** | Matches compose reality; pool numbers updated per bench conclusions (64) |
+| sdk-integration-guide.md | **SITE-READY** | Only the L8 `.kiro` source path was dead |
+| sdk-runtime-contract.md | **SITE-READY** | Only the L7 `.kiro` path was dead |
+| versioning-and-release.md | **SITE-READY** | Single governance home; L294 "840 commits" todo superseded by the version reset |
+| api-reference.md | **REWRITE** | L226 end_session "no signature check" contradicted #78 (its own error table lists 4006); L254 Google route wrong; §6 taught the stale openapi.json workflow, conflicting with the governance gate |
+| configuration-guide.md | **REWRITE** | L38 PG15→17; L69 cache layer described as "future" (shipped, config.json:152); L132 end_session stale semantics; L176 JWKS path wrong; env-var table listed only 5 of 30+ |
+| data-persistence.md | **REWRITE** | §3 vs §6 self-contradicted on Redis-storage deprecation (L96 vs L205); schema stuck at V002 (now V026); `fulla:cache:` keyspace absent; absorb data-consistency + add delayed double-delete section |
+| observability.md | **REWRITE** | Missing #80 cache-invalidation metrics; `oauth2_*` vs `fulla_*` naming never clarified; audit examples dated 2026-01 |
+| oidc-guide.md | **REWRITE** | L21/34 JWKS routes wrong (actual `/.well-known/jwks.json` — copying the doc fails); missing end_session/backchannel integration duties, auth_time/acr/amr, official SDK channel |
+| rbac-guide.md | **REWRITE** | L62 "roles in JWT — future" already implemented (TokenService.cc:334); scope layer (V023 dual-gate) entirely missing; manual SQL grants stale (admin API exists) |
+| security-architecture.md | **REWRITE** | L36 secret-transport claim violated F-017 (Basic header default); threat table predated PR#85 fixes (#78 forged logout / #79 cache race / #54 soft-delete bypass) |
+| testing-guide.md | **REWRITE** | L274 counts 364+450 (actual 501); L86-119 April snapshots; L195-263 four dangling "[DOC] (archived)" references |
+| data-consistency.md | **MERGE → data-persistence** | Narrow but correct; missing #79 delayed double-delete |
+| docker-guide.md | **MERGE → docker-deployment** | 60% overlap; L19 container names `oauth2-{service}` missed the rename; keep its uniques: naming table / debug containers / full_test_docker |
+| google-guide.md + wechat-guide.md | **MERGE → social-login.md** | Isomorphic twins; google L45 no-button vs L53 click-button self-contradiction; lead with the wired-up GitHub flow |
+| plugin-integration.md | **MERGE → sdk-integration-guide** | A quickstart subset of the latter's §3 |
+| security-hardening.md | **MERGE → security-architecture** | Rate-limit numbers mismatched config.prod.json across the board (3/2/5 vs documented 5/5/10); drop April snapshots and dangling refs; note Hodor is prod-only |
+| database-encoding-guide.md | **LOCAL** | Single-machine SQL_ASCII investigation; contains dangerous pg-catalog DELETE advice |
+| documentation-standards.md | **LOCAL** | Repo-directory meta-rules, belongs with CONTRIBUTING; rewritten by this governance |
+| ddd-domain-model.md | **ARCHIVE** | Self-described "unreviewed proposal"; honest mapping, an evolution draft — not a current-state doc |
 
-### 2.2 docs/ops/ + admin/ + frontend/ + performance-optimization/（16 篇）
+### 2.2 docs/ops/ + admin/ + frontend/ + performance-optimization/ (16 files)
 
-| 文件 | 裁决 | 关键证据 |
+| File | Verdict | Key evidence |
 |---|---|---|
-| ops/account-lockout.md | **SITE-READY** | 扎实；凭证口径需统一（见矛盾 #1） |
-| ops/postgresql-major-upgrade.md | **SITE-READY** | 最新且准确；修 L122 deploy 名；**补入 docs/README 索引（现在漏挂）** |
-| ops/deployment.md | **REWRITE（小）** | L571-583 initdb.d 手动迁移在 prod 不可执行（迁移已烘焙进镜像）；L783 Prometheus 直连与 loopback 绑定矛盾；性能调优节已正确同步最新结论 |
-| ops/deployment-windows-docker-desktop.md | **REWRITE** | 测试数 55/51 过期（实 59/52）；"80% 通过即成功"坏口径；6 处本机路径；admin123 凭证冲突 |
-| ops/verification-checklist.md | **REWRITE** | dev 容器表混入不存在的 nginx；`oauth2_migrations` 表名错（实 schema_migrations）；硬编码密码 WinDockerTest2024!；表数量门槛 >=7 过期；同文两个 admin 邮箱 |
-| ops/security-checklist.md | **MERGE → backend/security-hardening** | 整改结项备忘；L76-84 两条 filter-branch 命令复制粘贴事故 |
-| admin/e2e-testing-guide.md | **REWRITE（轻）** | L903 死链；附录"7 文件/53 用例"实为 16/174；§9 与 account-lockout 全篇重复 |
-| admin/test-cases.md | **SITE-READY** | 无硬伤，与实际 spec 对应健康 |
-| frontend/test-cases.md | **SITE-READY** | 无硬伤，覆盖当前功能面 |
-| performance-optimization/ 全部 7 篇 | **LOCAL** | prompt 是 AI 会话产物；wave 报告/仪器化/非代码方案/内存调查全是内部证据链（基线代际混乱，混排上站会呈现三个互相矛盾的 QPS 世界观）；面向用户的结论已正确抽取到 ops/deployment §性能调优；upstream-drogon-session-issue.md 是上游约束唯一记录，issue 发出后转链接再 ARCHIVE |
+| ops/account-lockout.md | **SITE-READY** | Solid; credential caliber needed unifying (conflict #1) |
+| ops/postgresql-major-upgrade.md | **SITE-READY** | Fresh and accurate; fix L122 deploy name; **add to docs/README index (was missing)** |
+| ops/deployment.md | **REWRITE (light)** | L571-583 initdb.d manual migration unexecutable in prod (migrations baked into the image); L783 Prometheus direct-connect vs loopback binding conflict; performance section already synced |
+| ops/deployment-windows-docker-desktop.md | **REWRITE** | Test counts 55/51 stale (actual 59/52); "80% pass = success" bad caliber; 6 machine-local paths; admin123 credential conflict |
+| ops/verification-checklist.md | **REWRITE** | Nonexistent nginx in the dev container table; `oauth2_migrations` table name wrong (actual schema_migrations); hardcoded password WinDockerTest2024!; table-count threshold >=7 stale; two different admin emails in one file |
+| ops/security-checklist.md | **MERGE → backend/security-hardening** | Remediation-closeout memo; L76-84 two copy-paste-accident filter-branch commands |
+| admin/e2e-testing-guide.md | **REWRITE (light)** | L903 dead link; appendix "7 files/53 cases" vs actual 16/174; §9 duplicated account-lockout wholesale |
+| admin/test-cases.md | **SITE-READY** | No defects; healthy spec correspondence |
+| frontend/test-cases.md | **SITE-READY** | No defects; covers the current feature surface |
+| performance-optimization/ (all 7) | **LOCAL** | Prompts were AI-session artifacts; wave reports / instrumentation / non-code plans / memory investigations are internal evidence chains (baseline generations tangled — publishing would present three mutually contradictory QPS worldviews); user-facing conclusions were already extracted into ops/deployment §performance; upstream-drogon-session-issue.md is the sole record of the upstream constraint — link it once the issue is filed, then ARCHIVE |
 
-### 2.3 docs/history/（60 篇）：ADR 矿
+### 2.3 docs/history/ (60 files): the ADR mine
 
-**修正 v1 误判**：superpowers/specs/ 并非全部会话产物——其中 2 篇是真设计文档。
+**v1 correction**: superpowers/specs/ were not all session artifacts — 2 of them
+are real design documents.
 
-- **ADR 转化清单（11 + 1 备选，按优先级）**——每篇已提炼决策陈述：
-  1. **产品 + 双 SDK 架构与依赖铁律**（sdk-refactor §2/§4.1/§5.2：Domain 禁 Drogon、oauth2/identity 互不依赖、端口下沉 common、arch-guard 强制）
-  2. **Drogon 自注册符号链接策略**（sdk-refactor §5.5/§5.7：显式 registerController 替代 whole-archive + 插件零改动方案 A）
-  3. **ErrorCatalog 单一权威与双通道错误**（error-code AD-1..6 + auth-flow-gap "不折叠原则"与 G7 防枚举例外）
-  4. **Opaque Access Token + 凭据哈希存储 + 迁移不可变**（production_hardening_spec §五；**注意**：决策表写 Argon2id 实际落地 PBKDF2-SHA256 310K，转 ADR 时必须修正）
-  5. **email 为主登录标识**（email-first §7 五项决策，V020 在库）
-  6. **异步回调生命周期模式**（并发审计四主线；CacheMap 线程安全语义结论）
-  7. **MFA 第二因子会话绑定**（mfa-fix：pending 绑定 + 防枚举同码，V022 在库）
-  8. **首方 SPA 登录凭证暴露面控制**（mfa_auth_code_pkce §6 修正版 + 现状 authService.ts：AJAX+PKCE 闭包、token 不落 localStorage、托管登录页方案搁置）
-  9. **ORM 生成模型豁免 + 迁移冻结**（repo-refactor §0/§1.2——已穿越两次重构验证）
-  10. **限流选型 Hodor**（superpowers/specs：令牌桶三级限流，config.prod 在用）
-  11. **集成测试平台分档**（http-integration-plan：DB-backed 测试限 Linux、进程内起 app、社交面不可达结论）
-  12. （备选）**客户端认证 PUBLIC/CONFIDENTIAL 分类**（client-secret spec）
-  另：productization/done/async-refactor-assessment 蒸馏"**为何 C++17 禁协程**"一页 ADR（贡献者必问）。
-- **ARCHIVE 保留 11 篇**（history/README + 各 bugfix/审计原始记录 + 6 篇 superseded 设计）；
-- **LOCAL 37 篇**（全部 tasks/requirements/plans 类 checkbox 文档与过程稿）；
-- **DELETE 1 篇**：PRD/frontend_design.md（是 frontend/oauth2_frontend_design.md 的严格子集+更早快照，已 diff 确认）。
+- **ADR conversion list (11 + 1 alternate, by priority)**:
+  1. **Product + dual-SDK architecture and dependency iron rules** (sdk-refactor §2/§4.1/§5.2: Domain bans Drogon, oauth2/identity do not depend on each other, ports sink into common, arch-guard enforces)
+  2. **Drogon self-registering-symbol linkage strategy** (sdk-refactor §5.5/§5.7: explicit registerController instead of whole-archive + plugin-zero-change option A)
+  3. **ErrorCatalog single authority and dual-channel errors** (error-code AD-1..6 + auth-flow-gap "no-folding principle" and the G7 anti-enumeration exception)
+  4. **Opaque access token + credential-hash storage + migration immutability** (production_hardening_spec §五; **note**: the decision table said Argon2id, the shipped implementation is PBKDF2-SHA256 310K — corrected during ADR conversion)
+  5. **Email as the primary login identifier** (email-first §7, five decisions; V020 in tree)
+  6. **Async callback lifetime patterns** (concurrency audit, four threads; CacheMap thread-safety conclusions)
+  7. **MFA second-factor session binding** (mfa-fix: pending binding + same-code anti-enumeration; V022 in tree)
+  8. **First-party SPA login credential-exposure control** (mfa_auth_code_pkce §6 revised + current authService.ts: AJAX+PKCE closure, tokens never in localStorage, hosted-login-page idea shelved)
+  9. **ORM generated-model exemption + migration freeze** (repo-refactor §0/§1.2 — survived two refactors)
+  10. **Rate-limiter choice: Hodor** (superpowers/specs: token-bucket three-tier limiting; config.prod uses it)
+  11. **Integration-test platform tiering** (http-integration-plan: DB-backed tests Linux-only, in-process app, social surfaces unreachable)
+  12. (Alternate) **PUBLIC/CONFIDENTIAL client authentication classes** (client-secret spec)
+  Plus: distill "why C++17 bans coroutines" from async-refactor-assessment into a one-page ADR (every contributor asks).
+- **ARCHIVE kept: 11 files** (history/README + bugfix/audit originals + 6 superseded designs);
+- **LOCAL: 37 files** (all checkbox-style tasks/requirements/plans and process drafts);
+- **DELETE: 1 file**: PRD/frontend_design.md (a strict subset of, and earlier snapshot than, frontend/oauth2_frontend_design.md — diff-verified).
 
-### 2.4 productization-evolution/ + branding/（25 篇）：两处对 v1 的硬修正
+### 2.4 productization-evolution/ + branding/ (25 files): two hard v1 corrections
 
-- **LOCAL 21 篇**（含 content-strategy "去 AI 味+软文流程"——公开即自伤；progress-status 枚举未修复安全项 #71/#73——不进站放大；research 含未公开定价 $499/$5000）；
-- **例外一（SITE，benchmark 区）：in-progress/competitor-benchmark-design.md 必须保持入库**——README 徽章链的 COMPARISON.md 与双语 README、benchmarks/competitors/README 共**三处公开入口指向它**；内容为可公开方法论（三同原则/官方配置出处/诚实修订记录），环境披露（WSL2 8vCPU/16GB）是复现性必需且已在公开 README 中；出库即断三条公开链。迁移：为它脱离即将出库的目录单独安家（建议挪至 `docs/benchmark/`）；
-- **例外二（SITE，档案/信任区）：done/oauth-oidc-compliance-audit.md 保持入库**——31 项全部已修复的 RFC 合规尽调，CHANGELOG.md:453 公开引用；是评估者眼中的信任资产（加"2026-08-07 基线快照"标注）；
-- **branding/rename-impact-fulla.md → ARCHIVE 入库但先脱敏**：删除/泛化 §L9 本机路径与工作区细节（含完整磁盘路径、记忆库哈希、WSL 路径）；压缩 P0 "先占资产"步骤（暴露 fulla.dev/PyPI 占位意图）；CHANGELOG:40 引用其 §3，出库断链；
-- **branding/repo-professionalization-audit.md → ARCHIVE 入库**：AGENTS.md 公开引用其为入库标准；
-- **branding/rename-candidates.md → LOCAL（最高敏感级）**：暴露 fulla.dev 未注册状态 + 9 个备选名可用性清单 + 自贬评估——资产落袋前等于给抢注者递情报；
-- 卫生项：`.mimosa/` 会话 JSON 已混入 docs/productization-evolution/（未跟踪）→ .gitignore 增补 `.mimosa/`（已有？核实）。
+- **LOCAL: 21 files** (including content-strategy "de-AI-flavor + advertorial process" — self-harming if public; progress-status enumerating unfixed security items #71/#73 — don't amplify; research containing unpublished pricing $499/$5000);
+- **Exception 1 (SITE, benchmark zone): in-progress/competitor-benchmark-design.md stays in-repo** — three public entry points link it (README-badge COMPARISON.md, both READMEs, benchmarks/competitors/README); the content is publishable methodology (three-sames principle / official-config provenance / honest revision log); the environment disclosure (WSL2 8 vCPU/16GB) is reproducibility-required and already public; removing it breaks three public links. New home: `docs/benchmark/`;
+- **Exception 2 (SITE, trust archive): done/oauth-oidc-compliance-audit.md stays in-repo** — an RFC compliance audit with all 31 findings fixed; publicly referenced from CHANGELOG.md:453; a trust asset for assessers (labeled "2026-08-07 baseline snapshot");
+- **branding/rename-impact-fulla.md → ARCHIVE in-repo, sanitized first**: generalize machine paths and workspace details; compress the P0 "squat the assets" step; CHANGELOG:40 references its §3 — removal would break the link;
+- **branding/repo-professionalization-audit.md → ARCHIVE in-repo**: AGENTS.md references it publicly as the in-repo standard;
+- **branding/rename-candidates.md → LOCAL (highest sensitivity)**: exposes the unregistered status of fulla.dev + a 9-name availability list + self-critical assessments — intelligence for squatters until the assets are secured;
+- Hygiene: `.mimosa/` session JSONs had leaked into docs/productization-evolution/ (untracked) → .gitignore `.mimosa/`.
 
-## 三、跨文档矛盾登记簿（Phase A 必修清单）
+## 3. Cross-document conflict register (Phase A must-fix list)
 
-深读发现的矛盾**必须在上站前修平**，否则站点会把矛盾双语放大：
+All conflicts found by the deep reads **had to be resolved before launch**,
+otherwise the site would amplify them bilingually:
 
-| # | 矛盾 | 定谳依据 |
+| # | Conflict | Settled by |
 |---|---|---|
-| 1 | **admin 默认凭证三种口径**（'admin' vs admin123 vs admin/admin123+admin-console 双客户端） | 以 apps/server/seed/dev_admin_user.sql 实测定谳，全站统一 |
-| 2 | end_session "不验签"（api-reference L226、configuration-guide L132）vs 错误表收录 4006 | 代码已强制验签（#78）；两处正文改写 |
-| 3 | Redis 缓存层 "future"（configuration-guide L69）vs 已上线（architecture-overview L12 还指错章节） | config.json cache 块为准；configuration-guide 补缓存配置节 |
-| 4 | CHANGELOG 宣称指标全改 `fulla_*` vs 代码实发 `oauth2_*`（authforge_* 前缀的已改） | **已在本 PR 修正 CHANGELOG 措辞** |
-| 5 | JWKS 路径三个版本（/oauth2/jwks、/oauth2/.well-known/jwks.json、/.well-known/jwks.json） | DiscoveryController.cc:60 定谳 |
-| 6 | PG 版本 15 vs 17（configuration-guide L38） | 17 |
-| 7 | Google 路由 /google/login vs /api/google/login | Controller 定谳 |
-| 8 | rbac-guide 单闸角色模型 vs api-reference 双闸（role+scope）vs "JWT roles 未来支持" | 现状=双闸+roles 已签发 |
-| 9 | 测试数量 364+450 vs 501；e2e "7 文件/53 用例" vs 16/174 | 脚本与 spec 实测 |
-| 10 | verification-checklist 的 oauth2-nginx(dev)/oauth2_migrations/WinDockerTest2024!/表名无前缀 | compose/V001/实配置定谳 |
-| 11 | docs/README.md 索引摘要 "session unbounded leak ~730B" vs 调查报告 v2 已撤回（TTL 有界 750B） | 后者定谳；README 重写时消化 |
-| 12 | 两个限流器（Hodor 全局 vs F-018 失败计数）从未说明并存关系与启用条件 | 重写时合并讲清 |
+| 1 | **Three admin default-credential calibers** ('admin' vs admin123 vs admin/admin123+admin-console dual client) | Measured against apps/server/seed/dev_admin_user.sql; unified site-wide |
+| 2 | end_session "no signature check" (api-reference L226, configuration-guide L132) vs the error table listing 4006 | Code enforces verification (#78); both passages rewritten |
+| 3 | Redis cache layer "future" (configuration-guide L69) vs shipped (architecture-overview L12 pointed at the wrong section too) | config.json cache block is authoritative; configuration-guide gained a cache section |
+| 4 | CHANGELOG claimed all metrics renamed `fulla_*` vs code emitting `oauth2_*` (the authforge_* ones were renamed) | **CHANGELOG wording fixed in that PR** |
+| 5 | JWKS path in three versions | DiscoveryController.cc:60 settles it |
+| 6 | PG version 15 vs 17 | 17 |
+| 7 | Google route /google/login vs /api/google/login | The controller settles it |
+| 8 | rbac-guide single-gate roles vs api-reference dual-gate (role+scope) vs "JWT roles — future" | Current state = dual gate + roles issued |
+| 9 | Test counts 364+450 vs 501; e2e "7 files/53 cases" vs 16/174 | Scripts and specs measured |
+| 10 | verification-checklist's oauth2-nginx(dev)/oauth2_migrations/WinDockerTest2024!/unprefixed table names | compose/V001/actual config settle it |
+| 11 | docs/README.md summary "session unbounded leak ~730B" vs investigation v2's retraction (TTL-bounded 750B) | The latter; absorbed in the README rewrite |
+| 12 | Two rate limiters (Hodor global vs F-018 failure counting) with their coexistence never explained | Explained together in the rewrite |
 
-## 四、Docusaurus 内容源（核心决策不变，素材清单更新）
+## 4. Docusaurus content source (decision unchanged, inventory updated)
 
-**站源 = docs/ 本体，零拷贝。** 站点七区与现状素材的映射（"现成"=SITE-READY，"重写后"=REWRITE/MERGE 完成）：
+**Site source = the repo's docs trees, zero copies.** Zone mapping (all rows
+now executed):
 
-| 站区 | 内容源 | 状态 |
+| Zone | Source | Status |
 |---|---|---|
-| intro | README 能力地图复用 + Quick Start（README Path A/B） | 现成 |
-| architecture | architecture-overview + security-architecture（重写后）+ 模块地图 | 1 现成 1 重写 |
-| domains | social-login（合并后）、oidc-guide（重写后）、rbac/access-control（重写后）、token-lifecycle（**新写**：吸收 data-persistence 一节+refresh family）、session-management（**新写**：吸收 drogon#278 结论）、multi-tenancy（**新写**） | 3 重写 + 3 新写 |
-| sdk | sdk-integration-guide（吸收 plugin-integration）+ sdk-runtime-contract + 官方 Python/Go 说明（client-sdk 设计的"auth 手写"理由 200 字） | 基本现成 |
-| operate | deployment（小修）、docker-deployment（吸收 docker-guide）、configuration-guide（重写后）、observability（重写后）、account-lockout、postgresql-major-upgrade、verification-checklist（重写后）、testing/e2e/ci-cd/versioning（contribute 区亦可） | 4 现成 4 重写 |
-| benchmark | COMPARISON.md + **competitor-benchmark-design.md（新家 docs/benchmark/）** + benchmarks/README | 现成 |
-| adr | **12 篇新转化 ADR** + ddd-domain-model（标注提案）+ 合规尽调报告（信任档案）+ rename-impact（脱敏后）+ professionalization-audit | 新建 |
-| API | openapi.yaml 直渲染（swagger-ui 静态资源不上站，属服务器托管物） | 插件 |
+| intro | README capability map + Quick Start (README Path A/B) | done |
+| architecture | architecture-overview + security-architecture + data-persistence | done |
+| domains | api-reference, oidc-guide, rbac-guide, social-login, **token-lifecycle, session-management, multi-tenancy (Phase C)** | done |
+| sdk | sdk-integration-guide + sdk-runtime-contract + official Python/Go clients | done |
+| operate | deployment, docker-deployment, deployment-windows-docker-desktop, configuration-guide, observability, account-lockout, postgresql-major-upgrade, verification-checklist | done |
+| benchmark | COMPARISON.md (repo) + competitor-benchmark-design.md (docs/benchmark/) | done |
+| adr | ADR-0001..0012 + three trust archives | done |
+| API | openapi.yaml rendered at runtime by the server (swagger-ui static assets are server-hosted, not site content) | n/a |
 
-双语（v3 修订）：**中文为主站语言**（fulla.dev 全站简体中文）；英文由 README.md（GitHub 门面）承载，中文 README（README.zh-CN.md）与 GitHub wiki 承载入门导流。英文 i18n（Docusaurus 原生支持）视海外流量/贡献者出现后再启用，切换成本低。
+Bilingual policy (v4): **English is the primary site language** (fulla.dev
+default locale = en — `/` serves English, `/zh-CN` serves Chinese, navbar
+language switcher). `docs/` is the **English canonical** (single source of
+truth); the Chinese tree mirrors it at
+`website/i18n/zh-CN/docusaurus-plugin-content-docs/current/` (identical
+layout, identical URLs). **Translation discipline**: a PR that changes an
+English doc under docs/ must update the Chinese counterpart in the same PR.
+The three historical archives keep their Chinese body in both locales with an
+English language-note header. The GitHub-facing README.md is English;
+README.zh-CN.md is Chinese and links to fulla.dev/zh-CN.
 
-### 四·A、终稿信息架构（2026-08-26 定稿）
+### 4A. Final information architecture (settled 2026-08-26, bilingualized 2026-08-27)
 
-内容资产分**三层**，各层有明确边界与进入判据：
+Content assets live in **three layers**, each with clear boundaries and
+entry criteria:
 
-**第 1 层：`docs/`（入库 + 上站）** —— 唯一的站点内容源（Docusaurus `docs.path=../docs`，零拷贝）。
-只收"stranger 可据此完成一件事 / 理解一个决策 / 建立一份信任"的用户向内容：
+**Layer 1: `docs/` (English canonical, in-repo, on-site) +
+`website/i18n/zh-CN/` (Chinese translation)** — the site content source
+(Docusaurus default locale reads `../docs`, the zh-CN locale reads the i18n
+tree; identical structure, no drift). Only content where "a stranger can get
+one thing done / understand one decision / establish one trust":
 
 ```
-docs/
-├── intro.md                     # 站点入口（快速路由表）
-├── README.md                    # GitHub 侧索引（Docusaurus exclude，不上站）
-├── documentation-governance.md  # 本文档（治理规则，贡献者区引用）
-├── architecture/   # 评估+深潜：architecture-overview / security-architecture / data-persistence
-├── domains/        # 领域指南：api-reference / oidc-guide / rbac-guide / social-login
-├── sdk/            # C++ SDK：sdk-integration-guide / sdk-runtime-contract
-├── operate/        # 运维：deployment / docker-deployment / deployment-windows-docker-desktop /
-│                  #        configuration-guide / observability / account-lockout /
-│                  #        postgresql-major-upgrade / verification-checklist
-├── contribute/     # 贡献：testing-guide / ci-cd-guide / versioning-and-release /
-│                  #        admin-test-cases / user-frontend-test-cases / admin-e2e-testing-guide
-├── benchmark/      # 竞品基准方法论（competitor-benchmark-design；结果表在仓库 benchmarks/）
-└── adr/            # ADR-0001..0012（现行架构决策记录）
+docs/ (English) and website/i18n/zh-CN/.../current/ (Chinese), mirrored:
+├── intro.md                     # site entry (routing table)
+├── README.md                    # GitHub-side index (excluded from the site)
+├── documentation-governance.md  # this document
+├── architecture/   # evaluate + deep-dives: architecture-overview / security-architecture / data-persistence
+├── domains/        # domain guides: api-reference / oidc-guide / rbac-guide / social-login /
+│                  #              token-lifecycle / session-management / multi-tenancy (Phase C)
+├── sdk/            # C++ SDK: sdk-integration-guide / sdk-runtime-contract
+├── operate/        # operations: deployment / docker-deployment / deployment-windows-docker-desktop /
+│                  #             configuration-guide / observability / account-lockout /
+│                  #             postgresql-major-upgrade / verification-checklist
+├── contribute/     # contributing: testing-guide / ci-cd-guide / versioning-and-release /
+│                  #               admin-test-cases / user-frontend-test-cases / admin-e2e-testing-guide
+├── benchmark/      # competitor-benchmark methodology (results live in the repo's benchmarks/)
+└── adr/            # ADR-0001..0012 + three historical archives (Chinese body, bilingual note)
 ```
 
-**第 2 层：仓库内非 docs 资产（入库、不上站）** —— 站内以绝对链接引用，不复制：
+**Layer 2: in-repo non-docs assets (tracked, not site content)** — referenced
+by absolute link, never copied:
 
-| 资产 | 角色 |
+| Asset | Role |
 |---|---|
-| `README.md` / `README.zh-CN.md` | GitHub 门面（能力地图、Quick Start、徽章） |
-| `benchmarks/competitors/results/COMPARISON.md` | 基准结果表（评估区链接） |
-| `apps/server/openapi.yaml` | API 契约 SSoT（api-reference 导读指向它） |
-| `.claude/rules/`、`TECH_SPECS.md`、`AGENTS.md` | 维护者契约（贡献者区可链接，不入站内容） |
+| `README.md` / `README.zh-CN.md` | GitHub front door (capability map, Quick Start, badges) |
+| `benchmarks/competitors/results/COMPARISON.md` | Benchmark results (evaluate-zone link) |
+| `apps/server/openapi.yaml` | API contract SSoT (api-reference points at it) |
+| `.claude/rules/`, `TECH_SPECS.md`, `AGENTS.md` | Maintainer contracts (linkable from contribute, not site content) |
 
-**第 3 层：`docs-local/`（不入库，磁盘保留）** —— 维护者与 agent 的过程档案（history、
-productization-evolution、branding、performance-optimization、performance 报告等）。
-gitignore；判据：不满足第一层三判据（可执行/可决策/可信任）中任何一条的过程性文档。
+**Layer 3: `docs-local/` (untracked, on disk)** — maintainer/agent process
+archives (history, productization-evolution, branding,
+performance-optimization, perf reports). gitignored; criterion: process
+documents that satisfy none of the three layer-1 criteria.
 
-**wiki 分工**：GitHub wiki 是自动生成的中文快照镜像（repowiki 转换），不做双向同步；
-其 Home 指向 fulla.dev 为权威内容源。站点与 wiki 内容重叠时以 `docs/` 为准。
+**Wiki division of labor**: the GitHub wiki is an auto-generated Chinese
+snapshot mirror (repowiki conversion), not bidirectionally synced; its Home
+points to fulla.dev as the authoritative source (Chinese readers go straight
+to /zh-CN). When site and wiki overlap, `docs/` wins.
 
-**边界速判**：新文档先问"stranger 需要它吗？"——需要 → `docs/` 对应分区；只有维护者/
-agent 需要 → `docs-local/`；是结果数据而非文档 → 仓库数据目录（如 `benchmarks/`）；
-是对外承诺 → `docs/` + 版本化（CHANGELOG 引用）。
+**Quick boundary test for a new document**: ask "does a stranger need it?" —
+yes → the matching docs/ zone (English) + the zh tree; only maintainers/
+agents → docs-local/; it's results data, not documentation → a repo data
+directory (e.g. `benchmarks/`); it's an outward commitment → docs/ +
+versioned (referenced from CHANGELOG).
 
-## 五、执行 Phase（v3 进度标注）
+## 5. Execution phases (v4 progress)
 
-- **Phase A（内容修复与重组）——已完成**（8783c8e5 + 6049e3d3 + 7e5cd55a + d33d1ec3 + 45ca1f30）：
-  A1 修矛盾登记簿 12 项 ✓（上站前三区复审补漏：verification-checklist/deployment-windows 残留口径二次清扫 ✓）；
-  A2 六组 MERGE 落地 ✓；A3 ADR 转化 12 篇 ✓（status/source/双标题规范统一 ✓）；
-  A4 出库 LOCAL 类 ✓（2 例外迁新家 ✓；**补执行缺口**：合规尽调报告/rename-impact（脱敏版）/
-  professionalization-audit 三份档案此前误落 docs-local，现已入 docs/adr/ 并修复 CHANGELOG 两处断链 ✓）；
-  A5 docs/README.md 重写 ✓。
-  新增收尾：语言统一（全站简体中文，architecture-overview/configuration-guide 中文化 ✓）。
-- **Phase B（站骨架）——已完成**（8a7e3b96）：website/ + 受众分区 sidebar + Pages 部署 + 死链守门。
-  收尾项：GitHub Pages 源切换为 GitHub Actions（用户网页操作）+ 首页/主题专业化（本 PR）。
-- **Phase C（内容补齐）——待办**：三篇新写深潜（token-lifecycle / session-management /
-  multi-tenancy）；api-reference 长期重写（§6 已改为 OpenAPI 治理流程，正文已统一简体）；
-  英文 i18n 视流量启动。
+- **Phase A (content repair & reorganization) — done** (8783c8e5 + 6049e3d3
+  + 7e5cd55a + d33d1ec3 + 45ca1f30): all 12 register conflicts closed
+  (including the second sweep of verification-checklist / deployment-windows
+  residuals); six MERGE groups landed; 12 ADRs converted (status/source/
+  duplicate-title normalized); LOCAL classes removed from the repo (both
+  exceptions rehomed; **execution gap closed**: the compliance audit /
+  sanitized rename-impact / professionalization-audit archives, initially
+  left in docs-local, moved into docs/adr/ with the two CHANGELOG links
+  fixed); docs/README rewritten; language unified to simplified Chinese
+  (superseded by v4's bilingual model).
+- **Phase B (site skeleton) — done** (8a7e3b96): website/ + audience-zoned
+  sidebar + Pages deployment + broken-link gate. Close-out: Pages source
+  switched to GitHub Actions (user action) + professional landing/theme.
+- **Phase C (content completion + bilingualization) — done**
+  (docs/phase-c-i18n): three new deep-dives (token-lifecycle /
+  session-management / multi-tenancy) in both languages; api-reference §6
+  rewritten around the OpenAPI governance gate; **English-primary i18n**:
+  docs/ converted to the English canonical (~40 files translated), the
+  Chinese tree moved to website/i18n/zh-CN/, navbar locale switcher,
+  editUrlLocalized edit links per locale; the deployment doc's session
+  section de-duplicated (single home for the sizing table =
+  session-management). Standing obligation: same-PR dual writes (en change
+  ⇒ zh sync).
 
-## 六、验收标准（不变，略增）
+## 6. Acceptance criteria (unchanged, extended)
 
-v1 四条全部保留，另加：⑤ 矛盾登记簿 12 项全部关闭；⑥ CHANGELOG 引用的文档链接零断链（合规报告、rename-impact §3）。
+All four v1 criteria hold, plus: ⑤ the 12-item conflict register fully
+closed; ⑥ zero broken links from CHANGELOG-referenced docs (compliance
+report, rename-impact §3); ⑦ (v4) every doc exists in both locales and both
+builds pass the broken-link gate.

--- a/docs/domains/api-reference.md
+++ b/docs/domains/api-reference.md
@@ -315,36 +315,38 @@ OIDC RP-Initiated Logout 1.0 §2 — terminates the user's server-side session a
 
 ### 5.1 Application Error Codes
 
+> **Language note**: the `Default Message` / `Description` columns quote the **exact strings the server emits** (registered in `ErrorCatalog`); they are kept verbatim — currently Chinese — because a client matching on `error_description` must see precisely what the catalog defines. A CI test (`Unit_P0_ErrorCatalogDoc_*`) fails if these tables drift from the catalog.
+
 Business endpoints (Application_Endpoint) return a uniform error envelope whose `error.code` values belong to the Error_Code set registered in the table below; `numeric_code` and `category` likewise come from the table, and the HTTP status code maps consistently by Error_Category (the NETWORK category distinguishes 502/504 by numeric_code). A few resource-semantics VALIDATION codes retain their pre-migration HTTP status codes via entry-level explicit overrides (Option A / requirement 11.4): `VALIDATION_RESOURCE_NOT_FOUND` → 404, resource-already-exists/conflict codes (`VALIDATION_RESOURCE_CONFLICT`, `VALIDATION_USERNAME_TAKEN`, `VALIDATION_EMAIL_TAKEN`, `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`) → 409, `VALIDATION_RATE_LIMITED` → 429; all other VALIDATION codes remain 400.
 
 | Error_Code | numeric_code | Error_Category | HTTP Status | Default Message (Client_Safe_Message) |
 |---|---|---|---|---|
-| `NET_CONNECTION_FAILED` | 1001 | NETWORK | 502 | Upstream connection failed |
-| `NET_TIMEOUT` | 1002 | NETWORK | 504 | Request timed out |
-| `DB_CONNECTION_ERROR` | 2001 | DATABASE | 500 | Service temporarily unavailable |
-| `DB_QUERY_ERROR` | 2002 | DATABASE | 500 | Service temporarily unavailable |
-| `DB_CONSTRAINT_VIOLATION` | 2003 | DATABASE | 500 | Data conflict |
-| `VALIDATION_INVALID_INPUT` | 3001 | VALIDATION | 400 | Invalid input parameters |
-| `VALIDATION_MISSING_REQUIRED_FIELD` | 3002 | VALIDATION | 400 | Missing required field |
-| `VALIDATION_FORMAT_ERROR` | 3003 | VALIDATION | 400 | Malformed format |
-| `VALIDATION_RESOURCE_NOT_FOUND` | 3004 | VALIDATION | 404 | Resource not found |
-| `VALIDATION_RESOURCE_CONFLICT` | 3005 | VALIDATION | 409 | Resource already exists or conflicts |
-| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | This username is already registered |
-| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | This email is already registered |
-| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | This security key is already registered; no need to add it again |
-| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400 | The reset link has expired; please request a new one |
-| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400 | The verification link has expired; please resend the email |
-| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400 | The device code is invalid, expired, or already processed |
-| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | Too many requests; please retry later |
-| `AUTH_INVALID_CREDENTIALS` | 4001 | AUTHENTICATION | 401 | Incorrect username or password |
-| `AUTH_TOKEN_EXPIRED` | 4002 | AUTHENTICATION | 401 | Login has expired |
-| `AUTH_TOKEN_INVALID` | 4003 | AUTHENTICATION | 401 | Login credentials are invalid |
-| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401 | Incorrect verification code |
-| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401 | Two-factor verification is not configured yet; complete setup first |
-| `AUTH_INVALID_ID_TOKEN_HINT` | 4006 | AUTHENTICATION | 400 | Invalid login token hint |
-| `AUTHZ_ACCESS_DENIED` | 5001 | AUTHORIZATION | 403 | Access denied |
-| `AUTHZ_INSUFFICIENT_PERMISSIONS` | 5002 | AUTHORIZATION | 403 | Insufficient permissions |
-| `INTERNAL_ERROR` | 6001 | INTERNAL | 500 | Internal server error |
+| `NET_CONNECTION_FAILED` | 1001 | NETWORK | 502 | 上游连接失败 |
+| `NET_TIMEOUT` | 1002 | NETWORK | 504 | 请求超时 |
+| `DB_CONNECTION_ERROR` | 2001 | DATABASE | 500 | 服务暂时不可用 |
+| `DB_QUERY_ERROR` | 2002 | DATABASE | 500 | 服务暂时不可用 |
+| `DB_CONSTRAINT_VIOLATION` | 2003 | DATABASE | 500 | 数据冲突 |
+| `VALIDATION_INVALID_INPUT` | 3001 | VALIDATION | 400 | 输入参数有误 |
+| `VALIDATION_MISSING_REQUIRED_FIELD` | 3002 | VALIDATION | 400 | 缺少必填字段 |
+| `VALIDATION_FORMAT_ERROR` | 3003 | VALIDATION | 400 | 格式不正确 |
+| `VALIDATION_RESOURCE_NOT_FOUND` | 3004 | VALIDATION | 404 | 资源不存在 |
+| `VALIDATION_RESOURCE_CONFLICT` | 3005 | VALIDATION | 409 | 资源已存在或冲突 |
+| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | 该用户名已被注册 |
+| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | 该邮箱已被注册 |
+| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | 该安全密钥已注册，无需重复添加 |
+| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400 | 重置链接已失效，请重新申请 |
+| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400 | 验证链接已失效，请重新发送邮件 |
+| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400 | 设备码无效、已过期或已被处理 |
+| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | 请求过于频繁，请稍后重试 |
+| `AUTH_INVALID_CREDENTIALS` | 4001 | AUTHENTICATION | 401 | 用户名或密码错误 |
+| `AUTH_TOKEN_EXPIRED` | 4002 | AUTHENTICATION | 401 | 登录已过期 |
+| `AUTH_TOKEN_INVALID` | 4003 | AUTHENTICATION | 401 | 登录凭证无效 |
+| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401 | 验证码不正确 |
+| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401 | 尚未设置双重验证，请先完成设置 |
+| `AUTH_INVALID_ID_TOKEN_HINT` | 4006 | AUTHENTICATION | 400 | 登录令牌提示无效 |
+| `AUTHZ_ACCESS_DENIED` | 5001 | AUTHORIZATION | 403 | 没有访问权限 |
+| `AUTHZ_INSUFFICIENT_PERMISSIONS` | 5002 | AUTHORIZATION | 403 | 权限不足 |
+| `INTERNAL_ERROR` | 6001 | INTERNAL | 500 | 服务器内部错误 |
 
 ### 5.2 OAuth2 Protocol Error Codes (RFC 6749 §5.2 / RFC 7009 / RFC 8628)
 
@@ -352,19 +354,19 @@ OAuth2 protocol endpoints (OAuth2_Protocol_Endpoint) keep the RFC 6749 §5.2 err
 
 | error | HTTP Status | Default error_description |
 |---|---|---|
-| `invalid_request` | 400 | Missing or invalid request parameters |
-| `invalid_client` | 401 | Client authentication failed |
-| `invalid_grant` | 400 | The authorization grant is invalid or has expired |
-| `unauthorized_client` | 400 | The client is not authorized to use this grant type |
-| `unsupported_grant_type` | 400 | Unsupported grant type |
-| `invalid_scope` | 400 | The requested scope is invalid |
-| `server_error` | 500 | Internal server error |
-| `temporarily_unavailable` | 503 | Service temporarily unavailable |
-| `access_denied` | 403 | The authorization request was denied (the user lacks permission or refused consent) |
-| `unsupported_token_type` | 400 | Unsupported token type |
-| `authorization_pending` | 400 | Authorization is not yet complete; please retry later |
-| `slow_down` | 400 | Polling too frequently; please slow down |
-| `expired_token` | 400 | The device code has expired; please restart the authorization |
+| `invalid_request` | 400 | 请求参数缺失或无效 |
+| `invalid_client` | 401 | 客户端认证失败 |
+| `invalid_grant` | 400 | 授权许可无效或已过期 |
+| `unauthorized_client` | 400 | 客户端无权使用该授权类型 |
+| `unsupported_grant_type` | 400 | 不支持的授权类型 |
+| `invalid_scope` | 400 | 请求的 scope 无效 |
+| `server_error` | 500 | 服务器内部错误 |
+| `temporarily_unavailable` | 503 | 服务暂时不可用 |
+| `access_denied` | 403 | 授权请求被拒绝（用户无权或拒绝授权） |
+| `unsupported_token_type` | 400 | 不支持的令牌类型 |
+| `authorization_pending` | 400 | 授权尚未完成，请稍后重试 |
+| `slow_down` | 400 | 轮询过于频繁，请降低频率 |
+| `expired_token` | 400 | 设备码已过期，请重新发起授权 |
 
 ### 5.3 HTTP Status Code Quick Reference
 

--- a/docs/domains/api-reference.md
+++ b/docs/domains/api-reference.md
@@ -1,57 +1,57 @@
-# OAuth2 API 接口文档
+# OAuth2 API Reference
 
-> **完整 API 规范**: 手工维护的 OpenAPI 源文件为 [`apps/server/openapi.yaml`](../../apps/server/openapi.yaml)（**唯一契约源**，CI 通过 `openapi-spec-validator` + 治理门校验三层一致性与版本同步）；Swagger UI（`/docs/api`）在线浏览的是运行时由 Controller 代码生成的 `apps/server/docs/api/openapi.json`（派生产物）。
+> **Complete API specification**: The hand-maintained OpenAPI source file is [`apps/server/openapi.yaml`](https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml) (the **single source of truth**; CI validates three-layer consistency and version synchronization via `openapi-spec-validator` plus a governance gate). The Swagger UI (`/docs/api`) browses `apps/server/docs/api/openapi.json`, a derived artifact generated at runtime from Controller code.
 
-本服务提供基于 OAuth2.0 标准（RFC 6749）的认证授权服务。
+This service provides authentication and authorization based on the OAuth 2.0 standard (RFC 6749).
 
-## 端点分类概览 (Endpoint Categories)
+## Endpoint Category Overview
 
-| 分类 | 描述 | 前缀 |
+| Category | Description | Prefix |
 |------|------|------|
-| **Password Reset** | 密码重置请求与确认（基于邮件验证码） | `/api/password-reset` |
-| **Email Verification** | 邮箱验证发送与确认 | `/api/email/verify` |
-| **MFA (Multi-Factor Auth)** | TOTP 设置、验证、恢复码管理 | `/api/me/mfa`（登录补全为 `/oauth2/mfa/verify`） |
-| **Admin API** | 用户管理、客户端管理、审计日志（需 admin 角色） | `/api/admin` |
-| **User Self-Service** | 用户个人资料更新、密码修改、会话管理 | `/api/user` |
-| **OIDC Discovery** | OpenID Connect 发现端点与 JWKS | `/.well-known/openid-configuration`, `/oauth2/jwks` |
+| **Password Reset** | Password reset requests and confirmation (based on email verification codes) | `/api/password-reset` |
+| **Email Verification** | Email verification sending and confirmation | `/api/email/verify` |
+| **MFA (Multi-Factor Auth)** | TOTP setup, verification, and recovery code management | `/api/me/mfa` (login completion at `/oauth2/mfa/verify`) |
+| **Admin API** | User management, client management, audit logs (requires the admin role) | `/api/admin` |
+| **User Self-Service** | User profile updates, password changes, session management | `/api/user` |
+| **OIDC Discovery** | OpenID Connect discovery endpoints and JWKS | `/.well-known/openid-configuration`, `/oauth2/jwks` |
 
 ---
 
-## 1. 授权端点 (Authorization Endpoint)
+## 1. Authorization Endpoint
 
-用于请求用户授权，获取 Authorization Code。
+Used to request user authorization and obtain an authorization code.
 
 - **URL**: `/oauth2/authorize`
 - **Method**: `GET`
-- **Access**: 公开 (需登录)
+- **Access**: Public (requires login)
 
-### 请求参数 (Query Parameters)
+### Request Parameters (Query Parameters)
 
-| 参数名 | 必选 | 描述 | 示例 |
+| Parameter | Required | Description | Example |
 |---|---|---|---|
-| `response_type` | 是 | 必须为 `code` | `code` |
-| `client_id` | 是 | 客户端 ID | `vue-client` |
-| `redirect_uri` | 是 | 回调地址 (需完全匹配) | `http://localhost:5173/callback` |
-| `scope` | 否 | 申请的权限范围 | `openid profile` |
-| `state` | 建议 | 防止 CSRF 的随机串 | `xyz123` |
-| `code_challenge` | 否 | PKCE code challenge（PUBLIC 客户端默认强制） | `dBjftJeZ4CVK...` |
-| `code_challenge_method` | 否 | `plain` 或 `S256`（提供 challenge 时默认 `plain`） | `S256` |
-| `nonce` | 否 | OIDC nonce（防重放），openid scope 时回显到 id_token | `n-0S6_WzA2Mj` |
-| `prompt` | 否 | OIDC 提示值，空格分隔：`none`/`login`/`consent`/`select_account`（§3.1.2.1）。`none` 禁止 UI；`login` 强制重认证；`consent` 强制同意页。`none` 与其他值并用 → 400 | `none` |
-| `max_age` | 否 | 认证最大允許年齡（秒）。session auth_time 超齡 → 強制重认证 | `3600` |
+| `response_type` | Yes | Must be `code` | `code` |
+| `client_id` | Yes | Client ID | `vue-client` |
+| `redirect_uri` | Yes | Callback URL (must match exactly) | `http://localhost:5173/callback` |
+| `scope` | No | Requested scope | `openid profile` |
+| `state` | Recommended | Random string for CSRF protection | `xyz123` |
+| `code_challenge` | No | PKCE code challenge (mandatory by default for PUBLIC clients) | `dBjftJeZ4CVK...` |
+| `code_challenge_method` | No | `plain` or `S256` (defaults to `plain` when a challenge is provided) | `S256` |
+| `nonce` | No | OIDC nonce (replay protection); echoed into the id_token when the openid scope is requested | `n-0S6_WzA2Mj` |
+| `prompt` | No | OIDC prompt values, space-separated: `none`/`login`/`consent`/`select_account` (§3.1.2.1). `none` forbids any UI; `login` forces re-authentication; `consent` forces the consent page. Combining `none` with other values → 400 | `none` |
+| `max_age` | No | Maximum allowable age of authentication (seconds). If the session auth_time exceeds the limit → forced re-authentication | `3600` |
 
-### 响应
+### Response
 
-**成功响应**：
-重定向至 `redirect_uri`，并附带 `code` 和 `state`。
+**Success**:
+Redirects to `redirect_uri` with `code` and `state` attached.
 
 ```http
 HTTP/1.1 302 Found
 Location: http://localhost:5173/callback?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz123
 ```
 
-**错误响应**：
-直接返回 JSON 错误或重定向带 error 参数。
+**Error**:
+Returns a JSON error directly, or redirects with an error parameter.
 
 ```json
 {
@@ -62,28 +62,28 @@ Location: http://localhost:5173/callback?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz12
 
 ---
 
-## 2. 令牌端点 (Token Endpoint)
+## 2. Token Endpoint
 
-用于使用 Authorization Code 换取 Access Token。
+Used to exchange an authorization code for an access token.
 
 - **URL**: `/oauth2/token`
 - **Method**: `POST`
-- **Access**: 公开 (需 Client 认证)
+- **Access**: Public (requires client authentication)
 - **Content-Type**: `application/x-www-form-urlencoded`
 
-### 请求参数 (Form Data)
+### Request Parameters (Form Data)
 
-| 参数名 | 必选 | 描述 | 示例 |
+| Parameter | Required | Description | Example |
 |---|---|---|---|
-| `grant_type` | 是 | 必须为 `authorization_code` | `authorization_code` |
-| `code` | 是 | 上一步获取的 code | `SplxlOBeZQQYbYS6WxSbIA` |
-| `redirect_uri` | 是 | 必须与获取 code 时一致 | `http://localhost:5173/callback` |
-| `client_id` | 是 | 客户端 ID | `vue-client` |
-| `client_secret` | 是 | 客户端密钥 (用于验证) | `vue-secret` |
+| `grant_type` | Yes | Must be `authorization_code` | `authorization_code` |
+| `code` | Yes | The code obtained in the previous step | `SplxlOBeZQQYbYS6WxSbIA` |
+| `redirect_uri` | Yes | Must be identical to the one used to obtain the code | `http://localhost:5173/callback` |
+| `client_id` | Yes | Client ID | `vue-client` |
+| `client_secret` | Yes | Client secret (used for authentication) | `vue-secret` |
 
-### 响应
+### Response
 
-**成功 (200 OK)**:
+**Success (200 OK)**:
 
 ```json
 {
@@ -95,13 +95,13 @@ Location: http://localhost:5173/callback?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz12
 }
 ```
 
-**响应头（F-019，RFC 6749 §5.1 / RFC 7009 §2.2.1）**：所有 token / introspect /
-revoke 成功响应都带 `Cache-Control: no-store` 与 `Pragma: no-cache`，禁止中间
-代理缓存含憑证的响应体。
+**Response headers (F-019, RFC 6749 §5.1 / RFC 7009 §2.2.1)**: All successful token /
+introspect / revoke responses carry `Cache-Control: no-store` and `Pragma: no-cache`,
+forbidding intermediary proxies from caching response bodies that contain credentials.
 
-*(注：`grant_type=refresh_token` 需先通过客户端认证（F-003/F-017，RFC 6749 §3.2.1/§6）：认证方式必须匹配客户端注册的 `token_endpoint_auth_method`——`client_secret_basic`（默认）仅接受 HTTP Basic（body 携带 `client_secret` 会被拒）；`client_secret_post` 仅接受表单字段；PUBLIC 客户端仅发 `client_id`（携带 secret 会被拒）。缺失或错误返回 401 `invalid_client`。refresh token 持久化仅 Postgres 后端支持；`storage_type="redis"` 已弃用，该模式下 refresh grant 返回 `unsupported_grant_type`（F-005）。)*
+*(Note: `grant_type=refresh_token` requires prior client authentication (F-003/F-017, RFC 6749 §3.2.1/§6): the authentication method must match the client's registered `token_endpoint_auth_method` — `client_secret_basic` (default) accepts only HTTP Basic (a `client_secret` in the body is rejected); `client_secret_post` accepts only form fields; PUBLIC clients send only `client_id` (including a secret is rejected). Missing or incorrect credentials return 401 `invalid_client`. Refresh token persistence is supported only on the Postgres backend; `storage_type="redis"` is deprecated, and in that mode the refresh grant returns `unsupported_grant_type` (F-005).)*
 
-**失败 (400/401)**:
+**Failure (400/401)**:
 
 ```json
 {
@@ -110,11 +110,13 @@ revoke 成功响应都带 `Cache-Control: no-store` 与 `Pragma: no-cache`，禁
 }
 ```
 
-**失败 (429 Too Many Requests)** — F-018 限流：`/oauth2/token`、
-`/oauth2/introspect`、`/oauth2/revoke` 与 device_code 轮询共享一個进程内滑动窗口
-限流器，按 `(client_ip, client_id)` 分桶。窗口内（默认 60s）**失败**計数達閾值
-（默认 30，可經 `custom_config["auth"]["rate_limit"]` 配置 `max_failures` /
-`window_seconds`）后，后续請求返回 429。仅計失败（认证/校验失败），成功清零。
+**Failure (429 Too Many Requests)** — F-018 rate limiting: `/oauth2/token`,
+`/oauth2/introspect`, `/oauth2/revoke`, and device_code polling share a single
+in-process sliding-window rate limiter, bucketed by `(client_ip, client_id)`. Within
+a window (default 60 s), once **failed** attempts reach the threshold (default 30;
+configurable via `custom_config["auth"]["rate_limit"]` with `max_failures` /
+`window_seconds`), subsequent requests return 429. Only failures (authentication /
+validation failures) are counted; a success resets the counter.
 
 ```http
 HTTP/1.1 429 Too Many Requests
@@ -129,21 +131,21 @@ Content-Type: application/json
 
 ---
 
-## 3. 用户信息端点 (UserInfo Endpoint)
+## 3. UserInfo Endpoint
 
-用于验证 Access Token 并获取用户信息。
+Used to validate an access token and retrieve user information.
 
 - **URL**: `/oauth2/userinfo`
 - **Method**: `GET`
-- **Access**: 受保护 (Bearer Token)
+- **Access**: Protected (Bearer token)
 
-### 请求头 (Headers)
+### Request Headers
 
 Authorization: `Bearer {access_token}`
 
-### 响应
+### Response
 
-**成功 (200 OK)**:
+**Success (200 OK)**:
 
 ```json
 {
@@ -155,7 +157,7 @@ Authorization: `Bearer {access_token}`
 }
 ```
 
-**失败 (401 Unauthorized)**:
+**Failure (401 Unauthorized)**:
 
 ```json
 {
@@ -163,9 +165,9 @@ Authorization: `Bearer {access_token}`
 }
 ```
 
-**失败 (403 Forbidden)** — F-023：access token scope 不含 `openid`，或为 M2M
-token（subject `client:*`）。响应附带
-`WWW-Authenticate: Bearer error="insufficient_scope"`：
+**Failure (403 Forbidden)** — F-023: the access token's scope does not include
+`openid`, or the token is an M2M token (subject `client:*`). The response carries
+`WWW-Authenticate: Bearer error="insufficient_scope"`:
 
 ```json
 {
@@ -174,231 +176,236 @@ token（subject `client:*`）。响应附带
 }
 ```
 
-### 3.x 路徑→required-scope 映射（F-010 最小资源-scope 模型）
+### 3.x Path → required-scope mapping (F-010 minimal resource-scope model)
 
-`OAuth2AuthFilter` / `AuthorizationFilter` 在 access token 校验通过后，按請求
-路徑強制最小 required-scope（RFC 6750 §3.1）。token scope 不足时返回 403，
-响应附带 `WWW-Authenticate: Bearer realm="fulla", error="insufficient_scope",
-scope="<required>"`，其中 `scope` 屬性命名解锁该资源所需的 scope。
+After an access token passes validation, `OAuth2AuthFilter` / `AuthorizationFilter`
+enforce a minimal required scope based on the request path (RFC 6750 §3.1). When the
+token's scope is insufficient, a 403 is returned with `WWW-Authenticate: Bearer
+realm="fulla", error="insufficient_scope", scope="<required>"`, where the `scope`
+attribute names the scope required to unlock the resource.
 
-| 路徑 | Required Scope | 備注 |
+| Path | Required Scope | Notes |
 |---|---|---|
-| `/oauth2/userinfo` | `openid` | 与 userinfo handler 内的 F-023 检查并存（defense-in-depth） |
-| `/api/me`、`/api/me/*` | `profile` | 經 `OAuth2AuthFilter` |
-| `/api/admin/*` | `admin` | 經 `AuthorizationFilter`，**疊加在既有 RBAC 角色检查之上**（scope 閘門先跑，角色閘門后跑，两者都須通过） |
+| `/oauth2/userinfo` | `openid` | Coexists with the F-023 check inside the userinfo handler (defense-in-depth) |
+| `/api/me`, `/api/me/*` | `profile` | Enforced via `OAuth2AuthFilter` |
+| `/api/admin/*` | `admin` | Enforced via `AuthorizationFilter`, **layered on top of the existing RBAC role check** (the scope gate runs first, then the role gate; both must pass) |
 
-> **完整资源-scope 授權模型为后续工作**（独立 issue「完整资源-scope 授權模型」）。
-> 當前仅上述最小映射；其餘 `/api/*` 路徑仍仅由既有 RBAC 规則（`rbac_rules`）
-> 把关，不额外要求特定 scope。Scope 匹配为空格分隔 token 的精确匹配
-> （`fulla::drogon::utils::hasScope()`），避免 `openidprofile` 误过
-> `openid`/`profile`。
+> **A complete resource-scope authorization model is future work** (separate issue
+> "Complete resource-scope authorization model"). Only the minimal mapping above
+> applies today; all other `/api/*` paths remain guarded solely by the existing RBAC
+> rules (`rbac_rules`), with no additional scope requirement. Scope matching is exact
+> matching against space-separated tokens (`fulla::drogon::utils::hasScope()`),
+> preventing `openidprofile` from erroneously passing `openid`/`profile`.
 
-### 3.y 客户端管理（F-030：admin-only，无 RFC 7592 自管理）
+### 3.y Client management (F-030: admin-only, no RFC 7592 self-management)
 
-客户端注册与管理**仅**經 admin API `/api/admin/clients/*`（需 admin scope +
-admin 角色）。本服務**不**实作 RFC 7592 動態客户端管理的
-`registration_access_token` 自管理端点 —— 客户端无法自助查看/修改自身注册
-信息。需要變更的客户端須联繫管理員經 admin API 处理。
+Client registration and management are available **only** via the admin API
+`/api/admin/clients/*` (requires the admin scope + admin role). This service does
+**not** implement the `registration_access_token` self-management endpoints of
+RFC 7592 dynamic client management — clients cannot view or modify their own
+registration information. Clients that require changes must contact an
+administrator to process them via the admin API.
 
-### 3.z nonce 重放防護（F-026：客户端責任）
+### 3.z Nonce replay protection (F-026: client responsibility)
 
-OIDC Core §15.5.2 规定 nonce 重放检查为**客户端 MUST**：服務端在 id_token 中
-**回顯**（echo）客户端提交的 nonce，但**不**为其存储或做服務端重放检查。客户端
-必須（1）为每次认证請求生成唯一的 nonce，（2）在收到 id_token 后比对回顯值与
-本地 nonce，并（3）拒絕重複或缺失 nonce 的 id_token。本服務遵循此分工，不
-提供服務端 nonce 重放防護。
+OIDC Core §15.5.2 makes nonce replay checking a **client-side MUST**: the server
+**echoes** the client-submitted nonce in the id_token but does not store it or
+perform server-side replay checks. Clients must (1) generate a unique nonce for
+every authentication request, (2) after receiving an id_token, compare the echoed
+value against the locally stored nonce, and (3) reject any id_token with a
+duplicated or missing nonce. This service follows that division of responsibility
+and provides no server-side nonce replay protection.
 
 ---
 
-## 3.1 RP-Initiated Logout 端点 (End Session Endpoint)
+## 3.1 RP-Initiated Logout Endpoint (End Session Endpoint)
 
-OIDC RP-Initiated Logout 1.0 §2 — 終止用户的 server-side session，并（可選）重
-定向到客户端注册的 `post_logout_redirect_uri`。
+OIDC RP-Initiated Logout 1.0 §2 — terminates the user's server-side session and
+(optionally) redirects to the client's registered `post_logout_redirect_uri`.
 
 - **URL**: `/oauth2/end_session`
-- **Method**: `GET`（鏈接式）或 `POST`（表單式）
-- **Access**: 公开（不需 Bearer token）
+- **Method**: `GET` (link-style) or `POST` (form-style)
+- **Access**: Public (no Bearer token required)
 
-### 請求參数 (Query/Form)
+### Request Parameters (Query/Form)
 
-| 參数名 | 必選 | 描述 |
+| Parameter | Required | Description |
 |---|---|---|
-| `id_token_hint` | 否* | 此前签发的 id_token，其 `aud` 声明标识客户端用于校验 `post_logout_redirect_uri`（签名强制校验：RS256 + kid 匹配 + iss/exp/sub 策略；验签失败返回 400 AUTH_INVALID_ID_TOKEN_HINT，错误码 4006）。*提供 `post_logout_redirect_uri` 时必需 |
-| `post_logout_redirect_uri` | 否 | 登出后重定向 URI，須为 `id_token_hint` 客户端注册的 redirect_uri，否則 400 |
-| `state` | 否 | 不透明值，原样回顯到重定向 URI |
+| `id_token_hint` | No* | A previously issued id_token whose `aud` claim identifies the client, used to validate `post_logout_redirect_uri` (signature verification is mandatory: RS256 + kid match + iss/exp/sub policy; verification failure returns 400 AUTH_INVALID_ID_TOKEN_HINT, error code 4006). *Required when `post_logout_redirect_uri` is provided |
+| `post_logout_redirect_uri` | No | Post-logout redirect URI; must be a redirect_uri registered by the `id_token_hint` client, otherwise 400 |
+| `state` | No | Opaque value echoed verbatim into the redirect URI |
 
-### 响应
+### Response
 
-- **200 OK**：未提供 `post_logout_redirect_uri` 时，返回 `{ "message": "Logged out successfully" }`，session 已清除。
-- **302 Found**：提供并校验通过的 `post_logout_redirect_uri`（附 `state`）。
-- **400 Bad Request**：`post_logout_redirect_uri` 未注册 / 缺 `id_token_hint` 无法标识客户端 / `id_token_hint` 验签失败（过期、issuer 不符、签名无效，错误码 4006）。
+- **200 OK**: When no `post_logout_redirect_uri` is provided, returns `{ "message": "Logged out successfully" }`; the session has been cleared.
+- **302 Found**: A provided and successfully validated `post_logout_redirect_uri` (with `state` attached).
+- **400 Bad Request**: `post_logout_redirect_uri` not registered / missing `id_token_hint` so the client cannot be identified / `id_token_hint` signature verification failed (expired, issuer mismatch, invalid signature; error code 4006).
 
 ---
 
-## 4. 辅助接口 (Helper Endpoints)
+## 4. Helper Endpoints
 
-### 登录提交 (Internal)
+### Login Submission (Internal)
 
 - **URL**: `/oauth2/login`
 - **Method**: `POST`
-- **Desc**: 内部使用的表单提交接口，用于 Session 登录并重定向。
+- **Desc**: An internal form-submission endpoint used for session login and redirect.
 
-### WeChat 登录 (Optional)
+### WeChat Login (Optional)
 
 - **URL**: `/api/wechat/login`
 - **Method**: `POST`
-- **Desc**: 处理微信小程序/扫码登录（演示用途）。
+- **Desc**: Handles WeChat Mini Program / QR-code login (for demonstration purposes).
 
-### Google 登录回调 (Optional)
+### Google Login Callback (Optional)
 
 - **URL**: `/api/google/login`
 - **Method**: `POST`
-- **Desc**: 接收前端传来的 Google Authorization Code，服务端向 Google 换取 Access Token 并调用 UserInfo API，返回过滤后的用户信息（`sub`, `name`, `email`, `picture`）。
-- **请求参数**:
-  - `code` (required): Google 返回的授权码
-- **成功 (200 OK)**:
+- **Desc**: Receives the Google authorization code from the frontend, the server exchanges it with Google for an access token and calls the UserInfo API, returning filtered user information (`sub`, `name`, `email`, `picture`).
+- **Request parameters**:
+  - `code` (required): The authorization code returned by Google
+- **Success (200 OK)**:
   ```json
   {"sub": "1234567890", "name": "John Doe", "email": "john@gmail.com", "picture": "..."}
   ```
-- **失败 (400/502)**: code 无效或 Google API 不可达。
+- **Failure (400/502)**: Invalid code or the Google API is unreachable.
 
-### 用户注册
+### User Registration
 
 - **URL**: `/api/register`
 - **Method**: `POST`
 - **Content-Type**: `application/x-www-form-urlencoded`
-- **限流**: 每IP每分钟最多 5 次，全局每分钟 5000 次（Hodor 插件）
+- **Rate limit**: 5 requests per minute per IP, 5000 per minute globally (Hodor plugin)
 
-#### 请求参数 (Form Data)
+#### Request Parameters (Form Data)
 
-| 参数名 | 必选 | 描述 |
+| Parameter | Required | Description |
 |---|---|---|
-| `username` | 是 | 用户名 |
-| `password` | 是 | 密码（明文，服务端 SHA256+Salt 存储）|
-| `email` | 否 | 邮件地址 |
+| `username` | Yes | Username |
+| `password` | Yes | Password (plaintext; stored server-side as SHA256 + salt) |
+| `email` | No | Email address |
 
-#### 响应
+#### Response
 
-- **成功 (200 OK)**: `User Registered`
-- **失败 (400 Bad Request)**: 缺少用户名或密码
-- **失败 (500 Internal Server Error)**: 用户名已存在等
+- **Success (200 OK)**: `User Registered`
+- **Failure (400 Bad Request)**: Missing username or password
+- **Failure (500 Internal Server Error)**: Username already exists, etc.
 
-### 管理员 Dashboard (RBAC Protected)
+### Admin Dashboard (RBAC Protected)
 
 - **URL**: `/api/admin/dashboard`
 - **Method**: `GET`
-- **Access**: 受保护，需 `admin` 角色（Header: `Authorization: Bearer <token>`）
+- **Access**: Protected; requires the `admin` role (Header: `Authorization: Bearer <token>`)
 
-#### 响应
+#### Response
 
-- **成功 (200 OK)**:
+- **Success (200 OK)**:
   ```json
   {"message": "Welcome to Admin Dashboard", "status": "success"}
   ```
-- **失败 (401)**: Token 无效或缺失
-- **失败 (403)**: 用户已登录但不具备 `admin` 角色
+- **Failure (401)**: Token invalid or missing
+- **Failure (403)**: User is authenticated but does not hold the `admin` role
 
 ---
 
-## 5. 通用错误码
+## 5. Common Error Codes
 
-> **单一权威来源（single source of truth）**：本章节 5.1 与 5.2 的表格由后端 `ErrorCatalog`（`libs/common/include/fulla/common/error/ErrorCatalog.h`）的 `allEntries()` / `allOAuthEntries()` 生成并由自动化测试校验，请勿手工修改表格行。
-> 任一不一致（缺失/多余条目、HTTP 状态码或 Error_Category 不匹配）都会导致校验测试失败：`fulla-tests -r ErrorCatalogDoc`。
+> **Single source of truth**: The tables in 5.1 and 5.2 below are generated from `allEntries()` / `allOAuthEntries()` of the backend `ErrorCatalog` (`libs/common/include/fulla/common/error/ErrorCatalog.h`) and verified by an automated test — do not modify table rows by hand.
+> Any inconsistency (missing/extra entries, HTTP status code or Error_Category mismatch) fails the verification test: `fulla-tests -r ErrorCatalogDoc`.
 
-### 5.1 应用错误码 (Application Error Codes)
+### 5.1 Application Error Codes
 
-业务端点（Application_Endpoint）返回统一的 Error Envelope，其 `error.code` 取值属于下表登记的 Error_Code 集合；`numeric_code` 与 `category` 同样取自下表，HTTP 状态码按 Error_Category（NETWORK 类按 numeric_code 区分 502/504）一致映射。少数面向资源语义的 VALIDATION 码通过条目级显式覆盖保留迁移前的 HTTP 状态码（方案 A / 需求 11.4）：`VALIDATION_RESOURCE_NOT_FOUND` → 404，资源已存在/冲突类（`VALIDATION_RESOURCE_CONFLICT`、`VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`）→ 409，`VALIDATION_RATE_LIMITED` → 429；其余 VALIDATION 码仍为 400。
+Business endpoints (Application_Endpoint) return a uniform error envelope whose `error.code` values belong to the Error_Code set registered in the table below; `numeric_code` and `category` likewise come from the table, and the HTTP status code maps consistently by Error_Category (the NETWORK category distinguishes 502/504 by numeric_code). A few resource-semantics VALIDATION codes retain their pre-migration HTTP status codes via entry-level explicit overrides (Option A / requirement 11.4): `VALIDATION_RESOURCE_NOT_FOUND` → 404, resource-already-exists/conflict codes (`VALIDATION_RESOURCE_CONFLICT`, `VALIDATION_USERNAME_TAKEN`, `VALIDATION_EMAIL_TAKEN`, `VALIDATION_CREDENTIAL_ALREADY_REGISTERED`) → 409, `VALIDATION_RATE_LIMITED` → 429; all other VALIDATION codes remain 400.
 
-| Error_Code | numeric_code | Error_Category | HTTP Status | 默认信息 (Client_Safe_Message) |
+| Error_Code | numeric_code | Error_Category | HTTP Status | Default Message (Client_Safe_Message) |
 |---|---|---|---|---|
-| `NET_CONNECTION_FAILED` | 1001 | NETWORK | 502 | 上游连接失败 |
-| `NET_TIMEOUT` | 1002 | NETWORK | 504 | 请求超时 |
-| `DB_CONNECTION_ERROR` | 2001 | DATABASE | 500 | 服务暂时不可用 |
-| `DB_QUERY_ERROR` | 2002 | DATABASE | 500 | 服务暂时不可用 |
-| `DB_CONSTRAINT_VIOLATION` | 2003 | DATABASE | 500 | 数据冲突 |
-| `VALIDATION_INVALID_INPUT` | 3001 | VALIDATION | 400 | 输入参数有误 |
-| `VALIDATION_MISSING_REQUIRED_FIELD` | 3002 | VALIDATION | 400 | 缺少必填字段 |
-| `VALIDATION_FORMAT_ERROR` | 3003 | VALIDATION | 400 | 格式不正确 |
-| `VALIDATION_RESOURCE_NOT_FOUND` | 3004 | VALIDATION | 404 | 资源不存在 |
-| `VALIDATION_RESOURCE_CONFLICT` | 3005 | VALIDATION | 409 | 资源已存在或冲突 |
-| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | 该用户名已被注册 |
-| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | 该邮箱已被注册 |
-| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | 该安全密钥已注册，无需重复添加 |
-| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400 | 重置链接已失效，请重新申请 |
-| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400 | 验证链接已失效，请重新发送邮件 |
-| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400 | 设备码无效、已过期或已被处理 |
-| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | 请求过于频繁，请稍后重试 |
-| `AUTH_INVALID_CREDENTIALS` | 4001 | AUTHENTICATION | 401 | 用户名或密码错误 |
-| `AUTH_TOKEN_EXPIRED` | 4002 | AUTHENTICATION | 401 | 登录已过期 |
-| `AUTH_TOKEN_INVALID` | 4003 | AUTHENTICATION | 401 | 登录凭证无效 |
-| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401 | 验证码不正确 |
-| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401 | 尚未设置双重验证，请先完成设置 |
-| `AUTH_INVALID_ID_TOKEN_HINT` | 4006 | AUTHENTICATION | 400 | 登录令牌提示无效 |
-| `AUTHZ_ACCESS_DENIED` | 5001 | AUTHORIZATION | 403 | 没有访问权限 |
-| `AUTHZ_INSUFFICIENT_PERMISSIONS` | 5002 | AUTHORIZATION | 403 | 权限不足 |
-| `INTERNAL_ERROR` | 6001 | INTERNAL | 500 | 服务器内部错误 |
+| `NET_CONNECTION_FAILED` | 1001 | NETWORK | 502 | Upstream connection failed |
+| `NET_TIMEOUT` | 1002 | NETWORK | 504 | Request timed out |
+| `DB_CONNECTION_ERROR` | 2001 | DATABASE | 500 | Service temporarily unavailable |
+| `DB_QUERY_ERROR` | 2002 | DATABASE | 500 | Service temporarily unavailable |
+| `DB_CONSTRAINT_VIOLATION` | 2003 | DATABASE | 500 | Data conflict |
+| `VALIDATION_INVALID_INPUT` | 3001 | VALIDATION | 400 | Invalid input parameters |
+| `VALIDATION_MISSING_REQUIRED_FIELD` | 3002 | VALIDATION | 400 | Missing required field |
+| `VALIDATION_FORMAT_ERROR` | 3003 | VALIDATION | 400 | Malformed format |
+| `VALIDATION_RESOURCE_NOT_FOUND` | 3004 | VALIDATION | 404 | Resource not found |
+| `VALIDATION_RESOURCE_CONFLICT` | 3005 | VALIDATION | 409 | Resource already exists or conflicts |
+| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | This username is already registered |
+| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | This email is already registered |
+| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | This security key is already registered; no need to add it again |
+| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400 | The reset link has expired; please request a new one |
+| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400 | The verification link has expired; please resend the email |
+| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400 | The device code is invalid, expired, or already processed |
+| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | Too many requests; please retry later |
+| `AUTH_INVALID_CREDENTIALS` | 4001 | AUTHENTICATION | 401 | Incorrect username or password |
+| `AUTH_TOKEN_EXPIRED` | 4002 | AUTHENTICATION | 401 | Login has expired |
+| `AUTH_TOKEN_INVALID` | 4003 | AUTHENTICATION | 401 | Login credentials are invalid |
+| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401 | Incorrect verification code |
+| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401 | Two-factor verification is not configured yet; complete setup first |
+| `AUTH_INVALID_ID_TOKEN_HINT` | 4006 | AUTHENTICATION | 400 | Invalid login token hint |
+| `AUTHZ_ACCESS_DENIED` | 5001 | AUTHORIZATION | 403 | Access denied |
+| `AUTHZ_INSUFFICIENT_PERMISSIONS` | 5002 | AUTHORIZATION | 403 | Insufficient permissions |
+| `INTERNAL_ERROR` | 6001 | INTERNAL | 500 | Internal server error |
 
-### 5.2 OAuth2 协议错误码 (RFC 6749 §5.2 / RFC 7009 / RFC 8628)
+### 5.2 OAuth2 Protocol Error Codes (RFC 6749 §5.2 / RFC 7009 / RFC 8628)
 
-OAuth2 协议端点（OAuth2_Protocol_Endpoint）保持 RFC 6749 §5.2 错误体结构 `{ "error", "error_description", "error_uri" }`，其 `error` 取值与 HTTP 状态码取自下表。
+OAuth2 protocol endpoints (OAuth2_Protocol_Endpoint) keep the RFC 6749 §5.2 error body structure `{ "error", "error_description", "error_uri" }`; the `error` values and HTTP status codes are taken from the table below.
 
-| error | HTTP Status | 默认 error_description |
+| error | HTTP Status | Default error_description |
 |---|---|---|
-| `invalid_request` | 400 | 请求参数缺失或无效 |
-| `invalid_client` | 401 | 客户端认证失败 |
-| `invalid_grant` | 400 | 授权许可无效或已过期 |
-| `unauthorized_client` | 400 | 客户端无权使用该授权类型 |
-| `unsupported_grant_type` | 400 | 不支持的授权类型 |
-| `invalid_scope` | 400 | 请求的 scope 无效 |
-| `server_error` | 500 | 服务器内部错误 |
-| `temporarily_unavailable` | 503 | 服务暂时不可用 |
-| `access_denied` | 403 | 授权请求被拒绝（用户无权或拒绝授权） |
-| `unsupported_token_type` | 400 | 不支持的令牌类型 |
-| `authorization_pending` | 400 | 授权尚未完成，请稍后重试 |
-| `slow_down` | 400 | 轮询过于频繁，请降低频率 |
-| `expired_token` | 400 | 设备码已过期，请重新发起授权 |
+| `invalid_request` | 400 | Missing or invalid request parameters |
+| `invalid_client` | 401 | Client authentication failed |
+| `invalid_grant` | 400 | The authorization grant is invalid or has expired |
+| `unauthorized_client` | 400 | The client is not authorized to use this grant type |
+| `unsupported_grant_type` | 400 | Unsupported grant type |
+| `invalid_scope` | 400 | The requested scope is invalid |
+| `server_error` | 500 | Internal server error |
+| `temporarily_unavailable` | 503 | Service temporarily unavailable |
+| `access_denied` | 403 | The authorization request was denied (the user lacks permission or refused consent) |
+| `unsupported_token_type` | 400 | Unsupported token type |
+| `authorization_pending` | 400 | Authorization is not yet complete; please retry later |
+| `slow_down` | 400 | Polling too frequently; please slow down |
+| `expired_token` | 400 | The device code has expired; please restart the authorization |
 
-### 5.3 HTTP 状态码速查
+### 5.3 HTTP Status Code Quick Reference
 
-| HTTP Status | 描述 | 原因示例 |
+| HTTP Status | Description | Example Causes |
 |---|---|---|
-| `200` | OK | 请求成功 |
-| `302` | Found | 重定向 (如 OAuth2 授权跳转) |
-| `400` | Bad Request | 参数错误, `invalid_grant`, `unauthorized_client` |
-| `401` | Unauthorized | Token 无效或过期, `invalid_client` |
-| `403` | Forbidden | **RBAC 拦截**: 用户已登录但缺少所需角色, `access_denied` |
-| `429` | Too Many Requests | 触发限流 (Rate Limiting) |
-| `500` | Internal Server Error | 服务器内部错误 |
+| `200` | OK | Request succeeded |
+| `302` | Found | Redirect (e.g., the OAuth2 authorization jump) |
+| `400` | Bad Request | Invalid parameters, `invalid_grant`, `unauthorized_client` |
+| `401` | Unauthorized | Token invalid or expired, `invalid_client` |
+| `403` | Forbidden | **RBAC block**: user is authenticated but lacks a required role, `access_denied` |
+| `429` | Too Many Requests | Rate limit triggered (Rate Limiting) |
+| `500` | Internal Server Error | Internal server error |
 
 ---
 
-## 6. API 契约维护流程（OpenAPI 治理）
+## 6. API Contract Maintenance Process (OpenAPI Governance)
 
-HTTP API 契约的**单一事实源是 [`apps/server/openapi.yaml`](https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml)**；本篇是它的导读与补全（含错误码表等 yaml 未承载的内容）。
+The **single source of truth for the HTTP API contract is [`apps/server/openapi.yaml`](https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml)**; this document is its guided introduction and complement (covering content the yaml does not carry, such as the error code tables).
 
-### 6.1 变更流程
+### 6.1 Change Process
 
-1. 修改端点行为时，同步修改 `apps/server/openapi.yaml`（新端点 / 参数 / 响应）。
-2. Controller 内经 `OpenApiGenerator::addEndpoint()` 登记的元数据保持一致（`fulla-tests -r OpenApiGenerator` 校验登记完整性）。
-3. Swagger UI（`http://localhost:5555/docs/api/`）由服务器托管，用于人工核对。
+1. When changing endpoint behavior, update `apps/server/openapi.yaml` in sync (new endpoints / parameters / responses).
+2. Metadata registered via `OpenApiGenerator::addEndpoint()` inside Controllers must stay consistent (`fulla-tests -r OpenApiGenerator` verifies registration completeness).
+3. Swagger UI (`http://localhost:5555/docs/api/`) is hosted by the server for manual review.
 
-### 6.2 破坏性变更门（CI）
+### 6.2 Breaking-Change Gate (CI)
 
-`OpenAPI Governance` workflow 在 PR 上运行 **oasdiff breaking** 门：对比 PR 与 master 的 `openapi.yaml`，任何破坏性变更（删路径、收紧请求体、收窄响应等）都会使 CI 失败，除非：
+The `OpenAPI Governance` workflow runs an **oasdiff breaking** gate on PRs: it compares the PR's `openapi.yaml` against master, and any breaking change (removed paths, tightened request bodies, narrowed responses, etc.) fails CI unless:
 
-- 变更伴随主版本号升级；或
-- 在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 中显式豁免并写明理由。
+- The change is accompanied by a major version bump; or
+- It is explicitly exempted in `tools/openapi-governance/oasdiff-breaking-ignore.md` with a documented rationale.
 
-本地可复现同一命令（见 `.github/workflows/openapi-governance.yml` 头部注释）。
+The same command can be reproduced locally (see the header comment in `.github/workflows/openapi-governance.yml`).
 
-### 6.3 质量标准
+### 6.3 Quality Standards
 
-*   **必需字段**：`path`, `method`, `summary`, `description`, `tags`, `responses`, `requiresAuth`。
-*   **推荐做法**：为每个响应码提供 `responseExamples`，并详细定义参数的 `type` 和 `location`。
+*   **Required fields**: `path`, `method`, `summary`, `description`, `tags`, `responses`, `requiresAuth`.
+*   **Recommended practice**: provide `responseExamples` for every response code, and fully define each parameter's `type` and `location`.
 
-### 6.4 故障排查
+### 6.4 Troubleshooting
 
-*   **Swagger UI 无法访问**：检查静态资源是否随服务器分发，确认静态文件服务已启用。
-*   **登记校验失败**：运行 `fulla-tests -r OpenApiGenerator` 单元测试，查看具体的注册错误。
-*   **治理门误报**：核对 `oasdiff breaking` 输出与豁免清单条目是否对应同一 path/operation。
-
+*   **Swagger UI inaccessible**: check whether static assets are shipped with the server and confirm that static file serving is enabled.
+*   **Registration validation fails**: run the `fulla-tests -r OpenApiGenerator` unit test and inspect the specific registration errors.
+*   **Governance-gate false positive**: verify that the `oasdiff breaking` output and the exemption-list entry refer to the same path/operation.

--- a/docs/domains/multi-tenancy.md
+++ b/docs/domains/multi-tenancy.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 7
+---
+
+# Multi-Tenancy (Organizations)
+
+fulla's multi-tenancy today is an **organizational layer**: organizations
+group users and clients, carry branding fields, and are managed through
+admin APIs. This page documents exactly what exists, what it does **not**
+do yet, and how to use it without over-assuming isolation.
+
+> **Read this first**: organizations are metadata and ownership grouping,
+> not a hard isolation boundary. Authorization is enforced by RBAC + scopes
+> (see [RBAC Guide](rbac-guide.md)); today an org-scoped principal is not
+> automatically fenced off from other orgs' data.
+
+## 1. Model (V017)
+
+```sql
+organizations (
+    id              SERIAL PRIMARY KEY,
+    slug            VARCHAR(50) UNIQUE,   -- 3–50 chars, lowercase
+    name            VARCHAR(200),
+    logo_uri        VARCHAR(512),         -- branding
+    primary_color   VARCHAR(7),           -- branding
+    issuer_override VARCHAR(512),         -- stored; see §4 roadmap
+    created_at / updated_at
+)
+```
+
+Two nullable foreign keys attach entities to an organization:
+
+| Column | On | Semantics |
+|---|---|---|
+| `org_id` | `users` | The user belongs to the org; `NULL` = unassigned (backwards compatible) |
+| `org_id` | `oauth2_clients` | The client is owned by the org; `NULL` = global/ownerless |
+
+Both are nullable by design: pre-V017 data and platform-level principals
+(the seed `admin`, the `admin-console` client) simply have no org.
+
+## 2. Admin API surface
+
+All routes require an admin-scope token (`AuthorizationFilter`;
+`impliedBy: admin`) — [API Reference](api-reference.md) §client management:
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/admin/organizations` | List organizations (id, slug, name, branding) |
+| `POST /api/admin/organizations` | Create (slug: 3–50 lowercase chars, unique) |
+| `GET /api/admin/organizations/{slug}` | Fetch one |
+
+Additionally:
+
+- `POST/PATCH /api/admin/users` accepts `org_id` — an integer assigns the
+  user to an org; JSON `null` **clears** the assignment.
+
+Example:
+
+```bash
+# Create an organization (token: admin scope)
+curl -X POST http://localhost:5555/api/admin/organizations \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"slug":"acme","name":"ACME Corp","logo_uri":"https://acme.example/logo.svg","primary_color":"#5b2fd1"}'
+
+# Attach a user to it
+curl -X PATCH http://localhost:5555/api/admin/users/42 \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"org_id": 1}'
+```
+
+## 3. What this buys you today
+
+- **Ownership bookkeeping**: which human belongs to which company, which
+  client application belongs to which company — queryable via the admin API
+  and SQL (`users.org_id`, `oauth2_clients.org_id`).
+- **Branding catalog**: per-org logo and primary color for frontends that
+  want to skin the login experience per tenant.
+- **No migration cliff**: everything is optional and additive; deployments
+  that don't care about orgs never touch it.
+
+## 4. What it does NOT do yet (roadmap)
+
+Be explicit with stakeholders — these are **not** implemented:
+
+1. **`issuer_override` is stored but not applied**: per-org issuer in the
+   discovery document and in issued tokens is schema-ready, not runtime-live.
+2. **No org-scoped filtering/isolation** on user or client listings; an
+   admin sees across orgs.
+3. **No org-scoped roles**: roles are global (RBAC), not per-org.
+4. **No update/delete** endpoints for organizations (create/list/get only).
+5. **No per-org rate limits, quotas, or keys**.
+
+If you need hard tenant isolation today, run one fulla stack per tenant —
+the Docker Compose / Helm paths make that cheap
+([Deployment](../operate/deployment.md)).
+
+## 5. Schema reference
+
+The authoritative DDL is
+[`V017__multi_tenant.sql`](https://github.com/voidvec/fulla/blob/master/apps/server/migrations/V017__multi_tenant.sql)
+(indexes on `users(org_id)`, `oauth2_clients(org_id)`, `organizations(slug)`).
+Storage-layer details: [Data Persistence](../architecture/data-persistence.md).

--- a/docs/domains/oidc-guide.md
+++ b/docs/domains/oidc-guide.md
@@ -1,16 +1,16 @@
-# OpenID Connect (OIDC) 集成指南
+# OpenID Connect (OIDC) Integration Guide
 
-本指南介绍如何将本 OAuth2 服务作为 OIDC Provider 集成到你的应用中。
+This guide describes how to integrate this OAuth2 service into your application as an OIDC Provider.
 
-## 1. Discovery 端点
+## 1. Discovery Endpoint
 
-OIDC Discovery 端点提供 Provider 的所有配置信息：
+The OIDC discovery endpoint provides all configuration information about the Provider:
 
 ```
 GET /.well-known/openid-configuration
 ```
 
-返回示例：
+Example response:
 
 ```json
 {
@@ -26,15 +26,15 @@ GET /.well-known/openid-configuration
 }
 ```
 
-## 2. JWKS 端点
+## 2. JWKS Endpoint
 
-JSON Web Key Set 端点提供用于验证 `id_token` 签名的公钥：
+The JSON Web Key Set endpoint provides the public keys used to verify `id_token` signatures:
 
 ```
 GET /.well-known/jwks.json
 ```
 
-返回示例：
+Example response:
 
 ```json
 {
@@ -51,59 +51,59 @@ GET /.well-known/jwks.json
 }
 ```
 
-## 3. id_token 格式
+## 3. id_token Format
 
-`id_token` 是一个 RS256 签名的 JWT，包含以下标准 claims：
+The `id_token` is an RS256-signed JWT containing the following standard claims:
 
-| Claim | 描述 | 示例 |
+| Claim | Description | Example |
 |-------|------|------|
-| `iss` | 签发者 (Issuer) | `https://your-domain.com` |
-| `sub` | 用户唯一标识 (UUID public_sub) | `550e8400-e29b-41d4-a716-446655440000` |
-| `aud` | 受众 (Client ID) | `your-client-id` |
-| `exp` | 过期时间 (Unix timestamp) | `1700000000` |
-| `iat` | 签发时间 (Unix timestamp) | `1699996400` |
-| `nonce` | 请求中传入的 nonce 值 | `abc123` |
+| `iss` | Issuer | `https://your-domain.com` |
+| `sub` | Unique user identifier (UUID public_sub) | `550e8400-e29b-41d4-a716-446655440000` |
+| `aud` | Audience (Client ID) | `your-client-id` |
+| `exp` | Expiration time (Unix timestamp) | `1700000000` |
+| `iat` | Issued-at time (Unix timestamp) | `1699996400` |
+| `nonce` | The nonce value sent in the request | `abc123` |
 
-根据请求的 scope，还可能包含：
+Depending on the requested scopes, it may also contain:
 
 - **profile scope**: `name`, `preferred_username`
 - **email scope**: `email`, `email_verified`
 
-## 4. 验证 id_token
+## 4. Verifying the id_token
 
-### 4.1 验证步骤
+### 4.1 Verification Steps
 
-1. **解码 JWT Header**：提取 `kid`（Key ID）和 `alg`（应为 RS256）
-2. **获取公钥**：从 JWKS 端点获取对应 `kid` 的公钥
-3. **验证签名**：使用 RSA 公钥验证 JWT 签名
-4. **验证 Claims**：
-   - `iss` 必须匹配你配置的 Issuer URL
-   - `aud` 必须包含你的 Client ID
-   - `exp` 必须大于当前时间
-   - `nonce` 必须匹配你在授权请求中发送的值
+1. **Decode the JWT header**: extract `kid` (Key ID) and `alg` (should be RS256)
+2. **Fetch the public key**: retrieve the public key matching the `kid` from the JWKS endpoint
+3. **Verify the signature**: verify the JWT signature with the RSA public key
+4. **Verify the claims**:
+   - `iss` must match your configured Issuer URL
+   - `aud` must include your Client ID
+   - `exp` must be in the future
+   - `nonce` must match the value you sent in the authorization request
 
-### 4.2 安全注意事项
+### 4.2 Security Considerations
 
-- **始终验证签名**，不要信任未验证的 JWT
-- **缓存 JWKS** 但设置合理的刷新间隔（建议 24 小时或按 Cache-Control 头）
-- **检查 `alg` 头**，拒绝 `none` 算法（防止算法降级攻击）
+- **Always verify the signature**; never trust an unverified JWT
+- **Cache the JWKS**, but with a sensible refresh interval (24 hours is recommended, or follow the Cache-Control header)
+- **Check the `alg` header** and reject the `none` algorithm (prevents algorithm downgrade attacks)
 
-## 5. 支持的 Scopes 与 Claims
+## 5. Supported Scopes and Claims
 
-| Scope | 返回的 Claims |
+| Scope | Returned Claims |
 |-------|---------------|
-| `openid` | `sub` (必需 scope，启用 OIDC) |
+| `openid` | `sub` (required scope; enables OIDC) |
 | `profile` | `name`, `preferred_username` |
 | `email` | `email`, `email_verified` |
 
-## 6. 集成示例
+## 6. Integration Examples
 
-### 6.1 使用标准 OIDC 客户端库 (Node.js)
+### 6.1 Using a Standard OIDC Client Library (Node.js)
 
 ```javascript
 const { Issuer } = require('openid-client');
 
-// 自动发现 Provider 配置
+// Discover the Provider configuration automatically
 const issuer = await Issuer.discover('https://your-domain.com');
 
 const client = new issuer.Client({
@@ -113,14 +113,14 @@ const client = new issuer.Client({
   response_types: ['code'],
 });
 
-// 生成授权 URL
+// Generate the authorization URL
 const authUrl = client.authorizationUrl({
   scope: 'openid profile email',
   state: 'random-state-value',
   nonce: 'random-nonce-value',
 });
 
-// 处理回调
+// Handle the callback
 const params = client.callbackParams(req);
 const tokenSet = await client.callback('http://localhost:3000/callback', params, {
   state: 'random-state-value',
@@ -131,7 +131,7 @@ console.log('ID Token claims:', tokenSet.claims());
 console.log('Access Token:', tokenSet.access_token);
 ```
 
-### 6.2 使用 Python (authlib)
+### 6.2 Using Python (authlib)
 
 ```python
 from authlib.integrations.requests_client import OAuth2Session
@@ -143,22 +143,22 @@ client = OAuth2Session(
     scope='openid profile email'
 )
 
-# 获取授权 URL
+# Build the authorization URL
 uri, state = client.create_authorization_url(
     'https://your-domain.com/oauth2/authorize'
 )
 
-# 处理回调，换取 Token
+# Handle the callback and exchange for tokens
 token = client.fetch_token(
     'https://your-domain.com/oauth2/token',
     authorization_response=callback_url
 )
 
-# 获取用户信息
+# Fetch user information
 userinfo = client.get('https://your-domain.com/oauth2/userinfo').json()
 ```
 
-### 6.3 使用 Go (coreos/go-oidc)
+### 6.3 Using Go (coreos/go-oidc)
 
 ```go
 provider, err := oidc.NewProvider(ctx, "https://your-domain.com")
@@ -171,18 +171,18 @@ oauth2Config := oauth2.Config{
     Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
 }
 
-// 验证 id_token
+// Verify the id_token
 verifier := provider.Verifier(&oidc.Config{ClientID: "your-client-id"})
 idToken, err := verifier.Verify(ctx, rawIDToken)
 ```
 
-## 7. 常见问题
+## 7. FAQ
 
-**Q: id_token 的有效期是多久？**
-A: 与 Access Token 一致，默认 1 小时。
+**Q: How long is the id_token valid?**
+A: The same as the access token — 1 hour by default.
 
-**Q: 如何处理密钥轮转？**
-A: 定期从 JWKS 端点刷新公钥。当验证失败时，先尝试刷新 JWKS 再重试验证。
+**Q: How should key rotation be handled?**
+A: Refresh the public keys from the JWKS endpoint periodically. When verification fails, refresh the JWKS first, then retry the verification.
 
-**Q: 是否支持 PKCE？**
-A: 支持。PKCE (RFC 7636) 已实现并默认对 PUBLIC 客户端强制启用（同时支持 `plain` 与 `S256`）。SPA 和移动端客户端应使用 `S256`。
+**Q: Is PKCE supported?**
+A: Yes. PKCE (RFC 7636) is implemented and enforced by default for PUBLIC clients (both `plain` and `S256` are supported). SPA and mobile clients should use `S256`.

--- a/docs/domains/rbac-guide.md
+++ b/docs/domains/rbac-guide.md
@@ -1,36 +1,36 @@
-# RBAC 权限控制系统 (Role-Based Access Control)
+# RBAC Access Control System (Role-Based Access Control)
 
-本文档详细说明了系统的基于角色的访问控制 (RBAC) 设计与使用。
+This document details the design and usage of the system's role-based access control (RBAC).
 
-## 1. 核心概念
+## 1. Core Concepts
 
-系统采用标准的 RBAC 模型：
+The system adopts the standard RBAC model:
 
-- **User (用户)**: 系统的操作主体。
-- **Role (角色)**: 权限的集合 (e.g., `admin`, `user`)。
-- **Permission (权限)**: 具体的访问能力 (e.g., `user:delete`, `sys:monitor`) - *注: 目前简化为基于角色的 URL 拦截*。
+- **User**: the acting subject of the system.
+- **Role**: a collection of permissions (e.g., `admin`, `user`).
+- **Permission**: a specific access capability (e.g., `user:delete`, `sys:monitor`) - *Note: currently simplified to role-based URL interception*.
 
-### 关系模型
+### Relationship Model
 
-- `User <-> Role`：多对多（Many-to-Many）
-- `Role <-> Permission`：多对多（Many-to-Many）
+- `User <-> Role`: many-to-many
+- `Role <-> Permission`: many-to-many
 
-## 2. 数据库设计
+## 2. Database Design
 
-相关表结构 (PostgreSQL):
+Relevant table structures (PostgreSQL):
 
 ```sql
--- 用户表
+-- Users table
 CREATE TABLE users (...);
 
--- 角色表
+-- Roles table
 CREATE TABLE roles (
     id SERIAL PRIMARY KEY,
     name VARCHAR(50) UNIQUE NOT NULL, -- e.g. 'admin', 'user'
     description TEXT
 );
 
--- 用户-角色关联表
+-- User-role association table
 CREATE TABLE user_roles (
     user_id INT REFERENCES users(id),
     role_id INT REFERENCES roles(id),
@@ -38,45 +38,45 @@ CREATE TABLE user_roles (
 );
 ```
 
-## 3. 配置规则 (rbac_rules)
+## 3. Configuration Rules (rbac_rules)
 
-在 `config.json` 中配置 URL 路径与所需角色的映射：
+Configure the mapping between URL paths and required roles in `config.json`:
 
 ```json
 "rbac_rules": {
-    "/api/admin/.*": ["admin"],       // 仅 admin 可访问
-    "/api/user/.*": ["user", "admin"] // user 或 admin 均可访问
+    "/api/admin/.*": ["admin"],       // admin only
+    "/api/user/.*": ["user", "admin"] // user or admin
 }
 ```
 
-- **逻辑**: OR 逻辑 (只要具备列表中任意一个角色即可通过)。
-- **匹配**: 正则表达式匹配 URL Path。
+- **Logic**: OR logic (possessing any single role in the list is sufficient to pass).
+- **Matching**: URL paths are matched by regular expression.
 
-## 4. 认证流程
+## 4. Authentication Flow
 
-1. **登录/注册**:
-   - 用户注册时，默认自动分配 `user` 角色。
-   - 用户登录时，系统查询 `user_roles` 表，获取用户所有角色。
-2. **Token 颁发**:
-   - `roles` 列表被包含在 Token 响应中 (JSON body)。
-   - `roles` 已随访问令牌签发进 JWT Claim（TokenService 签发时写入）。
-3. **请求拦截 (AuthorizationFilter)**:
-   - 解析 Access Token 获取 `userId`。
-   - 根据 `userId` 查询缓存/数据库获取当前角色。
-   - 匹配请求 URL 是否命中 `rbac_rules`。
-   - 验证用户是否持有要求角色。
-   - **通过**: 继续处理。
-   - **拒绝**: 返回 `403 Forbidden`。
+1. **Login/Registration**:
+   - On registration, users are automatically assigned the default `user` role.
+   - On login, the system queries the `user_roles` table to load all of the user's roles.
+2. **Token Issuance**:
+   - The `roles` list is included in the token response (JSON body).
+   - `roles` are also issued into the JWT claims along with the access token (written by TokenService at issuance).
+3. **Request Interception (AuthorizationFilter)**:
+   - Parse the access token to obtain the `userId`.
+   - Query the cache/database by `userId` to fetch the current roles.
+   - Match the request URL against `rbac_rules`.
+   - Verify that the user holds a required role.
+   - **Pass**: continue processing.
+   - **Deny**: return `403 Forbidden`.
 
-## 5. 管理接口
+## 5. Management Endpoints
 
-- **Dashboard**: `/api/admin/dashboard` (需 `admin` 角色)
+- **Dashboard**: `/api/admin/dashboard` (requires the `admin` role)
 
-## 6. 如何授予 Admin 权限
+## 6. How to Grant Admin Privileges
 
-目前需通过 SQL 手动授予（生产环境通常由 SuperAdmin 界面操作）：
+Currently this must be granted manually via SQL (in production it is usually done through the SuperAdmin UI):
 
 ```sql
--- 假设目标用户 ID 为 5，Admin 角色 ID 为 1
+-- Assume the target user ID is 5 and the Admin role ID is 1
 INSERT INTO user_roles (user_id, role_id) VALUES (5, 1);
 ```

--- a/docs/domains/session-management.md
+++ b/docs/domains/session-management.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 6
+---
+
+# Session Management
+
+fulla has **two different lifetimes that people often conflate**: the
+browser SSO session (a server-side session behind a cookie) and API tokens
+(no session involved at all). This page explains both, how they end, and —
+the operationally important part — what the Drogon session layer costs under
+machine traffic and how to size it.
+
+## 1. Two lifetimes, one system
+
+| | SSO session | API tokens |
+|---|---|---|
+| Who has one | Browsers walking the interactive login/consent flow | Any client calling token/introspect/userinfo — **no cookie is ever sent** |
+| Backed by | Drogon server-side session (`session_timeout`) | Opaque tokens, hashed at rest ([Token Lifecycle](token-lifecycle.md)) |
+| Ends via | `end_session` / logout / idle expiry | Expiry, revocation, refresh-family cascade |
+
+Machine traffic never touches the session store. But — the critical detail
+below — with sessions enabled it still *creates* session entries.
+
+## 2. The Drogon session behavior you must know (upstream #278)
+
+With `enable_session: true`, Drogon's framework layer creates a Session for
+**every request that arrives without a session cookie** and retains it in the
+SessionManager until `session_timeout` expires
+([drogon#278](https://github.com/an-tao/drogon/issues/278), verified on this
+codebase 2026-08-22). API clients (token / introspect / userinfo / discovery)
+never send cookies, so they pay this cost on **every request**.
+
+Measured on a production LTO build (three 60 s c=128 storms):
+
+| Quantity | Value |
+|---|---|
+| Retained per request | **~750 B** (744/755/759 B across runs) |
+| Steady-state formula | `API_QPS × session_timeout × 750 B` |
+| Discovery throughput tax | **~-54%** (164.6k → 76.3k QPS, session OFF/ON interleaved 6×) |
+
+The tax affects every endpoint (session creation happens in the framework
+layer, before routing). Historical benchmark numbers (S1 87–104k) were
+measured **with** sessions on; the session-less ceiling is ~165k.
+
+### Sizing table
+
+Sizing by the formula (interactive logins write-then-read within
+milliseconds, so correctness never depends on the TTL — verified across the
+full S4 login/authcode ladder at 120 s):
+
+| API QPS (cookie-less) | TTL 3600 (default) | TTL 300 | TTL 120 | TTL 30 |
+|---|---|---|---|---|
+| 100 | ~0.3 GB | ~23 MB | ~9 MB | ~2 MB |
+| 1,000 | **~2.7 GB** | ~225 MB | ~90 MB | ~23 MB |
+| 10,000 | **~27 GB (OOM zone)** | ~2.2 GB | ~0.9 GB | ~225 MB |
+
+**Guidance**:
+
+- Mostly-interactive deployments (under 100 QPS of API traffic): keep the default 3600 s —
+  the full SSO experience survives.
+- Non-trivial API traffic: lower `session_timeout` (and `session_max_age`
+  together) to a row your memory budget tolerates. A 2-minute idle window is
+  acceptable for browser SSO (OIDC deployments commonly use 5–15 min).
+- The benchmark profile uses 30 s (`config.bench.json`,
+  `QPS × 30 × 750 B` capped).
+- The throughput tax (not the retention) is independent of TTL and exists
+  whenever sessions are enabled; the structural fix is upstream lazy /
+  per-path session creation — tracked in
+  [drogon#278](https://github.com/an-tao/drogon/issues/278).
+
+Deployment-time operational summary: [Production Deployment · performance
+tuning](../operate/deployment.md).
+
+## 3. Ending a session
+
+### RP-Initiated Logout (F-027) — `GET/POST /oauth2/end_session`
+
+Terminates the server-side session and (optionally) redirects. Rules:
+
+- `post_logout_redirect_uri` **must** be one of the client's registered
+  redirect URIs; the client is identified by the `id_token_hint`'s `aud`.
+- The hint's **signature is verified** (RS256 + kid + iss/exp/sub policy).
+  A failed verification → 400 `AUTH_INVALID_ID_TOKEN_HINT` (4006).
+- No valid hint + registered URI → 400. On success: 302 with `state`
+  echoed, or 200 when no redirect URI was supplied.
+
+### API logout — `POST /oauth2/logout`
+
+Revokes the presented tokens **and** calls `session()->clear()` (F-028), so
+the server-side session dies together with the access token.
+
+### Re-authentication semantics (F-022)
+
+`prompt=login` forces re-authentication even with a live session;
+`prompt=none` forbids UI (errors `login_required` / `consent_required` are
+redirected back to the verified redirect URI); `max_age=<seconds>` forces
+re-auth when the session's `auth_time` is older. `auth_time`, `amr`, and
+`acr` (1 = password, 2 = MFA) travel on the authorization code and are
+stamped into the id_token — see
+[Configuration Guide §6](../operate/configuration-guide.md).
+
+## 4. What sessions are NOT
+
+- Token revocation surfaces (revoke by token / client / user) act on
+  **tokens**, not SSO sessions — see [Token Lifecycle §6](token-lifecycle.md).
+- The admin console's token browser lists at-rest tokens; it does not expose
+  live session inventory.

--- a/docs/domains/social-login.md
+++ b/docs/domains/social-login.md
@@ -1,19 +1,18 @@
-# 社交登录指南
+# Social Login Guide
 
-后端社交登录按"提供方适配器"模式实现；**GitHub 是当前唯一前后端完整接线的提供方**，
-Google 与微信为"后端就绪、前端自接"模式（后端路由与配置已就绪，前端按钮需自行接入）。
+Backend social login is implemented with a "provider adapter" pattern; **GitHub is currently the only provider fully wired end to end**, while Google and WeChat follow a "backend-ready, frontend wires itself" model (backend routes and configuration are in place; the frontend buttons must be wired in separately).
 
-## GitHub（已完整接线，主线索）
+## GitHub (fully wired, mainline)
 
-- 后端路由：`POST /api/github/login`；前端 `frontends/user` 已有"Sign in with GitHub"按钮
-  （OAuth App 的 client id 经 `VITE_GITHUB_CLIENT_ID` 注入）。
-- 账号模型：`oauth2_subject_mappings(provider, subject)` 映射到本地用户；首次登录按
-  `createLinkedUser` 语义创建带默认 `user` 角色的本地账号（用户名冲突时拒绝采用，fail-closed）。
+- Backend route: `POST /api/github/login`; the `frontends/user` frontend already has a "Sign in with GitHub" button
+  (the OAuth App's client id is injected via `VITE_GITHUB_CLIENT_ID`).
+- Account model: `oauth2_subject_mappings(provider, subject)` maps to a local user; on first login, a local account with
+  the default `user` role is created per the `createLinkedUser` semantics (username collisions are rejected — fail-closed).
 
-## Google（后端就绪）
+## Google (backend ready)
 
-1. Google Cloud 侧创建 OAuth 2.0 客户端（Web 应用，回调填 `https://<your-host>/api/google/login`）。
-2. 后端配置（`config.json`）：
+1. Create an OAuth 2.0 client on the Google Cloud side (Web application; set the callback to `https://<your-host>/api/google/login`).
+2. Backend configuration (`config.json`):
 
 ```json
 "external_auth": {
@@ -24,22 +23,22 @@ Google 与微信为"后端就绪、前端自接"模式（后端路由与配置�
 }
 ```
 
-3. 后端路由 `POST /api/google/login` 接收 `{ code, redirect_uri }` 并完成 code 交换。
-4. **前端按钮需自行接线**（当前 UI 未内置 Google 按钮——验证时用 curl 直接调后端路由）。
+3. The backend route `POST /api/google/login` accepts `{ code, redirect_uri }` and completes the code exchange.
+4. **The frontend button must be wired in yourself** (the current UI has no built-in Google button — use curl to call the backend route directly when verifying).
 
-## 微信（后端就绪；要求公网回调域名）
+## WeChat (backend ready; requires a public callback domain)
 
-1. 微信开放平台创建网站应用（**不支持 localhost 回调**，需备案域名）。
-2. 后端配置同上结构（`external_auth.wechat`：appid / app_secret）。
-3. 后端路由 `POST /api/wechat/login`。
-4. 本地开发三招：hosts 把回调域名指到 127.0.0.1 / Nginx 反代 / 内网穿透。
+1. Create a website application on the WeChat Open Platform (**localhost callbacks are not supported**; an ICP-registered domain is required).
+2. Backend configuration follows the same structure (`external_auth.wechat`: appid / app_secret).
+3. Backend route: `POST /api/wechat/login`.
+4. Three tricks for local development: point the callback domain to 127.0.0.1 via the hosts file / an Nginx reverse proxy / an intranet tunnel.
 
-## 通用安全注意
+## General Security Notes
 
-- 社交回调的 `state` 必须校验（防 CSRF）；提供方返回的 subject 只信任服务端 code 交换结果，
-  绝不信任前端提交的用户信息。
-- 解绑社交账号有"最后一种登录方式"保护与并发解绑竞态的已知限制（见 `docs/history`
-  归档的 social-link 设计与 CHANGELOG #54/#69 修复记录）。
+- The `state` on social callbacks must be verified (CSRF protection); the subject returned by a provider is trusted only
+  from the server-side code exchange result — never trust user information submitted by the frontend.
+- Unlinking a social account has "last login method" protection and a known limitation around concurrent-unlink races
+  (see the social-link design archived under `docs/history` and the CHANGELOG #54/#69 fix records).
 
-> 合并自已退役的 google-guide.md 与 wechat-guide.md（docs 治理 A2），并修正了 google 指南
-> 中"前端无按钮却让用户点击按钮"的自相矛盾。
+> Merged from the retired google-guide.md and wechat-guide.md (docs governance A2), and fixed the self-contradiction
+> in the Google guide where "there was no frontend button, yet users were told to click the button".

--- a/docs/domains/token-lifecycle.md
+++ b/docs/domains/token-lifecycle.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 5
+---
+
+# Token Lifecycle
+
+How tokens are born, live, and die in fulla: the three token types, what is
+actually stored, how refresh rotation detects theft, and every knob that
+controls a lifetime. For the storage schema behind this, see
+[Data Persistence](../architecture/data-persistence.md); for the HTTP
+contract, see the [API Reference](api-reference.md) and
+[ADR-0004](../adr/ADR-0004.md).
+
+## 1. Three token types, three different shapes
+
+| Token | Shape | Validated by | Lifetime default |
+|---|---|---|---|
+| Access token | **Opaque random string** (`generateSecureToken`) | Server-side state (introspection / userinfo) — never a self-contained JWT | 3600 s (`access_token_ttl`) |
+| Refresh token | Opaque random string + **family id** | Server-side state; rotation on every use | 30 days (configurable) |
+| id_token | **RS256 JWT** signed via JWKS (`kid` published at `/.well-known/jwks.json`) | Client-side signature verification (standard OIDC) | Same as access token; issued only with the `openid` scope |
+
+Design rationale ([ADR-0004](../adr/ADR-0004.md)): opaque access tokens keep
+the server in full control — revocation is immediate and stateful, and no
+key-compromised token outlives its server-side record. The JWT capability is
+reserved for the OIDC `id_token`, where the protocol requires it.
+
+One frequent confusion: the **roles** that accompany a token response are part
+of the JSON envelope (`"roles": [...]`) and the id_token claims — the opaque
+access token itself carries nothing that needs decoding.
+
+## 2. Issuance paths
+
+All grants converge on `TokenService` (libs/oauth2):
+
+| Grant | Mints | Notes |
+|---|---|---|
+| `authorization_code` (+ PKCE, mandatory for PUBLIC clients) | access + refresh (+ id_token if `openid`) | The code is single-use with atomic consume (see §5) |
+| `refresh_token` | new access + **new** refresh | Old refresh is revoked; family id is inherited (§4) |
+| `client_credentials` | access only (M2M, no user) | CONFIDENTIAL clients only |
+| `device_code` | access + refresh after user approval | Polling per RFC 8628 |
+
+`expires_in` in every response advertises the **configured** access-token
+lifetime — not a hardcoded 3600 (RFC 6749 §5.1).
+
+## 3. What is stored (and what is not)
+
+- Access and refresh tokens are persisted **only as SHA-256 hashes**
+  (`hashToken()` before any repository write) — a database dump exposes no
+  usable credentials ([ADR-0004](../adr/ADR-0004.md)).
+- The refresh token row additionally stores its `token_family` id, the
+  associated access-token hash, `revoked`/`revoked_at`/`revoked_by`.
+- Rows past their TTL are deleted by `OAuth2CleanupService`
+  (`cleanup_interval_seconds`, default 3600 s) — Postgres via periodic DELETE,
+  Redis historically via TTL, memory via periodic sweep.
+
+## 4. Refresh rotation, reuse detection, family revocation
+
+Every refresh grants a **new** refresh token that inherits the same
+`token_family` (V008). If a refresh token that was already revoked is
+presented again, that is treated as theft: the server **cascades revocation
+to every token in the family** — attacker and legitimate user alike must
+re-authenticate. The full threat-model walkthrough (with a sequence diagram)
+lives in [Security Architecture §7](../architecture/security-architecture.md).
+
+## 5. Single-use of authorization codes
+
+`consumeAuthCode` is atomic per backend: Postgres uses
+`UPDATE ... WHERE consumed = false ... RETURNING`, Redis used a Lua script,
+memory uses a mutex — so a stolen code replayed in a race loses, always. The
+contract is enforced across all three implementations by
+`GrantRepositoryContractTest` (`ctest -L Contract`).
+
+## 6. Revocation surfaces
+
+| Surface | Granularity |
+|---|---|
+| `POST /oauth2/revoke` (RFC 7009) | The presented token |
+| Admin API `DELETE /api/admin/tokens/{prefix}` | By token prefix |
+| Admin token management | Revoke by **client** or by **user** — wipes every token minted for that principal |
+
+Revocation is stateful and immediate: the very next introspection or
+userinfo call with a revoked token returns `{"active": false}` / 401.
+
+## 7. Cache interplay
+
+With the Redis L2 cache enabled (`cache.enabled`), token and client reads hit
+`fulla:cache:*` before Postgres. Every write path (issue, refresh, revoke)
+invalidates through **delayed double-delete** (immediate DEL + a second DEL
+~200 ms later, `cache.invalidation_double_delete_delay_ms`), closing the
+race where a concurrent reader re-fills a stale entry between the write and
+the first delete. Failures of the second delete are counted in
+`fulla_cache_invalidation_failures_total` — see
+[Observability](../operate/observability.md). Details in
+[Data Persistence · cache consistency](../architecture/data-persistence.md).
+
+## 8. Configuration reference
+
+| Key | Default | Meaning |
+|---|---|---|
+| `access_token_ttl` | 3600 | Access-token lifetime (seconds); advertised in `expires_in` |
+| refresh-token TTL | 30 days | Refresh-token lifetime |
+| `cleanup_interval_seconds` | 3600 | How often `OAuth2CleanupService` purges expired rows |
+| `cache.enabled` / `cache.ttl_seconds` | false / — | L2 cache for token/client reads ([Configuration Guide](../operate/configuration-guide.md)) |

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -2,23 +2,20 @@
 sidebar_position: 0
 ---
 
-# 开始
+# Getting Started
 
-**Fulla** 是以 C++17 构建的高性能开源身份与访问管理（IAM）核心：生产级 OAuth2/OIDC
-授权服务器，完整覆盖用户认证、MFA、WebAuthn、RBAC 与多租户——既可作为**开箱即用的
-产品**（Docker/Helm）部署，也可作为**可嵌入的 C++ SDK**（`find_package(fulla-*)`）集成。
+**fulla** is a high-performance, open-source identity and access management (IAM) core built in C++17: a production-grade OAuth2/OIDC authorization server with full coverage of user authentication, MFA, WebAuthn, RBAC, and multi-tenancy — it can be deployed as an **out-of-the-box product** (Docker/Helm) or integrated as an **embeddable C++ SDK** (`find_package(fulla-*)`).
 
-快速入口：
+Quick entry points:
 
-| 你想… | 去 |
+| If you want to… | Go to |
 |---|---|
-| 五分钟了解架构 | [架构总览](architecture/architecture-overview) |
-| 跑起来试试 | [Docker 部署](operate/docker-deployment) · README 的 [Quick Start](https://github.com/voidvec/fulla#quick-start) |
-| 把 OAuth2 引擎嵌进你的 C++ 项目 | [SDK 集成指南](sdk/sdk-integration-guide) |
-| 用任意语言调 HTTP API | [API 参考](domains/api-reference) · [OIDC 集成](domains/oidc-guide) |
-| 部署到生产 | [生产部署](operate/deployment) · [配置指南](operate/configuration-guide) |
-| 理解某个设计为什么是这样 | [ADR 决策记录](adr/ADR-0001.md) |
-| 给项目贡献 | [贡献区](contribute/testing-guide) |
+| Understand the architecture in five minutes | [Architecture Overview](architecture/architecture-overview) |
+| Get it running | [Docker Deployment](operate/docker-deployment) · [Quick Start](https://github.com/voidvec/fulla#quick-start) in the README |
+| Embed the OAuth2 engine in your C++ project | [SDK Integration Guide](sdk/sdk-integration-guide) |
+| Call the HTTP API from any language | [API Reference](domains/api-reference) · [OIDC Integration](domains/oidc-guide) |
+| Deploy to production | [Production Deployment](operate/deployment) · [Configuration Guide](operate/configuration-guide) |
+| Understand why a design is the way it is | [ADR Decision Records](adr/ADR-0001.md) |
+| Contribute to the project | [Contribute](contribute/testing-guide) |
 
-本站内容直接来自[仓库的 docs/ 目录](https://github.com/voidvec/fulla/tree/master/docs)
-（单一事实源，零拷贝）；发现错误请提 PR 修改仓库文档，站点随 master 自动重建。
+The content on this site comes directly from [the repository's docs/ directory](https://github.com/voidvec/fulla/tree/master/docs) (single source of truth, zero copying); if you find an error, please open a PR against the repository documentation — the site is rebuilt automatically from master.

--- a/docs/operate/account-lockout.md
+++ b/docs/operate/account-lockout.md
@@ -1,40 +1,40 @@
-# 账号锁定机制说明
+# Account Lockout Mechanism
 
-## 问题描述
+## Problem Description
 
-OAuth2 系统实现了账号锁定机制以防止暴力破解攻击。当用户多次登录失败时，账号会被临时锁定。
+The OAuth2 system implements an account lockout mechanism to defend against brute-force attacks. After repeated failed logins, an account is temporarily locked.
 
-## 锁定规则
+## Lockout Rules
 
-根据 `AuthService.cc` 中的实现，锁定规则如下：
+Per the implementation in `AuthService.cc`, the lockout rules are:
 
-| 失败次数 | 锁定时长 |
+| Failed attempts | Lockout duration |
 |---------|---------|
-| 5-9次   | 1分钟   |
-| 10-14次 | 5分钟   |
-| 15-19次 | 30分钟  |
-| 20次以上 | 1小时   |
+| 5-9    | 1 minute  |
+| 10-14  | 5 minutes |
+| 15-19  | 30 minutes|
+| 20+    | 1 hour    |
 
-## 常见场景
+## Common Scenarios
 
-### 场景1：测试脚本重复执行导致锁定
+### Scenario 1: lockout caused by repeated test-script runs
 
-**症状**：
-- 第一次运行测试脚本成功
-- 第二次运行时所有测试失败
-- 后端日志显示：`Account locked for user: admin until 1779441748`
+**Symptoms**:
+- The first run of the test script succeeds
+- The second run fails all tests
+- Backend logs show: `Account locked for user: admin until 1779441748`
 
-**原因**：
-测试脚本中某个测试用例登录失败（例如使用了错误的凭证），累积失败次数达到阈值。
+**Cause**:
+A test case in the script failed to log in (e.g. wrong credentials), accumulating failed attempts up to the threshold.
 
-**解决方案**：
-测试脚本已自动在结束时重置账号锁定状态。如果仍然遇到问题，可以手动重置。
+**Solution**:
+The test script now automatically resets the account lockout state at the end. If the problem persists, reset manually.
 
-## 手动重置账号锁定
+## Manually Resetting Account Lockout
 
-### 方法1：使用重置脚本（推荐）
+### Method 1: use the reset script (recommended)
 
-#### 本地PostgreSQL数据库
+#### Local PostgreSQL database
 
 ```powershell
 # 默认使用config.json中的配置（fulla_user/fulla_db/123456）
@@ -47,7 +47,7 @@ OAuth2 系统实现了账号锁定机制以防止暴力破解攻击。当用户�
 .\scripts\backend\reset-account-lockout.ps1 -DbHost localhost -DbUser fulla_user -DbPassword 123456
 ```
 
-#### Docker数据库
+#### Docker database
 
 ```powershell
 # 脚本会自动检测Docker容器
@@ -57,20 +57,20 @@ OAuth2 系统实现了账号锁定机制以防止暴力破解攻击。当用户�
 .\scripts\backend\reset-account-lockout.ps1 -Username admin
 ```
 
-### 方法2：重置admin密码
+### Method 2: reset the admin password
 
-如果admin账号密码被意外修改或升级为PBKDF2后无法登录，使用此脚本重置为默认密码：
+If the admin password was changed accidentally, or login fails after the upgrade to PBKDF2, use this script to reset it to the default password:
 
 ```powershell
 # 重置admin密码为默认值 'admin'
 .\scripts\backend\reset-admin-password.ps1
 ```
 
-**注意**：此脚本会将admin密码重置为SHA-256格式的默认密码（开发环境用）。首次登录后，系统会自动升级为PBKDF2格式。
+**Note**: this script resets the admin password to the default in SHA-256 form (for development environments). On first login, the system automatically upgrades it to PBKDF2.
 
-### 方法3：直接使用SQL
+### Method 3: direct SQL
 
-#### 本地PostgreSQL
+#### Local PostgreSQL
 
 ```powershell
 # Windows PowerShell - 重置锁定状态
@@ -92,7 +92,7 @@ PGPASSWORD=123456 psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users S
 PGPASSWORD=123456 psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET password_hash = '892738161086b314334f88d661aa6e7bab7c825c34bf55222811dad46cdbf724', salt = 'admin_salt', failed_login_count = 0, locked_until = 0 WHERE username = 'admin';"
 ```
 
-#### Docker数据库
+#### Docker database
 
 ```bash
 # 重置锁定状态
@@ -102,7 +102,7 @@ docker exec <container_name> psql -U fulla_user -d fulla_db -c "UPDATE users SET
 docker exec <container_name> psql -U fulla_user -d fulla_db -c "UPDATE users SET password_hash = '892738161086b314334f88d661aa6e7bab7c825c34bf55222811dad46cdbf724', salt = 'admin_salt', failed_login_count = 0, locked_until = 0 WHERE username = 'admin';"
 ```
 
-### 方法4：查看锁定状态
+### Method 4: inspect lockout state
 
 ```sql
 -- 查看所有用户的锁定状态
@@ -123,9 +123,9 @@ FROM users
 ORDER BY username;
 ```
 
-## 测试脚本自动清理
+## Test Script Auto-Cleanup
 
-`test-admin-endpoints.ps1` 已经在测试结束时自动重置admin账号的锁定状态：
+`test-admin-endpoints.ps1` already resets the admin account's lockout state when tests finish:
 
 ```powershell
 # 测试脚本会在结束时执行：
@@ -134,18 +134,18 @@ ORDER BY username;
 # 3. 重置admin账号的 failed_login_count 和 locked_until
 ```
 
-**注意**：如果使用本地PostgreSQL，需要在脚本中配置数据库密码：
+**Note**: when using a local PostgreSQL, configure the database password in the script:
 
 ```powershell
 # 编辑 test-admin-endpoints.ps1，找到这一行：
 $env:PGPASSWORD = "your_password"  # 修改为你的数据库密码
 ```
 
-## 预防措施
+## Preventive Measures
 
-### 1. 测试环境使用专用账号
+### 1. Use a dedicated account for testing
 
-不要在测试中使用生产环境的admin账号。创建专门的测试账号：
+Do not use the production admin account in tests. Create a dedicated test account:
 
 ```sql
 INSERT INTO users (username, password_hash, salt, email, email_verified)
@@ -156,9 +156,9 @@ SELECT u.id, r.id FROM users u, roles r
 WHERE u.username = 'test_admin' AND r.name = 'admin';
 ```
 
-### 2. 测试后自动清理
+### 2. Automatic cleanup after tests
 
-在所有测试脚本的末尾添加清理代码：
+Add cleanup code at the end of every test script:
 
 ```powershell
 # Cleanup
@@ -170,9 +170,9 @@ try {
 }
 ```
 
-### 3. 使用正确的凭证
+### 3. Use correct credentials
 
-确保测试脚本中使用的用户名和密码与数据库中的一致：
+Make sure the usernames and passwords used in test scripts match the database:
 
 ```powershell
 # 检查数据库中的用户
@@ -182,11 +182,11 @@ psql -U fulla_user -d fulla_db -h localhost -c "SELECT username FROM users;"
 # 需要通过应用程序的注册接口或直接调用PasswordHasher
 ```
 
-## 生产环境建议
+## Production Recommendations
 
-### 1. 监控锁定事件
+### 1. Monitor lockout events
 
-在生产环境中监控账号锁定事件：
+Monitor account lockout events in production:
 
 ```sql
 -- 查找最近被锁定的账号
@@ -200,9 +200,9 @@ WHERE locked_until > EXTRACT(EPOCH FROM NOW())
 ORDER BY locked_until DESC;
 ```
 
-### 2. 设置告警
+### 2. Set up alerts
 
-当关键账号（如admin）被锁定时发送告警：
+Raise an alert when critical accounts (such as admin) get locked:
 
 ```sql
 -- 可以通过定时任务检查
@@ -211,27 +211,27 @@ WHERE username IN ('admin', 'superuser')
 AND locked_until > EXTRACT(EPOCH FROM NOW());
 ```
 
-### 3. 审计日志
+### 3. Audit logs
 
-后端日志会记录所有锁定事件：
+The backend logs every lockout event:
 
 ```
 WARN  Account locked for user: admin until 1779441748
 INFO  [METRIC] oauth2_login_failures_total reason=bad_credentials
 ```
 
-建议将这些日志发送到集中式日志系统（如ELK、Grafana Loki）进行分析。
+Consider shipping these logs to a centralized logging system (e.g. ELK, Grafana Loki) for analysis.
 
-## 安全注意事项
+## Security Considerations
 
-1. **不要禁用锁定机制**：这是防止暴力破解的重要安全措施
-2. **不要在代码中硬编码数据库密码**：使用环境变量或密钥管理系统
-3. **限制重置权限**：只有管理员应该能够重置账号锁定状态
-4. **记录重置操作**：在生产环境中，所有重置操作都应该被审计
+1. **Do not disable the lockout mechanism**: it is an important defense against brute-force attacks
+2. **Do not hardcode database passwords in code**: use environment variables or a secret management system
+3. **Restrict reset permissions**: only administrators should be able to reset account lockout state
+4. **Record reset operations**: in production, every reset operation should be audited
 
-## 相关文件
+## Related Files
 
-- `libs/drogon/src/AuthService.cc` - 账号锁定逻辑实现
-- `scripts/backend/test-admin-endpoints.ps1` - 测试脚本（含自动清理）
-- `scripts/backend/reset-account-lockout.ps1` - 手动重置脚本
-- 数据库表：`users` (字段: `failed_login_count`, `locked_until`, `last_failed_login`)
+- `libs/drogon/src/AuthService.cc` - account lockout logic implementation
+- `scripts/backend/test-admin-endpoints.ps1` - test script (with auto-cleanup)
+- `scripts/backend/reset-account-lockout.ps1` - manual reset script
+- Database table: `users` (columns: `failed_login_count`, `locked_until`, `last_failed_login`)

--- a/docs/operate/configuration-guide.md
+++ b/docs/operate/configuration-guide.md
@@ -1,48 +1,51 @@
-# 配置指南
+# Configuration Guide
 
-## 1. 环境变量注入
+## 1. Environment Variable Injection
 
-应用支持用环境变量覆盖关键配置项。这在 Docker/Kubernetes 环境下尤为重要——
-敏感信息不应硬编码在 `config.json` 中。
+The application supports overriding key configuration items with environment variables. This matters
+especially in Docker/Kubernetes environments — sensitive values should not be hardcoded in
+`config.json`.
 
-### 支持的环境变量
+### Supported Environment Variables
 
-| 变量名 | 说明 | 覆盖的配置路径 | 示例 |
+| Variable | Description | Config path overridden | Example |
 |---|---|---|---|
-| `FULLA_DB_HOST` | 数据库主机名 | `db_clients[0].host` | `postgres` |
-| `FULLA_DB_NAME` | 数据库名 | `db_clients[0].dbname` | `fulla_db` |
-| `FULLA_DB_PASSWORD` | 数据库密码 | `db_clients[0].passwd` | `secret` |
-| `FULLA_REDIS_HOST` | Redis 主机名 | `redis_clients[0].host` | `redis` |
-| `FULLA_REDIS_PASSWORD` | Redis 密码 | `redis_clients[0].passwd` | `secret` |
-| `FULLA_VUE_CLIENT_SECRET` | Vue 客户端密钥 | `plugins[OAuth2Plugin].config.clients.vue-client.secret` | `...` |
+| `FULLA_DB_HOST` | Database host | `db_clients[0].host` | `postgres` |
+| `FULLA_DB_NAME` | Database name | `db_clients[0].dbname` | `fulla_db` |
+| `FULLA_DB_PASSWORD` | Database password | `db_clients[0].passwd` | `secret` |
+| `FULLA_REDIS_HOST` | Redis host | `redis_clients[0].host` | `redis` |
+| `FULLA_REDIS_PASSWORD` | Redis password | `redis_clients[0].passwd` | `secret` |
+| `FULLA_VUE_CLIENT_SECRET` | Vue client secret | `plugins[OAuth2Plugin].config.clients.vue-client.secret` | `...` |
 
-> 生产部署的完整环境变量清单（30+ 项）见[生产部署](deployment.md)的变量表；本表只列注入机制的六个核心项。
+> For the full production environment variable list (30+ entries), see the variable table in
+> [Production Deployment](deployment.md); this table lists only the six core items of the
+> injection mechanism.
 
-### 工作机制
+### How It Works
 
-1. **加载钩子**：启动时 `main.cc` 的 `loadConfiguration()` 先调用 `common::config::ConfigManager::load()`，再调用 `ConfigManager::validate()`。
-2. **解析**：把基础 `config.json` 读入 `Json::Value` 对象。
-3. **注入**：检查上述环境变量是否存在；存在则就地更新 `Json::Value` 中对应节点。
-4. **加载**：Drogon 通过 `drogon::app().loadConfigJson(config)` 直接加载修改后的配置对象，磁盘上不产生临时文件。
+1. **Load hook**: at startup, `loadConfiguration()` in `main.cc` first calls `common::config::ConfigManager::load()`, then `ConfigManager::validate()`.
+2. **Parse**: the base `config.json` is read into a `Json::Value` object.
+3. **Inject**: the environment variables above are checked; when present, the corresponding nodes in the `Json::Value` are updated in place.
+4. **Load**: Drogon loads the modified configuration object directly via `drogon::app().loadConfigJson(config)`; no temporary files are written to disk.
 
-### 验证
+### Verification
 
-专用测试 `EnvInjectionVerify`（`EnvConfigTest.cc`）保证该逻辑正确。
+A dedicated test, `EnvInjectionVerify` (`EnvConfigTest.cc`), guarantees this logic is correct.
 
-## 2. Docker 部署
+## 2. Docker Deployment
 
-仓库内置 `docker-compose.yml` 编排全栈（详解见 [Docker 部署](docker-deployment.md)）。
+The repository ships a `docker-compose.yml` that orchestrates the full stack (see [Docker Deployment](docker-deployment.md) for details).
 
-### 服务栈
+### Service Stack
 
-- **fulla-frontend**：Vue SPA + Nginx（构建自 `deploy/docker/Dockerfile` 的 `frontend-runtime`）。
-- **fulla-admin**：管理后台前端（构建自 `frontends/admin/Dockerfile`）。
-- **fulla-backend**：Drogon 后端（构建自 `deploy/docker/Dockerfile` 的 `backend-runtime`）。
-- **fulla-postgres**：PostgreSQL 17（后端启动时经 `FULLA_AUTO_MIGRATE=true` 应用 `apps/server/migrations/` 下的 schema）。
-- **fulla-redis**：带密码保护的 Redis 7。
-- **fulla-prometheus**：指标采集。
+- **fulla-frontend**: Vue SPA + Nginx (built from the `frontend-runtime` stage of `deploy/docker/Dockerfile`).
+- **fulla-admin**: admin console frontend (built from `frontends/admin/Dockerfile`).
+- **fulla-backend**: Drogon backend (built from the `backend-runtime` stage of `deploy/docker/Dockerfile`).
+- **fulla-postgres**: PostgreSQL 17 (schema under `apps/server/migrations/` applied at backend startup via `FULLA_AUTO_MIGRATE=true`).
+- **fulla-redis**: password-protected Redis 7.
+- **fulla-prometheus**: metrics collection.
 
-### 快速开始
+### Quick Start
 
 ```bash
 # 构建并启动（在仓库根目录执行）
@@ -55,103 +58,109 @@ docker compose -f deploy/docker/docker-compose.yml logs -f fulla-backend
 docker compose -f deploy/docker/docker-compose.yml down
 ```
 
-### Docker 下的配置处理
+### Configuration Handling under Docker
 
-`docker-compose.yml` 将 `apps/server/config/config.json` 只读挂载进容器；
-`environment` 段注入环境变量（见 §1），运行时经 `ConfigManager::load()` +
-环境注入覆盖文件默认值。
+`docker-compose.yml` mounts `apps/server/config/config.json` into the container read-only;
+the `environment` section injects environment variables (see §1), and at runtime
+`ConfigManager::load()` plus environment injection override the file defaults.
 
-## 3. 存储后端选择
+## 3. Storage Backend Selection
 
-OAuth2 插件的 `config.storage_type` 决定持久化后端：
+The OAuth2 plugin's `config.storage_type` determines the persistence backend:
 
-| `storage_type` | 状态 | 说明 |
+| `storage_type` | Status | Notes |
 |---|---|---|
-| `postgres` | **支持（唯一生产后端）** | 完整令牌持久化、refresh token 轮换与重用检测。 |
-| `redis` | **已弃用** | 历史上从未持久化 refresh token（`saveRefreshToken`/`getRefreshToken` 为空操作），轮换与重用检测静默失效。该模式仍可启动（兼容考虑，启动时打 ERROR 日志），但 `refresh_token` 授权会以 `unsupported_grant_type` 被拒绝。新部署不要使用。 |
-| `memory` | 仅测试 | 面向单元/集成测试，不用于生产。 |
+| `postgres` | **Supported (the only production backend)** | Full token persistence, refresh token rotation and reuse detection. |
+| `redis` | **Deprecated** | Never persisted refresh tokens historically (`saveRefreshToken`/`getRefreshToken` are no-ops), so rotation and reuse detection silently fail. The mode still starts (for compatibility; it logs an ERROR at startup), but the `refresh_token` grant is rejected with `unsupported_grant_type`. Do not use in new deployments. |
+| `memory` | Test only | For unit/integration tests; not for production. |
 
-目标架构：**Postgres 作为存储层，前置一个在线 Redis L2 缓存**（键空间
-`fulla:cache:*`，经 `config.json` 的 `cache` 块配置 `enabled` /
-`ttl_seconds` / `invalidation_double_delete_delay_ms`；失效采用延迟双删，
-见 `DelayedDoubleDelete`）。不存在独立 Redis 存储模式。
+Target architecture: **Postgres as the storage layer, fronted by an online Redis L2 cache**
+(keyspace `fulla:cache:*`, configured via the `cache` block in `config.json` — `enabled` /
+`ttl_seconds` / `invalidation_double_delete_delay_ms`; invalidation uses the delayed
+double-delete, see `DelayedDoubleDelete`). There is no standalone Redis storage mode.
 
-## 4. Issuer 配置
+## 4. Issuer Configuration
 
-`config.metadata.issuer`（custom config）是服务器 issuer URL 的唯一事实源。
-`OAuth2Plugin` 启动时读取一次，一致地用于：
+`config.metadata.issuer` (custom config) is the single source of truth for the server's issuer
+URL. `OAuth2Plugin` reads it once at startup and uses it consistently for:
 
-- 签发 access token 时打上的 `iss` 声明（authorization_code / refresh_token / client_credentials / device_code 授权）；
-- 内省响应的 `iss`（存储行未携带时以配置值回填）；
-- 发现文档（`/.well-known/openid-configuration`、`/.well-known/oauth-authorization-server`）。
+- the `iss` claim stamped on issued access tokens (authorization_code / refresh_token / client_credentials / device_code grants);
+- `iss` in introspection responses (backfilled from the configured value when the stored row carries none);
+- the discovery documents (`/.well-known/openid-configuration`, `/.well-known/oauth-authorization-server`).
 
-约束：
+Constraints:
 
-- 末尾斜杠会被自动规范化掉，不要依赖它。
-- 未设置时默认 `http://localhost:5555`，此时打 `LOG_WARN`。
-- 生产部署**必须**配置 `https://` issuer；非回环主机上使用明文 http issuer 会有启动告警。
-- 内省 `iss` 与发现文档 `issuer` 保证逐字节一致（OIDC Discovery §3 要求）。
+- Trailing slashes are normalized away automatically; do not rely on them.
+- Defaults to `http://localhost:5555` when unset, with a `LOG_WARN`.
+- Production deployments **must** configure an `https://` issuer; a plaintext http issuer on a non-loopback host triggers a startup warning.
+- Introspection `iss` and the discovery documents' `issuer` are guaranteed byte-for-byte identical (as OIDC Discovery §3 requires).
 
-## 5. 客户端令牌端点认证方式（F-017）
+## 5. Client Token-Endpoint Authentication Methods (F-017)
 
-每个客户端通过 `oauth2_clients.token_endpoint_auth_method` 列声明其在
-`/oauth2/token`、`/oauth2/introspect`、`/oauth2/revoke` 的认证方式：
+Each client declares, via the `oauth2_clients.token_endpoint_auth_method` column, how it
+authenticates at `/oauth2/token`, `/oauth2/introspect`, and `/oauth2/revoke`:
 
-| 取值 | 语义 |
+| Value | Semantics |
 |---|---|
-| `client_secret_basic` | 密钥**必须**走 `Authorization: Basic` 头；body 携带 `client_secret` 会被拒绝。 |
-| `client_secret_post` | 密钥**必须**走 POST body；Basic 头会被拒绝。 |
-| `none` | PUBLIC 客户端；携带任何 `client_secret` 都会被拒绝。 |
-| NULL / 空 | 旧版宽松回退：接受 Basic 头，也接受 body 密钥（Basic→body 回退）。 |
+| `client_secret_basic` | The secret **must** be sent in the `Authorization: Basic` header; a `client_secret` in the body is rejected. |
+| `client_secret_post` | The secret **must** be sent in the POST body; the Basic header is rejected. |
+| `none` | PUBLIC client; any `client_secret` present is rejected. |
+| NULL / empty | Legacy lenient fallback: accepts the Basic header and also a body secret (Basic→body fallback). |
 
-注册/管理端创建时若省略该字段，按以下默认值落库：
+When the field is omitted at creation through the registration/admin endpoints, the following
+defaults are stored:
 
-- `PUBLIC` 客户端 → `none`（本就没有密钥）。
-- `CONFIDENTIAL` 客户端 → `client_secret_basic`。
+- `PUBLIC` clients → `none` (they have no secret to begin with).
+- `CONFIDENTIAL` clients → `client_secret_basic`.
 
-种子客户端均显式声明：`vue-client` 与 `admin-console` → `none`；
-`backend-svc` → `client_secret_basic`。已有 NULL 值的客户端保持升级前的
-行为，升级不破坏存量部署。
+Seed clients declare it explicitly: `vue-client` and `admin-console` → `none`;
+`backend-svc` → `client_secret_basic`. Existing clients with NULL values keep their
+pre-upgrade behavior; the upgrade does not break existing deployments.
 
-## 6. OIDC prompt / max_age / auth_time（F-022）
+## 6. OIDC prompt / max_age / auth_time (F-022)
 
-授权端点支持 OIDC Core §3.1.2.1 的 `prompt` 与 `max_age` 参数：
+The authorization endpoint supports the `prompt` and `max_age` parameters from OIDC Core
+§3.1.2.1:
 
-- **`prompt=none`**：禁止任何 UI。无会话 → 302 `error=login_required`；
-  需要同意 → `error=consent_required`。错误会带着回显的 `state` 重定向回
-  已验证的 `redirect_uri`。`none` 与其他值组合（如 `none login`）自相矛盾，
-  直接返回 400。
-- **`prompt=login`**：即使已有会话也强制重新认证。
-- **`prompt=consent`**：即使既有同意已覆盖所请求的 scope，也强制显示同意页。
-- **`max_age=<秒>`**：若会话的 `auth_time`（登录 / MFA 验证时设置）早于
-  `max_age`，强制重新认证。
+- **`prompt=none`**: no UI of any kind. No session → 302 `error=login_required`;
+  consent required → `error=consent_required`. Errors redirect back to the validated
+  `redirect_uri` carrying the echoed `state`. Combining `none` with other values (such as
+  `none login`) is self-contradictory and returns 400 outright.
+- **`prompt=login`**: forces re-authentication even when a session already exists.
+- **`prompt=consent`**: forces the consent page even when existing consent already covers the requested scopes.
+- **`max_age=<seconds>`**: forces re-authentication if the session's `auth_time` (set at
+  login / MFA verification) is older than `max_age`.
 
-`auth_time` 与 `amr` 随授权码持久化，并在换票时打进 id_token：`auth_time`
-（大于 0 时）、`amr`（设置时为 JSON 数组）、`acr`（`1` = 仅密码，`2` = MFA）。
-发现文档宣告 `prompt_values_supported`、`acr_values_supported` 与相关 claims。
+`auth_time` and `amr` are persisted with the authorization code and included in the id_token
+at redemption: `auth_time` (when greater than 0), `amr` (a JSON array when set), `acr`
+(`1` = password only, `2` = MFA). The discovery document advertises
+`prompt_values_supported`, `acr_values_supported`, and related claims.
 
-## 7. RP-Initiated Logout（F-027）与会话失效（F-028）
+## 7. RP-Initiated Logout (F-027) and Session Invalidation (F-028)
 
-`/oauth2/end_session`（GET + POST）终结服务端会话。要在登出后重定向，
-客户端须提供 `post_logout_redirect_uri`，且它**必须**是该客户端已注册的
-redirect URI 之一；客户端由 `id_token_hint` 的 `aud` 声明识别。hint 的
-签名**会**被验证（RS256 + kid + iss/exp/sub 策略，issue #78），验证失败以
-400 `AUTH_INVALID_ID_TOKEN_HINT` 拒绝。没有合法 hint + 已注册 URI 时请求
-被 400 拒绝；成功时带 `state` 回显 302 重定向，未提供重定向 URI 时返回 200。
+`/oauth2/end_session` (GET + POST) terminates the server-side session. To redirect after
+logout, the client must supply a `post_logout_redirect_uri`, and it **must** be one of the
+client's registered redirect URIs; the client is identified by the `aud` claim of the
+`id_token_hint`. The hint's signature **is** verified (RS256 + kid + iss/exp/sub policy,
+issue #78); failed verification is rejected with 400 `AUTH_INVALID_ID_TOKEN_HINT`. Without
+a valid hint plus a registered URI, the request is rejected with 400; on success a 302
+redirect carries the echoed `state`, and a 200 is returned when no redirect URI is provided.
 
-`POST /oauth2/logout`（既有的 API 登出）额外调用 `session()->clear()`
-（F-028），因此服务端会话随 access token 撤销一并终结。
+`POST /oauth2/logout` (the existing API logout) additionally calls `session()->clear()`
+(F-028), so the server-side session is terminated together with access-token revocation.
 
-## 8. 认证失败限流（F-018）
+## 8. Authentication Failure Rate Limiting (F-018)
 
-token / introspect / revoke / device-code 轮询四个端点共享一个进程内
-滑动窗口限流器，按 `(client_ip, client_id)` 分桶。滚动窗口
-（默认 60s）内**失败**计数达 `max_failures`（默认 30）后，后续请求返回
-**HTTP 429**，带 `Retry-After` 头与 OAuth2 风格的
-`{error, error_description}` 响应体。只计**失败**；一次成功即清零，因此
-正常负载（以及大量连续成功请求的集成测试套件）不会被限流。
+The token / introspect / revoke / device-code polling endpoints share one in-process
+sliding-window rate limiter, bucketed by `(client_ip, client_id)`. Once **failed** attempts
+within the rolling window (default 60s) reach `max_failures` (default 30), subsequent
+requests return **HTTP 429** with a `Retry-After` header and an OAuth2-style
+`{error, error_description}` body. Only **failures** count; a single success resets the
+counter, so normal load (and integration suites making many consecutive successful requests)
+is never rate-limited.
 
-经 `custom_config.auth.rate_limit` 配置（所有 `config*.json` 都显式携带默认值）：
+Configured via `custom_config.auth.rate_limit` (all `config*.json` carry the defaults
+explicitly):
 
 ```json
 "custom_config": {
@@ -166,19 +175,21 @@ token / introspect / revoke / device-code 轮询四个端点共享一个进程�
 }
 ```
 
-两个键均可省略；`rate_limit` 对象缺失时使用内置默认（30 / 60）。限流器是
-函数局部单例（`libs/common/include/fulla/common/utils/RateLimiter.h` 的
-`RateLimiter::instance()`），四个受保护端点在同一进程内共享一份计数表。
-这是最小化的暴力破解/令牌探测防护；多实例部署需要共享存储（Redis），
-为后续工作。
+Both keys may be omitted; when the `rate_limit` object is missing, built-in defaults are used
+(30 / 60). The limiter is a function-local singleton (`RateLimiter::instance()` from
+`libs/common/include/fulla/common/utils/RateLimiter.h`); the four protected endpoints share
+one counter table within the same process. This is minimal brute-force / token-probing
+protection; multi-instance deployments require shared storage (Redis), which is future work.
 
-## 9. JWKS 密钥轮换（F-029 —— 运维待办）
+## 9. JWKS Key Rotation (F-029 — Operations To-Do)
 
-JWKS 端点（`/.well-known/jwks.json`）当前只服务**单个静态 `kid`**，在插件
-启动时由配置的 JWK 物料初始化一次（`OAuth2Plugin::initAndStart()` →
-`JwkManager::init()`）。**轮换尚未实现**：没有轮换周期、没有 kid 滚动窗口、
-没有双密钥发布。当前密钥签发的令牌在其整个生命周期内有效；轮换密钥会使
-前任密钥签发的所有存量令牌失效。
+The JWKS endpoint (`/.well-known/jwks.json`) currently serves a **single static `kid`**,
+initialized once at plugin startup from the configured JWK material
+(`OAuth2Plugin::initAndStart()` → `JwkManager::init()`). **Rotation is not implemented**:
+there is no rotation schedule, no kid rolling window, and no dual-key publication. Tokens
+signed by the current key remain valid for their entire lifetime; rotating the key would
+invalidate all outstanding tokens signed by its predecessor.
 
-生产轮换已登记为运维待办。在此之前，将密钥泄露纳入威胁模型的运维者应
-以新 JWK 物料重启服务器（并接受此前签发的全部令牌失效）。
+Production rotation is registered as an operations to-do. Until then, operators who include
+key compromise in their threat model should restart the server with new JWK material (and
+accept the invalidation of all previously issued tokens).

--- a/docs/operate/deployment-windows-docker-desktop.md
+++ b/docs/operate/deployment-windows-docker-desktop.md
@@ -1,60 +1,60 @@
-# Windows Docker Desktop 部署验证指南
+# Windows Docker Desktop Deployment Validation Guide
 
-本指南说明如何在 Windows Docker Desktop 上验证 fulla 全栈系统的部署，**除了域名和 SSL 外，其他所有功能与 Linux 生产环境完全一致**。
+This guide explains how to validate the deployment of the full fulla stack on Windows Docker Desktop. **Apart from domain and SSL, every other feature is fully identical to the Linux production environment**.
 
 ---
 
-## 为什么使用 Windows Docker Desktop 验证？
+## Why validate on Windows Docker Desktop?
 
-✓ **完全模拟生产环境**：使用相同的 Docker Compose 配置、相同的容器镜像、相同的网络拓扑  
-✓ **快速反馈循环**：本地修改代码 → 立即验证 → 确认无误后再推送到 Linux 服务器  
-✓ **节省时间**：避免每次"推送 → 服务器拉取 → 重启服务 → 发现问题"的漫长循环  
-✓ **核心功能全覆盖**：数据库迁移、API 端点、前端路由、OAuth2 流程全部可测试  
+✓ **Fully simulates the production environment**: the same Docker Compose configuration, the same container images, the same network topology  
+✓ **Fast feedback loop**: modify code locally → validate immediately → push to the Linux server only after everything checks out  
+✓ **Saves time**: avoids the long "push → server pull → restart services → discover the problem" loop every single time  
+✓ **Full coverage of core functionality**: database migrations, API endpoints, frontend routing, and OAuth2 flows are all testable  
 
-**与 Linux 生产环境的差异**：
-| 功能 | Windows Docker Desktop | Linux 生产环境 |
+**Differences from the Linux production environment**:
+| Feature | Windows Docker Desktop | Linux production |
 |------|------------------------|----------------|
-| PostgreSQL | ✓ 完全相同 | ✓ |
-| Redis | ✓ 完全相同 | ✓ |
-| 后端 API | ✓ 完全相同 | ✓ |
-| 前端 | ✓ 完全相同 | ✓ |
-| 管理后台 | ✓ 完全相同 | ✓ |
-| Nginx 反向代理 | ⚠ 简化配置（无 TLS） | ✓ |
-| 域名访问 | ✗ 使用 localhost | ✓ |
-| SSL/TLS | ✗ 不启用 | ✓ |
+| PostgreSQL | ✓ Identical | ✓ |
+| Redis | ✓ Identical | ✓ |
+| Backend API | ✓ Identical | ✓ |
+| Frontend | ✓ Identical | ✓ |
+| Admin console | ✓ Identical | ✓ |
+| Nginx reverse proxy | ⚠ Simplified configuration (no TLS) | ✓ |
+| Domain access | ✗ localhost only | ✓ |
+| SSL/TLS | ✗ Not enabled | ✓ |
 
 ---
 
-## 前置条件
+## Prerequisites
 
-### 软件要求
+### Software requirements
 
-1. **Windows 10/11 专业版或企业版**（家庭版需要 WSL2 手动配置）
-2. **Docker Desktop for Windows**（最新稳定版）
-   - 下载：https://www.docker.com/products/docker-desktop/
-   - 安装时启用 WSL2 后端（推荐）或 Hyper-V
-3. **Git**（用于克隆项目）
-   - 下载：https://git-scm.com/download/win
-4. **OpenSSL**（用于生成 JWT 密钥，可选）
-   - Windows: 下载 https://slproweb.com/products/Win32OpenSSL.html
-   - 或使用 Git Bash 自带的 OpenSSL
+1. **Windows 10/11 Pro or Enterprise** (Home edition requires manual WSL2 configuration)
+2. **Docker Desktop for Windows** (latest stable version)
+   - Download: https://www.docker.com/products/docker-desktop/
+   - Enable the WSL2 backend (recommended) or Hyper-V during installation
+3. **Git** (for cloning the project)
+   - Download: https://git-scm.com/download/win
+4. **OpenSSL** (for generating JWT keys, optional)
+   - Windows: download from https://slproweb.com/products/Win32OpenSSL.html
+   - Or use the OpenSSL bundled with Git Bash
 
-### 验证 Docker Desktop 安装
+### Verify the Docker Desktop installation
 
-打开 PowerShell 或 Windows Terminal：
+Open PowerShell or Windows Terminal:
 
 ```powershell
-# 检查 Docker 版本（要求 20.10+）
+# Check the Docker version (20.10+ required)
 docker --version
 
-# 检查 Docker Compose 版本（要求 v2+）
+# Check the Docker Compose version (v2+ required)
 docker compose version
 
-# 检查 Docker 是否正常运行
+# Check that Docker is running properly
 docker ps
 ```
 
-预期输出示例：
+Example expected output:
 ```
 Docker version 24.0.7, build afdd53b
 Docker Compose version v2.23.0
@@ -63,62 +63,62 @@ CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
 
 ---
 
-## 快速开始（5 步）
+## Quick start (5 steps)
 
-### 1. 克隆项目
+### 1. Clone the project
 
 ```powershell
-# 克隆仓库（替换为实际地址）
+# Clone the repository (replace with the actual URL)
 git clone <repo-url>
 cd fulla
 
-# 检查分支
+# Check the branch
 git branch
 ```
 
-### 2. 生成 JWT 密钥
+### 2. Generate JWT keys
 
-**方法 A：使用 Git Bash（推荐）**
+**Option A: use Git Bash (recommended)**
 
 ```bash
-# 在项目根目录执行
+# Run from the project root
 cd /path/to/repo-root
 
-# 生成 JWT 签名密钥
+# Generate the JWT signing key
 chmod +x scripts/generate-jwt-keys.sh
 ./scripts/generate-jwt-keys.sh
 
-# 验证密钥生成
+# Verify key generation
 ls -la deploy/keys/
-# 应该看到 signing.pem 和 signing.pub
+# You should see signing.pem and signing.pub
 ```
 
-**方法 B：使用 PowerShell + OpenSSL**
+**Option B: use PowerShell + OpenSSL**
 
 ```powershell
-# 安装 OpenSSL for Windows 后
+# After installing OpenSSL for Windows
 openssl genrsa -out deploy\keys\signing.pem 2048
 openssl rsa -in deploy\keys\signing.pem -pubout -out deploy\keys\signing.pub
 
-# 验证
+# Verify
 dir deploy\keys
 ```
 
-**方法 C：跳过密钥生成（仅用于测试）**
+**Option C: skip key generation (testing only)**
 
-如果只是验证部署流程，可以暂时跳过此步，后端会使用内置测试密钥（⚠ 生产环境必须生成真实密钥）。
+If you are only validating the deployment workflow, you can skip this step for now and the backend will use its built-in test keys (⚠ real keys must be generated for production).
 
-### 3. 配置环境变量
+### 3. Configure environment variables
 
 ```powershell
-# 复制环境变量模板
+# Copy the environment variable template
 Copy deploy\env\docker.env.example .env.docker
 
-# 编辑文件（使用 VS Code 或记事本）
+# Edit the file (with VS Code or Notepad)
 notepad .env.docker
 ```
 
-**编辑 `.env.docker`，设置本地测试密码**：
+**Edit `.env.docker` and set local test passwords**:
 
 ```env
 # PostgreSQL
@@ -137,73 +137,73 @@ FULLA_REDIS_HOST=fulla-redis
 FULLA_REDIS_PASSWORD=WinDockerTest2024!
 FULLA_FRONTEND_URL=http://localhost:8080
 
-# 域名（本地测试忽略）
+# Domain (ignored for local testing)
 DOMAIN=localhost
 ```
 
-> **注意**：Windows 环境变量文件使用 CRLF 换行符，Docker Compose 会自动处理。
+> **Note**: environment files on Windows use CRLF line endings; Docker Compose handles them automatically.
 
-#### 邮件服务配置（可选）
+#### Email service configuration (optional)
 
-后端邮件服务有两种模式（由 [EmailService.cc](../../libs/drogon/src/utils/EmailService.cc) 的 `getEmailService()` 决定）：
+The backend email service has two modes (decided by `getEmailService()` in [EmailService.cc](https://github.com/voidvec/fulla/blob/master/libs/drogon/src/utils/EmailService.cc)):
 
-| 模式 | 触发条件 | 行为 |
+| Mode | Trigger | Behavior |
 |------|---------|------|
-| **Console 模式**（默认） | 未设置 `FULLA_SMTP_*` | 验证邮件只输出到后端日志，不真正发送 |
-| **SMTP 模式** | 设置 `FULLA_SMTP_HOST` + `FULLA_SMTP_USER` + `FULLA_SMTP_PASSWORD` | 通过 SMTP 真正发送邮件 |
+| **Console mode** (default) | `FULLA_SMTP_*` not set | Verification emails are only written to the backend log; nothing is actually sent |
+| **SMTP mode** | `FULLA_SMTP_HOST` + `FULLA_SMTP_USER` + `FULLA_SMTP_PASSWORD` set | Emails are actually sent via SMTP |
 
-**默认 Console 模式（本地验证推荐）**：
+**Default Console mode (recommended for local validation)**:
 
-无需任何配置。点击"发送邮箱验证"后，邮件内容（含验证链接）会打到后端日志，可从中复制链接验证：
+No configuration required. After clicking "Send verification email", the email content (including the verification link) is written to the backend log; copy the link from there to verify:
 
 ```bash
 docker logs fulla-backend --tail 50 2>&1 | grep -A 5 -iE "verify|email"
 ```
 
-**启用真实 SMTP 发送（163 邮箱示例）**：
+**Enable real SMTP delivery (163 Mail example)**:
 
-在 `.env.docker` 末尾追加：
+Append the following to the end of `.env.docker`:
 
 ```env
 # Email / SMTP
 FULLA_SMTP_HOST=smtp.163.com
 FULLA_SMTP_PORT=465
 FULLA_SMTP_USER=your-email@163.com
-FULLA_SMTP_PASSWORD=your-authorization-code   # 163 授权码，非登录密码
+FULLA_SMTP_PASSWORD=your-authorization-code   # 163 authorization code, not the login password
 FULLA_SMTP_FROM_NAME=OAuth2 Platform
-FULLA_SMTP_SSL=true                            # 465 端口必须 SSL
+FULLA_SMTP_SSL=true                            # Port 465 requires SSL
 ```
 
-> **获取 163 授权码**：登录 163 邮箱网页版 → 设置 → POP3/SMTP/IMAP → 开启 SMTP 服务 → 生成授权码。
+> **Obtaining a 163 authorization code**: log in to the 163 Mail web interface → Settings → POP3/SMTP/IMAP → enable the SMTP service → generate an authorization code.
 
-修改后重启后端使配置生效：
+Restart the backend after the change for it to take effect:
 
 ```bash
 docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d fulla-backend
 
-# 验证已切换到 SMTP 模式（应看到 "Email service: SMTP (smtp.163.com:465)"）
+# Verify the switch to SMTP mode (you should see "Email service: SMTP (smtp.163.com:465)")
 docker logs fulla-backend 2>&1 | grep -i "Email service"
 ```
 
-> **注意**：邮件里的验证链接使用 `FULLA_FRONTEND_URL`（本地为 `http://localhost:8080`），从其他机器点开会失效——这是本地部署的预期限制。
+> **Note**: verification links inside emails use `FULLA_FRONTEND_URL` (`http://localhost:8080` locally), so they stop working when opened from another machine — this is an expected limitation of a local deployment.
 
-### 4. 修改 Docker Compose 配置
+### 4. Adjust the Docker Compose configuration
 
-由于本地环境不需要 HTTPS，我们创建一个简化的 Compose 文件：
+Since the local environment does not need HTTPS, we create a simplified Compose file:
 
-**选项 A：使用现有的开发配置（推荐）**
+**Option A: use the existing development configuration (recommended)**
 
 ```powershell
-# 直接使用 docker-compose.yml（已配置好本地端口）
+# Use docker-compose.yml directly (local ports already configured)
 docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d --build
 ```
 
-**选项 B：创建自定义配置**
+**Option B: create a custom configuration**
 
-如果需要更多控制，创建 `deploy/docker/docker-compose.windows.yml`：
+If you need more control, create `deploy/docker/docker-compose.windows.yml`:
 
 ```yaml
-# 基于 docker-compose.yml，移除外部认证和 TLS 相关配置
+# Based on docker-compose.yml, with external auth and TLS-related configuration removed
 services:
   fulla-backend:
     environment:
@@ -215,24 +215,24 @@ services:
       - FULLA_AUTO_MIGRATE=true
       - FULLA_FRONTEND_URL=http://localhost:8080
     volumes:
-      - ../../deploy/keys:/app/keys:ro  # JWT 密钥
+      - ../../deploy/keys:/app/keys:ro  # JWT keys
       - ../../apps/server/migrations:/app/sql/migrations:ro
       - ../../apps/server/seed:/app/sql/seed:ro
 
-  # 其他服务保持不变...
+  # Other services unchanged...
 ```
 
-### 5. 启动服务
+### 5. Start the services
 
 ```powershell
-# 启动所有服务
+# Start all services
 docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d --build
 
-# 查看启动日志
+# Watch the startup logs
 docker compose -f deploy/docker/docker-compose.yml logs -f
 ```
 
-预期输出（服务启动成功）：
+Expected output (services started successfully):
 ```
 [+] Running 8/8
  [+] Network oauth2-net          Created                 0.1s
@@ -247,15 +247,15 @@ docker compose -f deploy/docker/docker-compose.yml logs -f
 
 ---
 
-## 验证部署
+## Validating the deployment
 
-### 1. 检查容器状态
+### 1. Check container status
 
 ```powershell
 docker compose -f deploy/docker/docker-compose.yml ps
 ```
 
-预期所有容器状态为 `Up`：
+All containers are expected to be `Up`:
 
 ```
 NAME                STATUS          PORTS
@@ -267,38 +267,38 @@ fulla-prometheus   Up              0.0.0.0:9090->9090/tcp
 fulla-redis        Up              0.0.0.0:6380->6379/tcp
 ```
 
-### 2. 验证后端健康
+### 2. Verify backend health
 
 ```powershell
 curl http://localhost:5555/health
 ```
 
-预期返回：
+Expected response:
 ```json
 {"status":"healthy","timestamp":"2024-06-23T10:30:00Z"}
 ```
 
-### 3. 验证数据库迁移
+### 3. Verify database migration
 
 ```powershell
-# 进入 postgres 容器
+# Enter the postgres container
 docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "\dt"
 
-# 预期看到 OAuth2 相关表
+# Expect to see the OAuth2-related tables
 # clients, users, tokens, authorization_codes, etc.
 ```
 
-### 4. 验证前端访问
+### 4. Verify frontend access
 
-在浏览器中打开：
-- **用户前端**：http://localhost:8080
-- **管理后台**：http://localhost:8081/admin/
-- **Prometheus**：http://localhost:9090
+Open in a browser:
+- **User frontend**: http://localhost:8080
+- **Admin console**: http://localhost:8081/admin/
+- **Prometheus**: http://localhost:9090
 
-### 5. 创建管理员账号
+### 5. Create the administrator account
 
 ```Git Bash
-# 执行 seed 脚本
+# Run the seed scripts
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_user.sql
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_console_client.sql
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_vue_client.sql
@@ -306,44 +306,44 @@ docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/
 ```
 
 ```powershell
-# 执行管理员用户 seed
+# Run the admin user seed
 Get-Content apps\server\seed\dev_admin_user.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
 
-# 执行管理后台客户端 seed
+# Run the admin console client seed
 Get-Content apps\server\seed\dev_admin_console_client.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
 
-# 执行 Vue 客户端 seed
+# Run the Vue client seed
 Get-Content apps\server\seed\dev_vue_client.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
 
-# 执行 backend-svc 客户端 seed
+# Run the backend-svc client seed
 Get-Content apps\server\seed\dev_backend_client.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
 ```
 
-验证管理员账号：
+Verify the administrator account:
 
-**方法 1：使用 Git Bash（推荐）**
+**Method 1: use Git Bash (recommended)**
 ```bash
 docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT username, email FROM users WHERE username = 'admin';"
 ```
 
-**方法 2：使用 PowerShell**
+**Method 2: use PowerShell**
 ```powershell
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT username, email FROM users WHERE username = 'admin';"
 ```
 
-**预期输出**：
+**Expected output**:
 ```
  username |       email       
 ----------+-------------------
  admin    | admin@example.com
 ```
 
-**验证管理员角色**：
+**Verify the administrator role**:
 ```bash
 docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT u.username, u.email, r.name FROM users u LEFT JOIN user_roles ur ON u.id = ur.user_id LEFT JOIN roles r ON ur.role_id = r.id WHERE u.username = 'admin';"
 ```
 
-**预期输出**：
+**Expected output**:
 ```
  username |       email       | name  
 ----------+-------------------+-------
@@ -352,80 +352,80 @@ docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT u.usern
 
 ---
 
-## 执行端点测试
+## Running endpoint tests
 
-项目包含完整的端点测试套件，用于验证 OAuth2 核心功能和管理后台 API。
+The project ships a complete endpoint test suite for validating core OAuth2 functionality and the admin console API.
 
-### 推荐方式：Git Bash
+### Recommended: Git Bash
 
-**优势**：原生支持 shell 脚本、路径处理正确、与 Linux 环境一致
+**Advantages**: native shell-script support, correct path handling, and parity with the Linux environment
 
-#### 1. 执行 OAuth2 核心端点测试
+#### 1. Run the core OAuth2 endpoint tests
 
 ```bash
-# 进入项目目录
+# Enter the project directory
 cd /path/to/repo-root
 
-# 确保测试脚本有执行权限
+# Make sure the test scripts are executable
 chmod +x scripts/backend/test-oauth2-endpoints.sh
 
-# 执行测试（55个测试）
+# Run the tests (55 tests)
 ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
 ```
 
-**测试覆盖**：
-- 健康检查、JWKS 端点
-- OAuth2 登录、令牌交换、刷新令牌
-- 令牌内省、撤销
-- 用户注册、登录、个人资料
-- 密码重置、修改
-- MFA 设置、验证、禁用
-- 动态客户端注册（RFC 7591）
-- WebAuthn 认证
-- 设备授权流程
-- 外部认证（GitHub、Google、微信）
+**Test coverage**:
+- Health check, JWKS endpoint
+- OAuth2 login, token exchange, refresh token
+- Token introspection, revocation
+- User registration, login, profile
+- Password reset and change
+- MFA setup, verification, disable
+- Dynamic client registration (RFC 7591)
+- WebAuthn authentication
+- Device authorization flow
+- External authentication (GitHub, Google, WeChat)
 
-#### 2. 执行管理后台 API 测试
+#### 2. Run the admin console API tests
 
 ```bash
 chmod +x scripts/backend/test-admin-endpoints.sh
 ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
 ```
 
-**测试覆盖**：
-- 管理员登录、仪表板统计
-- 用户管理（CRUD 操作）
-- 客户端应用管理
-- Scope 管理
-- Token 管理
-- 授权用户管理
-- 角色权限管理
+**Test coverage**:
+- Admin login, dashboard statistics
+- User management (CRUD operations)
+- Client application management
+- Scope management
+- Token management
+- Authorized user management
+- Role and permission management
 
-### 备选方式：WSL2 Ubuntu
+### Alternative: WSL2 Ubuntu
 
 ```bash
-# 1. 启动 WSL2
+# 1. Start WSL2
 wsl
 
-# 2. 进入项目目录（注意路径转换）
+# 2. Enter the project directory (mind the path translation)
 cd /path/to/repo-root
 
-# 3. 执行测试
+# 3. Run the tests
 ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
 ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
 ```
 
-### PowerShell 混合方式
+### PowerShell hybrid approach
 
 ```powershell
-# 在 PowerShell 中调用 Git Bash 执行测试
+# Invoke the tests via Git Bash from PowerShell
 bash ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
 bash ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
 ```
 
-### 测试结果解读
+### Interpreting test results
 
-#### 预期输出
+#### Expected output
 
 ```bash
 ========================================
@@ -448,107 +448,107 @@ Test Results: 59/59 passed, 0 failed
 ========================================
 ```
 
-#### 失败排查
+#### Troubleshooting failures
 
-**端点测试应全部通过（当前口径：OAuth2 侧 59、Admin 侧 52）**。若出现失败，按以下已知环境依赖排查：
+**All endpoint tests are expected to pass (current tally: 59 on the OAuth2 side, 52 on the Admin side)**. If any fail, check the following known environment dependencies:
 
-1. **Test 10 失败**：`no access_token`
-   - **原因**：缺少测试客户端 `backend-svc`
-   - **解决**：执行 `dev_backend_client.sql` 创建测试客户端
+1. **Test 10 fails**: `no access_token`
+   - **Cause**: the `backend-svc` test client is missing
+   - **Fix**: run `dev_backend_client.sql` to create the test client
 
-2. **Test 20/20b 失败**：`missing field: .client_id` 或 `Expected HTTP 400, got 403`
-   - **原因**：RBAC 权限控制正确工作，动态客户端注册需要特殊配置
-   - **影响**：无（这是预期行为）
+2. **Test 20/20b fails**: `missing field: .client_id` or `Expected HTTP 400, got 403`
+   - **Cause**: RBAC access control is working correctly; dynamic client registration requires special configuration
+   - **Impact**: none (this is expected behavior)
 
-3. **连锁失败**：`skipped: no token`
-   - **原因**：前序测试撤销令牌导致后续测试无令牌可用
-   - **影响**：无（测试脚本设计如此）
+3. **Cascading failures**: `skipped: no token`
+   - **Cause**: an earlier test revoked the token, leaving later tests without one
+   - **Impact**: none (the test scripts are designed this way)
 
-#### 成功标准
+#### Success criteria
 
-**59/52 全部通过才算部署验证成功**。个别失败若出现，先核对是否为上述已知的脚本环境依赖（数据库重置、种子数据、端口占用）；不要把『部分通过』当作部署成功标准。
+**Deployment validation counts as successful only when all 59/52 tests pass**. If individual failures appear, first check whether they match the known script environment dependencies above (database reset, seed data, port conflicts); do not treat "partially passing" as the success criterion for a deployment.
 
-### 测试前准备
+### Pre-test preparation
 
-#### 1. 确保数据库种子数据
+#### 1. Make sure the database has seed data
 
 ```bash
-# 执行必需的 seed 脚本
+# Run the required seed scripts
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_user.sql
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_console_client.sql
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_vue_client.sql
 
-# 可选：创建测试客户端（提高测试通过率）
+# Optional: create the test client (improves the pass rate)
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_backend_client.sql
 ```
 
-#### 2. 验证基础服务
+#### 2. Verify the base services
 
 ```bash
-# 检查容器状态
+# Check container status
 docker ps
 
-# 检查后端健康
+# Check backend health
 curl http://localhost:5555/health
 
-# 检查数据库连接
+# Check the database connection
 docker exec fulla-postgres pg_isready -U fulla_user
 ```
 
-### 快速验证命令
+### Quick validation command
 
 ```bash
-# 一键执行所有测试
+# Run all tests in one go
 cd /path/to/repo-root && \
 chmod +x scripts/backend/*.sh && \
-echo "[+] 执行 OAuth2 核心测试..." && \
+echo "[+] Running OAuth2 core tests..." && \
 ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555 && \
 echo "" && \
-echo "[+] 执行管理后台 API 测试..." && \
+echo "[+] Running admin console API tests..." && \
 ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
 ```
 
 ---
 
-## 功能测试清单
+## Functional test checklist
 
-### 核心 OAuth2 流程
+### Core OAuth2 flows
 
-| 测试项 | 测试方法 | 预期结果 |
+| Test item | Method | Expected result |
 |--------|---------|---------|
-| 用户注册 | 前端注册页面 | 注册成功，可登录 |
-| 用户登录 | POST /oauth2/login（授权码 + PKCE 流程第一步） | 返回授权码 code |
-| 刷新令牌 | POST /oauth2/token (refresh_token grant) | 返回新的 access_token |
-| 令牌校验 | POST /oauth2/introspect | 返回 token 有效信息 |
-| 令牌撤销 | POST /oauth2/revoke | 返回 200 OK |
-| 授权码流程 | /oauth2/authorize → /callback | 完整 OAuth2 流程 |
-| 客户端管理 | Admin Console 创建/删除客户端 | 操作成功 |
+| User registration | Frontend registration page | Registration succeeds and the user can log in |
+| User login | POST /oauth2/login (first step of the authorization-code + PKCE flow) | Returns an authorization code |
+| Refresh token | POST /oauth2/token (refresh_token grant) | Returns a new access_token |
+| Token validation | POST /oauth2/introspect | Returns valid token information |
+| Token revocation | POST /oauth2/revoke | Returns 200 OK |
+| Authorization-code flow | /oauth2/authorize → /callback | Complete OAuth2 flow |
+| Client management | Create/delete clients in the Admin Console | Operations succeed |
 
-### API 端点测试
+### API endpoint tests
 
-#### 方法 1：使用现有测试脚本（推荐）
+#### Method 1: use the existing test scripts (recommended)
 
-项目包含完整的端点测试脚本，推荐使用 Git Bash 执行：
+The project includes complete endpoint test scripts; running them via Git Bash is recommended:
 
-**执行 OAuth2 核心端点测试（59 个测试）**：
+**Run the core OAuth2 endpoint tests (59 tests)**:
 ```bash
-# 1. 进入项目目录（Git Bash）
+# 1. Enter the project directory (Git Bash)
 cd /path/to/repo-root
 
-# 2. 确保测试脚本有执行权限
+# 2. Make sure the test scripts are executable
 chmod +x scripts/backend/test-oauth2-endpoints.sh
 
-# 3. 执行测试
+# 3. Run the tests
 ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
 ```
 
-**执行管理后台 API 测试（52 个测试）**：
+**Run the admin console API tests (52 tests)**:
 ```bash
 chmod +x scripts/backend/test-admin-endpoints.sh
 ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
 ```
 
-**预期输出示例**：
+**Example expected output**:
 ```bash
 ========================================
 OAuth2 Endpoints Tests (59 tests)
@@ -566,59 +566,59 @@ Test Results: 59/59 passed, 0 failed
 ========================================
 ```
 
-**成功标准**：全部通过（59/52）。个别失败先按上文「失败排查」核对环境依赖；不要把『部分通过』当作部署成功标准。
+**Success criteria**: all pass (59/52). For individual failures, first cross-check the environment dependencies per "Troubleshooting failures" above; do not treat "partially passing" as the success criterion for a deployment.
 
-#### 方法 2：使用 PowerShell 脚本测试
+#### Method 2: test with the PowerShell script
 
-`admin-console` 是 PUBLIC 客户端（PKCE 强制、无 secret、无 password grant），手工构造令牌流程较繁琐，推荐直接使用仓库自带的 PowerShell 测试脚本（内部已实现 PKCE 登录）：
+`admin-console` is a PUBLIC client (PKCE enforced, no secret, no password grant), so constructing the token flow by hand is rather tedious; using the repository's bundled PowerShell test script is recommended (it implements PKCE login internally):
 
 ```powershell
-# 执行管理后台端点测试（含 PKCE 登录 + 52 项断言）
+# Run the admin console endpoint tests (PKCE login + 52 assertions)
 .\scripts\backend\test-admin-endpoints.ps1 -BaseUrl "http://localhost:5555"
 
-# 若已从其他途径拿到 access_token，可直接手工调用受保护 API 验证：
+# If you already have an access_token from another source, call protected APIs directly to verify:
 $headers = @{ Authorization = "Bearer <access_token>" }
 Invoke-RestMethod -Uri "http://localhost:5555/api/admin/users" -Headers $headers
-# 预期：用户列表 JSON
+# Expected: user list JSON
 ```
 
-#### 方法 3：使用 WSL2 Ubuntu（推荐）
+#### Method 3: use WSL2 Ubuntu (recommended)
 
 ```bash
-# 1. 启动 WSL2
+# 1. Start WSL2
 wsl
 
-# 2. 进入项目目录
+# 2. Enter the project directory
 cd /path/to/repo-root
 
-# 3. 执行测试
+# 3. Run the tests
 ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
 ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
 ```
 
-### 前端路由测试
+### Frontend routing tests
 
-| 路径 | 预期页面 |
+| Path | Expected page |
 |------|---------|
-| http://localhost:8080/ | 用户登录页 |
-| http://localhost:8080/register | 用户注册页 |
-| http://localhost:8080/profile | 个人资料页（需登录） |
-| http://localhost:8080/callback | OAuth2 回调页 |
-| http://localhost:8081/admin/ | 管理后台（需登录） |
-| http://localhost:8081/admin/apps | 应用管理页 |
+| http://localhost:8080/ | User login page |
+| http://localhost:8080/register | User registration page |
+| http://localhost:8080/profile | Profile page (login required) |
+| http://localhost:8080/callback | OAuth2 callback page |
+| http://localhost:8081/admin/ | Admin console (login required) |
+| http://localhost:8081/admin/apps | Application management page |
 
 ---
 
-## 常见问题排查
+## Troubleshooting common issues
 
-### Docker Desktop 启动失败
+### Docker Desktop fails to start
 
-**症状**：`docker ps` 报错 "Cannot connect to the Docker daemon"
+**Symptom**: `docker ps` reports "Cannot connect to the Docker daemon"
 
-**解决**：
-1. 检查 Docker Desktop 是否正在运行（系统托盘图标）
-2. 重启 Docker Desktop
-3. 检查 Hyper-V 或 WSL2 是否启用：
+**Solution**:
+1. Check whether Docker Desktop is running (system tray icon)
+2. Restart Docker Desktop
+3. Check whether Hyper-V or WSL2 is enabled:
    ```powershell
    # WSL2
    wsl --list --verbose
@@ -627,138 +627,138 @@ cd /path/to/repo-root
    dism /Online /Get-FeatureInformation /FeatureName:Microsoft-Hyper-V
    ```
 
-### 端口冲突
+### Port conflicts
 
-**症状**：容器启动失败，日志显示 "port is already allocated"
+**Symptom**: containers fail to start and the log shows "port is already allocated"
 
-**检查占用端口的进程**：
+**Find the process holding the port**:
 ```powershell
-# 检查 8080 端口
+# Check port 8080
 netstat -ano | findstr :8080
 
-# 检查 5433 端口
+# Check port 5433
 netstat -ano | findstr :5433
 ```
 
-**解决**：
-1. 停止冲突的服务
-2. 或修改 `docker-compose.yml` 中的端口映射（如改为 `8082:80`）
+**Solution**:
+1. Stop the conflicting service
+2. Or change the port mapping in `docker-compose.yml` (e.g. to `8082:80`)
 
-### 数据库连接失败
+### Database connection failure
 
-**症状**：后端日志显示 "Connection refused" 或 "Host unreachable"
+**Symptom**: the backend log shows "Connection refused" or "Host unreachable"
 
-**排查**：
+**Diagnosis**:
 ```powershell
-# 1. 检查 postgres 容器状态
+# 1. Check the postgres container status
 docker ps | findstr fulla-postgres
 
-# 2. 检查 postgres 日志
+# 2. Check the postgres logs
 docker logs fulla-postgres
 
-# 3. 测试数据库连接
+# 3. Test the database connection
 docker exec fulla-postgres pg_isready -U fulla_user
 
-# 4. 从后端容器测试网络连通性
+# 4. Test network connectivity from the backend container
 docker exec fulla-backend curl -s http://fulla-postgres:5432 2>&1
 docker exec fulla-backend curl -s http://fulla-redis:6379 2>&1
 ```
 
-### 构建失败
+### Build failures
 
-**症状**：`docker compose build` 报错 "failed to solve"
+**Symptom**: `docker compose build` fails with "failed to solve"
 
-**解决**：
+**Solution**:
 ```powershell
-# 清理构建缓存
+# Clean the build cache
 docker builder prune -a
 
-# 重新构建
+# Rebuild
 docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker build --no-cache
 
-# 如果仍失败，检查磁盘空间
+# If it still fails, check disk space
 docker system df
 ```
 
-### Windows 路径问题
+### Windows path issues
 
-**症状**：卷挂载失败，错误 "invalid mount config"
+**Symptom**: volume mounts fail with the error "invalid mount config"
 
-**原因**：Windows 路径转换问题（`C:\` → `/c/`）
+**Cause**: Windows path-translation problems (`C:\` → `/c/`)
 
-**解决**：
-1. 使用 Git Bash 执行 Docker 命令（自动转换路径）
-2. 或使用 WSL2 执行：
+**Solution**:
+1. Run Docker commands from Git Bash (paths are translated automatically)
+2. Or run them from WSL2:
    ```powershell
    wsl docker compose -f deploy/docker/docker-compose.yml up -d
    ```
 
 ---
 
-## 与 Linux 生产部署的映射关系
+## Mapping to the Linux production deployment
 
-### 配置文件映射
+### Configuration file mapping
 
-| Windows 本地 | Linux 生产 | 说明 |
+| Windows local | Linux production | Notes |
 |-------------|-----------|------|
-| `.env.docker` | `/root/fulla/.env.docker` | 环境变量完全相同 |
-| `deploy/keys/signing.pem` | `/root/fulla/deploy/keys/signing.pem` | JWT 密钥 |
-| `docker-compose.yml` | `docker-compose.prod.yml` | 端口和 TLS 配置差异 |
+| `.env.docker` | `/root/fulla/.env.docker` | Environment variables are identical |
+| `deploy/keys/signing.pem` | `/root/fulla/deploy/keys/signing.pem` | JWT keys |
+| `docker-compose.yml` | `docker-compose.prod.yml` | Differences in ports and TLS configuration |
 
-### 部署命令映射
+### Deployment command mapping
 
-| 操作 | Windows Docker Desktop | Linux 生产 |
+| Operation | Windows Docker Desktop | Linux production |
 |------|----------------------|-----------|
-| 启动 | `docker compose --env-file .env.docker up -d` | `docker compose --env-file .env.docker -f docker-compose.prod.yml up -d` |
-| 查看日志 | `docker compose logs -f` | `docker compose -f docker-compose.prod.yml logs -f` |
-| 重建 | `docker compose up -d --build` | `docker compose -f docker-compose.prod.yml up -d --build` |
-| 停止 | `docker compose down` | `docker compose -f docker-compose.prod.yml down` |
+| Start | `docker compose --env-file .env.docker up -d` | `docker compose --env-file .env.docker -f docker-compose.prod.yml up -d` |
+| View logs | `docker compose logs -f` | `docker compose -f docker-compose.prod.yml logs -f` |
+| Rebuild | `docker compose up -d --build` | `docker compose -f docker-compose.prod.yml up -d --build` |
+| Stop | `docker compose down` | `docker compose -f docker-compose.prod.yml down` |
 
-### 访问地址映射
+### Access URL mapping
 
-| 服务 | Windows 本地 | Linux 生产 |
+| Service | Windows local | Linux production |
 |------|-------------|-----------|
-| 用户前端 | http://localhost:8080 | https://your-domain.com/ |
-| 管理后台 | http://localhost:8081 | https://your-domain.com/admin/ |
-| 后端 API | http://localhost:5555 | https://your-domain.com/api/ |
+| User frontend | http://localhost:8080 | https://your-domain.com/ |
+| Admin console | http://localhost:8081 | https://your-domain.com/admin/ |
+| Backend API | http://localhost:5555 | https://your-domain.com/api/ |
 | Prometheus | http://localhost:9090 | http://your-server:9090 |
 
 ---
 
-## 从本地验证到生产部署
+## From local validation to production deployment
 
-### 验证通过后部署到 Linux
+### Deploy to Linux after validation passes
 
-1. **确保本地验证成功**：
+1. **Make sure local validation succeeded**:
    ```powershell
-   # 运行完整测试
+   # Run the full test suite
    .\scripts\backend\test-oauth2-endpoints.ps1
    .\scripts\backend\test-admin-endpoints.ps1
    ```
 
-2. **提交代码**：
+2. **Commit the code**:
    ```powershell
    git add .
    git commit -m "feat: XXX (tested on Windows Docker Desktop)"
    git push
    ```
 
-3. **在 Linux 服务器上部署**：
+3. **Deploy on the Linux server**:
    ```bash
-   # 拉取代码
+   # Pull the code
    git pull
 
-   # 复制环境变量（只复制一次）
+   # Copy the environment variables (one-time only)
    cp deploy/env/docker.env.example .env.docker
-   # 编辑 .env.docker 设置生产密码
+   # Edit .env.docker to set production passwords
 
-   # 使用生产配置启动
+   # Start with the production configuration
    docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker up -d --build
    ```
 
-4. **配置 TLS**（Linux 唯一额外步骤）：
+4. **Configure TLS** (the only extra step on Linux):
    ```bash
-   # 使用 Let's Encrypt
+   # Use Let's Encrypt
    sudo certbot certonly --standalone -d your-domain.com
    cp /etc/letsencrypt/live/your-domain.com/fullchain.pem deploy/nginx/ssl/
    cp /etc/letsencrypt/live/your-domain.com/privkey.pem deploy/nginx/ssl/
@@ -767,70 +767,70 @@ docker system df
 
 ---
 
-## 性能对比
+## Performance comparison
 
-| 指标 | Windows Docker Desktop | Linux 生产服务器 |
+| Metric | Windows Docker Desktop | Linux production server |
 |------|----------------------|----------------|
-| 启动时间 | ~45 秒（6 个容器） | ~30 秒（相同配置） |
-| 内存占用 | ~2.5 GB | ~1.8 GB |
-| API 响应时间 | ~50ms | ~40ms |
-| 数据库查询 | ~10ms | ~8ms |
+| Startup time | ~45 s (6 containers) | ~30 s (same configuration) |
+| Memory footprint | ~2.5 GB | ~1.8 GB |
+| API response time | ~50ms | ~40ms |
+| Database query | ~10ms | ~8ms |
 
-> 差异主要来自 Windows 系统开销和 WSL2 虚拟化层，但功能完全一致。
-
----
-
-## 下一步
-
-1. **完成本地验证**：确保所有核心功能正常
-2. **记录测试结果**：在项目文档中标记"Windows Docker Desktop 已验证"
-3. **推送到 Linux**：一次性部署成功
-4. **配置监控**：设置 Prometheus + Grafana
+> The differences mainly come from Windows system overhead and the WSL2 virtualization layer, but functionality is fully identical.
 
 ---
 
-## 附录：完整端口映射
+## Next steps
+
+1. **Finish local validation**: make sure all core functionality works
+2. **Record test results**: mark "Verified on Windows Docker Desktop" in the project documentation
+3. **Push to Linux**: succeed with a one-shot deployment
+4. **Configure monitoring**: set up Prometheus + Grafana
+
+---
+
+## Appendix: complete port mapping
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    Windows 宿主机                             │
+│                       Windows host                           │
 ├─────────────────────────────────────────────────────────────┤
-│  Port 8080 ──→ fulla-frontend:80 (Vue 用户前端)              │
-│  Port 8081 ──→ fulla-admin:80 (Vue 管理后台)                 │
-│  Port 5555 ──→ fulla-backend:5555 (C++ API)                │
-│  Port 5433 ──→ fulla-postgres:5432 (PostgreSQL)            │
-│  Port 6380 ──→ fulla-redis:6379 (Redis)                    │
-│  Port 9090 ──→ fulla-prometheus:9090 (监控)                │
+│  Port 8080 ──→ fulla-frontend:80 (Vue user frontend)        │
+│  Port 8081 ──→ fulla-admin:80 (Vue admin console)           │
+│  Port 5555 ──→ fulla-backend:5555 (C++ API)                 │
+│  Port 5433 ──→ fulla-postgres:5432 (PostgreSQL)             │
+│  Port 6380 ──→ fulla-redis:6379 (Redis)                     │
+│  Port 9090 ──→ fulla-prometheus:9090 (monitoring)           │
 └─────────────────────────────────────────────────────────────┘
          │
          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                  Docker 内部网络 (oauth2-net)                 │
-│                                                               │
-│  所有容器通过内部 DNS 互相访问：                              │
-│  - fulla-backend → fulla-postgres:5432                     │
-│  - fulla-backend → fulla-redis:6379                        │
-│  - fulla-frontend → fulla-backend:5555                     │
-│  - fulla-admin → fulla-backend:5555                        │
+│             Docker internal network (oauth2-net)             │
+│                                                              │
+│  All containers reach each other via internal DNS:          │
+│  - fulla-backend → fulla-postgres:5432                       │
+│  - fulla-backend → fulla-redis:6379                          │
+│  - fulla-frontend → fulla-backend:5555                       │
+│  - fulla-admin → fulla-backend:5555                          │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## 总结
+## Summary
 
-✓ **可行**：Windows Docker Desktop 可以完全验证部署流程（除域名和 SSL）  
-✓ **推荐**：本地验证 → 推送代码 → Linux 部署，大幅减少调试时间  
-✓ **一致性**：数据库模式、API 接口、前端逻辑与生产环境 100% 一致  
+✓ **Feasible**: Windows Docker Desktop can validate the entire deployment workflow (except domain and SSL)  
+✓ **Recommended**: validate locally → push code → deploy on Linux; dramatically reduces debugging time  
+✓ **Consistency**: database schema, API surface, and frontend logic are 100% identical to production  
 
-**适用场景**：
-- ✓ 验证代码更改
-- ✓ 测试数据库迁移
-- ✓ 调试 API 端点
-- ✓ 验证前端路由
-- ✓ 测试 OAuth2 流程
+**Suitable scenarios**:
+- ✓ Verifying code changes
+- ✓ Testing database migrations
+- ✓ Debugging API endpoints
+- ✓ Verifying frontend routing
+- ✓ Testing OAuth2 flows
 
-**不适用场景**：
-- ✗ TLS/SSL 测试（使用自签名证书可部分替代）
-- ✗ 性能压测（使用 Linux 服务器）
-- ✗ 高可用配置（需要多台服务器）
+**Unsuitable scenarios**:
+- ✗ TLS/SSL testing (self-signed certificates can partially substitute)
+- ✗ Performance/load testing (use a Linux server)
+- ✗ High-availability configurations (multiple servers required)

--- a/docs/operate/deployment.md
+++ b/docs/operate/deployment.md
@@ -1,17 +1,18 @@
-# 生产化部署指南
+# Production Deployment Guide
 
-本指南说明如何将 OAuth2 全栈系统（用户前端 + 管理后台 + 后端 API）部署到生产环境。
+This guide explains how to deploy the full OAuth2 stack (user frontend + admin console + backend API) to a production environment.
 
 ---
 
-## 架构概览
+## Architecture Overview
 
 ```
                     Internet
                        │
                 ┌──────┴──────┐
                 │   Nginx     │  :80 → :443 (TLS)
-                │  (反向代理)  │
+                │   reverse   │
+                │   proxy     │
                 └──────┬──────┘
           ┌────────────┼────────────┐
           │            │            │
@@ -29,105 +30,105 @@
                    └───────────┘     └───────────────┘
 ```
 
-**路由规则（Nginx）**：
+**Routing rules (Nginx)**:
 - `/api/*`, `/oauth2/*`, `/.well-known/*`, `/health` → Backend
 - `/admin/*` → Admin Console
-- `/*` (其他) → User Frontend
+- `/*` (everything else) → User Frontend
 
 ---
 
-## 前置条件
+## Prerequisites
 
-### 硬件要求
-- **CPU**: 2 核心以上
-- **内存**: 4GB 以上（推荐 8GB）
-- **磁盘**: 20GB 以上可用空间
-- **网络**: 公网 IP，域名已解析到服务器
+### Hardware requirements
+- **CPU**: 2 cores or more
+- **Memory**: 4GB or more (8GB recommended)
+- **Disk**: 20GB or more of free space
+- **Network**: public IP, with a domain resolved to the server
 
-### 操作系统支持
+### Supported operating systems
 
 - Ubuntu 20.04 / 22.04 / 24.04 LTS
 - Debian 11 / 12
 - CentOS Stream 8 / 9
 - Rocky Linux 8 / 9
 
-### 软件依赖安装
+### Installing software dependencies
 
-#### 1. 安装 Docker
+#### 1. Install Docker
 
 **Ubuntu/Debian**:
 ```bash
-# 更新包索引
+# Update the package index
 sudo apt update
 
-# 安装必要依赖
+# Install required dependencies
 sudo apt install -y ca-certificates curl gnupg lsb-release
 
-# 添加 Docker 官方 GPG 密钥
+# Add Docker's official GPG key
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 
-# 设置 Docker 仓库
+# Set up the Docker repository
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# 安装 Docker Engine
+# Install Docker Engine
 sudo apt update
 sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-# 启动 Docker 服务
+# Start the Docker service
 sudo systemctl start docker
 sudo systemctl enable docker
 
-# 验证安装
+# Verify the installation
 docker --version
 docker compose version
 ```
 
 **CentOS/Rocky Linux**:
 ```bash
-# 安装必要依赖
+# Install required dependencies
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 
-# 添加 Docker 仓库
+# Add the Docker repository
 sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
-# 安装 Docker
+# Install Docker
 sudo yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-# 启动 Docker 服务
+# Start the Docker service
 sudo systemctl start docker
 sudo systemctl enable docker
 
-# 验证安装
+# Verify the installation
 docker --version
 docker compose version
 ```
 
-#### 2. 配置 Docker 用户组（可选但推荐）
+#### 2. Configure the Docker group (optional but recommended)
 
 ```bash
-# 创建 docker 组（如果不存在）
+# Create the docker group (if it does not exist)
 sudo groupadd docker
 
-# 将当前用户添加到 docker 组
+# Add the current user to the docker group
 sudo usermod -aG docker $USER
 
-# 重新登录或运行以下命令使组权限生效
+# Log out and back in, or run the following command for the group membership to take effect
 newgrp docker
 
-# 验证：无需 sudo 运行 docker
+# Verify: run docker without sudo
 docker ps
 ```
 
-#### 2.5. 配置 Docker 镜像加速器（中国大陆必需）
+#### 2.5. Configure Docker registry mirrors (required in mainland China)
 
-由于 Docker Hub 在中国大陆访问不稳定，拉取镜像会超时（典型错误：`dial tcp registry-1.docker.io:443: i/o timeout`），必须配置镜像加速器。
+Docker Hub is unstable to reach from mainland China and image pulls will time out (typical error: `dial tcp registry-1.docker.io:443: i/o timeout`); you must configure registry mirrors.
 
-以下加速器地址经实测（2026-06）在阿里云服务器上验证可用：
+The following mirror addresses were verified working on Alibaba Cloud servers as of 2026-06:
 
-**创建或修改 Docker 配置文件**:
+**Create or modify the Docker configuration file**:
 
 ```bash
 sudo mkdir -p /etc/docker
@@ -147,9 +148,9 @@ sudo tee /etc/docker/daemon.json > /dev/null << 'EOF'
 EOF
 ```
 
-> 说明：配置多个加速器，Docker 会按顺序尝试，任一可用即拉取成功。
+> Note: with multiple mirrors configured, Docker tries them in order; a pull succeeds as soon as any one of them works.
 
-**重启 Docker 服务使配置生效**:
+**Restart the Docker service to apply the configuration**:
 
 ```bash
 sudo systemctl daemon-reload
@@ -157,13 +158,13 @@ sudo systemctl restart docker
 sudo systemctl status docker
 ```
 
-**验证镜像加速器配置**:
+**Verify the registry mirror configuration**:
 
 ```bash
-# 检查配置是否被加载（应显示上述 registry-mirrors 列表）
+# Check that the configuration was loaded (should show the registry-mirrors list above)
 docker info | grep -A 5 "Registry Mirrors"
 
-# 测试拉取镜像（本项目需要的全部镜像）
+# Test image pulls (all images required by this project)
 docker pull postgres:17-alpine
 docker pull redis:7-alpine
 docker pull nginx:stable-alpine
@@ -171,21 +172,21 @@ docker pull prom/prometheus:latest
 docker pull ubuntu:22.04
 ```
 
-如果某个加速器报错（如 `502` 或 `i/o timeout`），Docker 会自动尝试下一个；若全部失败，参考下方故障排除。
+If a mirror reports an error (such as `502` or `i/o timeout`), Docker automatically tries the next one; if all of them fail, see the troubleshooting notes below.
 
-**故障排除**:
+**Troubleshooting**:
 
-1. **所有加速器均失败**：访问 [dongyubin/DockerHub](https://github.com/dongyubin/DockerHub) 获取最新可用列表，替换 `daemon.json` 中的地址后重启 Docker。
+1. **All mirrors failed**: visit [dongyubin/DockerHub](https://github.com/dongyubin/DockerHub) for the latest working list, replace the addresses in `daemon.json`, and restart Docker.
 
-2. **使用阿里云专属加速器**（需要阿里云账号，最稳定）:
-   - 登录 [阿里云容器镜像服务](https://cr.console.aliyun.com/) → 镜像工具 → 镜像加速器
-   - 获取专属加速地址（形如 `https://<your_code>.mirror.aliyuncs.com`）
-   - 将该地址置于 `daemon.json` 的 `registry-mirrors` 数组首位
+2. **Use a dedicated Alibaba Cloud mirror** (requires an Alibaba Cloud account; most stable):
+   - Log in to [Alibaba Cloud Container Registry](https://cr.console.aliyun.com/) → Image Tools → Image Accelerator
+   - Obtain your dedicated mirror address (of the form `https://<your_code>.mirror.aliyuncs.com`)
+   - Put that address at the head of the `registry-mirrors` array in `daemon.json`
 
-3. **使用代理拉取**（如果有可用的代理服务器）:
+3. **Pull through a proxy** (if you have a usable proxy server):
 
    ```bash
-   # 为 Docker 守护进程配置代理
+   # Configure a proxy for the Docker daemon
    sudo mkdir -p /etc/systemd/system/docker.service.d
    sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf > /dev/null << EOF
    [Service]
@@ -198,7 +199,7 @@ docker pull ubuntu:22.04
    sudo systemctl restart docker
    ```
 
-#### 3. 安装 Git
+#### 3. Install Git
 
 **Ubuntu/Debian**:
 ```bash
@@ -210,7 +211,7 @@ sudo apt install -y git
 sudo yum install -y git
 ```
 
-#### 4. 安装 OpenSSL（用于生成密钥）
+#### 4. Install OpenSSL (for key generation)
 
 **Ubuntu/Debian**:
 ```bash
@@ -222,7 +223,7 @@ sudo apt install -y openssl
 sudo yum install -y openssl
 ```
 
-#### 5. 安装 Certbot（用于获取 Let's Encrypt 证书）
+#### 5. Install Certbot (for obtaining Let's Encrypt certificates)
 
 **Ubuntu/Debian**:
 ```bash
@@ -234,39 +235,39 @@ sudo apt install -y certbot
 sudo yum install -y certbot
 ```
 
-### 验证依赖安装
+### Verify the dependency installation
 
 ```bash
-# 检查 Docker 版本（要求 24+）
+# Check the Docker version (24+ required)
 docker --version
 
-# 检查 Docker Compose 版本（要求 v2）
+# Check the Docker Compose version (v2 required)
 docker compose version
 
-# 检查 Git
+# Check Git
 git --version
 
-# 检查 OpenSSL
+# Check OpenSSL
 openssl version
 
-# 检查 Certbot
+# Check Certbot
 certbot --version
 ```
 
-### 域名和 DNS 配置
+### Domain and DNS configuration
 
-1. **域名解析**：确保您的域名（如 `your-domain.example.com`）的 A 记录指向服务器公网 IP
-2. **DNS 传播验证**：
+1. **Domain resolution**: make sure the A record of your domain (e.g. `your-domain.example.com`) points to the server's public IP
+2. **Verify DNS propagation**:
    ```bash
-   # 检查域名是否正确解析
+   # Check that the domain resolves correctly
    dig +short your-domain.example.com
    nslookup your-domain.example.com
    ```
-3. **防火墙配置**：确保以下端口可访问：
+3. **Firewall configuration**: make sure the following ports are reachable:
    - `80/tcp` (HTTP)
    - `443/tcp` (HTTPS)
 
-### 防火墙配置
+### Firewall configuration
 
 **Ubuntu (UFW)**:
 ```bash
@@ -284,97 +285,97 @@ sudo firewall-cmd --reload
 
 ---
 
-## 快速部署（5 步）
+## Quick deployment (5 steps)
 
-### 1. 克隆项目
+### 1. Clone the project
 
 ```bash
 git clone <repo-url>
 cd fulla
 ```
 
-### 2. 生成密钥
+### 2. Generate keys
 
 ```bash
-# 生成 JWT 签名密钥
+# Generate the JWT signing key
 chmod +x scripts/generate-jwt-keys.sh
 ./scripts/generate-jwt-keys.sh
 
-# 生成 TLS 证书（开发用自签名，生产用 Let's Encrypt）
+# Generate TLS certificates (self-signed for development; Let's Encrypt for production)
 chmod +x scripts/generate-certs.sh
 ./scripts/generate-certs.sh
 ```
 
-**生产环境使用 Let's Encrypt**：
+**Using Let's Encrypt in production**:
 ```bash
-# 安装 certbot
+# Install certbot
 sudo apt install certbot
 
-# 创建 SSL 证书目录
+# Create the SSL certificate directory
 mkdir -p deploy/nginx/ssl/
 
-# 获取证书（先停止 nginx）
+# Obtain the certificate (stop nginx first)
 sudo certbot certonly --standalone -d your-domain.com
 
-# 复制证书
+# Copy the certificates
 cp /etc/letsencrypt/live/your-domain.com/fullchain.pem deploy/nginx/ssl/
 cp /etc/letsencrypt/live/your-domain.com/privkey.pem deploy/nginx/ssl/
 ```
 
-### 3. 配置环境变量
+### 3. Configure environment variables
 
 ```bash
-# 检查模板文件是否存在
-[ -f deploy/env/docker.env.example ] && echo "模板文件存在" || echo "错误：模板文件不存在"
+# Check that the template file exists
+[ -f deploy/env/docker.env.example ] && echo "Template file exists" || echo "Error: template file missing"
 
 cp deploy/env/docker.env.example .env.docker
 ```
 
-编辑 `.env.docker`，设置强密码与 HTTPS 域名相关配置：
+Edit `.env.docker` to set strong passwords and the HTTPS-domain-related configuration:
 
 ```env
-# 运行模式（生产强制校验 HTTPS issuer / 强密码；须配合 FULLA_ISSUER=https://）
+# Run mode (production enforces HTTPS issuer / strong passwords; must be paired with FULLA_ISSUER=https://)
 FULLA_ENV=production
 FULLA_ISSUER=https://your-domain.com
 
-# JWT 签名密钥（生产必填；不设则每次重启 token 失效）
+# JWT signing key (required in production; without it tokens are invalidated on every restart)
 FULLA_JWT_KEY_PATH=/app/keys/signing.pem
 
 POSTGRES_USER=fulla_user
-POSTGRES_PASSWORD=<生成强密码>
+POSTGRES_PASSWORD=<generate a strong password>
 POSTGRES_DB=fulla_db
 
-REDIS_PASSWORD=<生成强密码>
+REDIS_PASSWORD=<generate a strong password>
 
 FULLA_DB_HOST=fulla-postgres
 FULLA_DB_PORT=5432
 FULLA_DB_NAME=fulla_db
 FULLA_DB_USER=fulla_user
-FULLA_DB_PASSWORD=<与 POSTGRES_PASSWORD 相同>
+FULLA_DB_PASSWORD=<same as POSTGRES_PASSWORD>
 FULLA_REDIS_HOST=fulla-redis
 FULLA_REDIS_PORT=6379
-FULLA_REDIS_PASSWORD=<与 REDIS_PASSWORD 相同>
+FULLA_REDIS_PASSWORD=<same as REDIS_PASSWORD>
 
-# CORS / OAuth 回调（HTTPS 域名必填，否则浏览器请求被拦截）
+# CORS / OAuth callbacks (HTTPS domain required, otherwise browser requests are blocked)
 FULLA_FRONTEND_URL=https://your-domain.com
 FULLA_CORS_ALLOW_ORIGINS=https://your-domain.com
 FULLA_VUE_REDIRECT_URI=https://your-domain.com/callback
-FULLA_VUE_CLIENT_SECRET=<生成强密码>
+FULLA_VUE_CLIENT_SECRET=<generate a strong password>
 FULLA_GOOGLE_REDIRECT_URI=https://your-domain.com/callback
 
-# 错误详细度（生产建议 false，不暴露字段级校验错误）
+# Error verbosity (false recommended in production; do not expose field-level validation errors)
 DETAILED_VALIDATION_ERRORS=false
 
-# 邮件服务（SMTP）— 生产环境必须配置
+# Email service (SMTP) — must be configured in production
 FULLA_SMTP_HOST=smtp.example.com
 FULLA_SMTP_PORT=465
 FULLA_SMTP_USER=noreply@example.com
-FULLA_SMTP_PASSWORD=<SMTP 授权码，非邮箱登录密码>
+FULLA_SMTP_PASSWORD=<SMTP authorization code, not the mailbox login password>
 FULLA_SMTP_FROM_NAME=OAuth2 Platform
 FULLA_SMTP_SSL=true
 
-# 前端构建变量（Vite 构建期注入）
-# VITE_API_BASE_URL 生产必须留空 → SPA 走相对路径（nginx 同源反代）
+# Frontend build variables (injected at Vite build time)
+# VITE_API_BASE_URL must be left empty in production → the SPA uses relative paths (same-origin reverse proxying via nginx)
 VITE_API_BASE_URL=
 VITE_CLIENT_ID=vue-client
 VITE_REDIRECT_URI=https://your-domain.com/callback
@@ -383,198 +384,198 @@ VITE_GITHUB_CLIENT_ID=
 DOMAIN=your-domain.com
 ```
 
-> **重要耦合**：`FULLA_ENV=production` 与 `FULLA_ISSUER=https://...` 必须同时设置。仅设 production 而不配 HTTPS issuer 会导致后端启动校验失败（`ConfigManager` 的 prod-mode 校验拒绝非 https issuer）。同理 DB/Redis 密码不能是默认的 `123456` / `password`，否则 prod 校验也会拒绝启动。
+> **Critical coupling**: `FULLA_ENV=production` and `FULLA_ISSUER=https://...` must be set together. Setting production without an HTTPS issuer makes backend startup validation fail (the prod-mode check in `ConfigManager` rejects non-https issuers). Likewise, the DB/Redis passwords must not be the defaults `123456` / `password`, or the prod validation will also refuse to start.
 
-生成强密码：
+Generate strong passwords:
 ```bash
 openssl rand -base64 32
 ```
 
-#### 邮件服务（SMTP）配置说明
+#### Email service (SMTP) configuration notes
 
-后端邮件服务有两种模式（由 `getEmailService()` 根据环境变量自动选择）：
+The backend email service has two modes (chosen automatically by `getEmailService()` based on environment variables):
 
-| 模式 | 触发条件 | 行为 |
+| Mode | Trigger | Behavior |
 |------|---------|------|
-| **Console 模式** | 未设置 `FULLA_SMTP_HOST` / `USER` / `PASSWORD` | 邮件内容只输出到后端日志，**不真正发送** |
-| **SMTP 模式** | 上述三个变量均已设置且非空 | 通过 SMTP 真正发送邮件 |
+| **Console mode** | `FULLA_SMTP_HOST` / `USER` / `PASSWORD` not set | Email content is only written to the backend log; **nothing is actually sent** |
+| **SMTP mode** | All three variables above are set and non-empty | Emails are actually sent via SMTP |
 
-> **生产环境必须配置 SMTP**，否则邮箱验证、密码重置等功能的邮件不会真正发送给用户（只在服务器日志里）。
+> **SMTP must be configured in production**, otherwise emails for features such as email verification and password reset are never actually delivered to users (they only land in the server logs).
 
-**常见邮箱服务商配置参考**：
+**Common email provider configuration reference**:
 
-| 服务商 | SMTP 主机 | 端口 | SSL | 凭据说明 |
+| Provider | SMTP host | Port | SSL | Credential notes |
 |--------|----------|------|-----|---------|
-| 163 邮箱 | `smtp.163.com` | 465 | true | 授权码（非登录密码） |
-| QQ 邮箱 | `smtp.qq.com` | 465 | true | 授权码 |
-| Gmail | `smtp.gmail.com` | 465 | true | 应用专用密码（需开两步验证） |
-| 腾讯企业邮 | `smtp.exmail.qq.com` | 465 | true | 邮箱密码 |
-| 阿里云企业邮 | `smtp.qiye.aliyun.com` | 465 | true | 邮箱密码 |
-| SendGrid | `smtp.sendgrid.net` | 587 | false | 用户名 `apikey`，密码为 API Key |
+| 163 Mail | `smtp.163.com` | 465 | true | Authorization code (not the login password) |
+| QQ Mail | `smtp.qq.com` | 465 | true | Authorization code |
+| Gmail | `smtp.gmail.com` | 465 | true | App password (2FA must be enabled) |
+| Tencent Exmail | `smtp.exmail.qq.com` | 465 | true | Mailbox password |
+| Alibaba Cloud enterprise mail | `smtp.qiye.aliyun.com` | 465 | true | Mailbox password |
+| SendGrid | `smtp.sendgrid.net` | 587 | false | Username `apikey`, password is the API key |
 
-**获取授权码（以 163 为例）**：
-1. 登录 163 邮箱网页版
-2. 设置 → POP3/SMTP/IMAP
-3. 开启 SMTP 服务
-4. 按提示生成授权码（16 位字符串）
+**Obtaining an authorization code (163 example)**:
+1. Log in to the 163 Mail web interface
+2. Settings → POP3/SMTP/IMAP
+3. Enable the SMTP service
+4. Follow the prompts to generate an authorization code (a 16-character string)
 
-配置完成后重启后端生效：
+Restart the backend after configuring for the change to take effect:
 
 ```bash
 docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker up -d fulla-backend
 
-# 验证已切换到 SMTP 模式（应输出 "Email service: SMTP (...)"）
+# Verify the switch to SMTP mode (should print "Email service: SMTP (...)")
 docker compose -f deploy/docker/docker-compose.prod.yml logs fulla-backend | grep "Email service"
 ```
 
-### 4. 启动服务
+### 4. Start the services
 
 ```bash
 docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker up -d
 ```
 
-### 5. 验证部署
+### 5. Verify the deployment
 
 ```bash
-# 检查所有容器状态
+# Check the status of all containers
 docker compose -f deploy/docker/docker-compose.prod.yml ps
 
-# 检查后端健康
+# Check backend health
 curl -k https://localhost/health
 
-# 检查前端
+# Check the frontend
 curl -k https://localhost/
 
-# 检查管理后台
+# Check the admin console
 curl -k https://localhost/admin/
 ```
 
 ---
 
-## 服务详情
+## Service details
 
-### 用户前端 (OAuth2Frontend)
+### User frontend (OAuth2Frontend)
 
-| 项目 | 值 |
+| Item | Value |
 |------|-----|
-| 容器名 | fulla-frontend |
-| 构建 | Dockerfile (target: frontend-runtime) |
-| 基础镜像 | nginx:stable-alpine |
-| 内部端口 | 80 |
-| 访问路径 | `https://your-domain.com/` |
-| 功能 | 登录、注册、个人资料、安全设置、OAuth2 授权 |
+| Container name | fulla-frontend |
+| Build | Dockerfile (target: frontend-runtime) |
+| Base image | nginx:stable-alpine |
+| Internal port | 80 |
+| Access path | `https://your-domain.com/` |
+| Features | Login, registration, profile, security settings, OAuth2 authorization |
 
-### 管理后台 (OAuth2Admin)
+### Admin console (OAuth2Admin)
 
-| 项目 | 值 |
+| Item | Value |
 |------|-----|
-| 容器名 | fulla-admin |
-| 构建 | frontends/admin/Dockerfile |
-| 基础镜像 | nginx:alpine |
-| 内部端口 | 80 |
-| 访问路径 | `https://your-domain.com/admin/` |
-| 功能 | 应用管理、用户管理、角色/Scope/Token 管理 |
+| Container name | fulla-admin |
+| Build | frontends/admin/Dockerfile |
+| Base image | nginx:alpine |
+| Internal port | 80 |
+| Access path | `https://your-domain.com/admin/` |
+| Features | Application management, user management, role/scope/token management |
 
-### 后端 API (fulla-server)
+### Backend API (fulla-server)
 
-| 项目 | 值 |
+| Item | Value |
 |------|-----|
-| 容器名 | fulla-backend |
-| 构建 | Dockerfile (target: backend-runtime) |
-| 基础镜像 | ubuntu:22.04 (minimal) |
-| 内部端口 | 5555 |
-| 访问路径 | `https://your-domain.com/api/*`, `/oauth2/*` |
-| 数据库迁移 | 启动时自动执行（FULLA_AUTO_MIGRATE=true） |
+| Container name | fulla-backend |
+| Build | Dockerfile (target: backend-runtime) |
+| Base image | ubuntu:22.04 (minimal) |
+| Internal port | 5555 |
+| Access path | `https://your-domain.com/api/*`, `/oauth2/*` |
+| Database migration | Executed automatically at startup (FULLA_AUTO_MIGRATE=true) |
 
-### 基础设施
+### Infrastructure
 
-| 服务 | 镜像 | 用途 |
+| Service | Image | Purpose |
 |------|------|------|
-| fulla-postgres | postgres:17-alpine | 主数据库 |
-| fulla-redis | redis:7-alpine | Token 缓存 |
-| oauth2-nginx | nginx:stable-alpine | TLS 终止 + 反向代理 |
-| fulla-prometheus | prom/prometheus | 监控指标采集 |
+| fulla-postgres | postgres:17-alpine | Primary database |
+| fulla-redis | redis:7-alpine | Token cache |
+| oauth2-nginx | nginx:stable-alpine | TLS termination + reverse proxy |
+| fulla-prometheus | prom/prometheus | Monitoring metrics collection |
 
 ---
 
-## 配置说明
+## Configuration reference
 
-### 后端配置 (config.prod.json)
+### Backend configuration (config.prod.json)
 
-后端通过环境变量覆盖配置文件中的值（优先级：`.env` 文件 > 系统环境变量 > `config.prod.json` 默认值）：
+The backend overrides configuration-file values with environment variables (precedence: `.env` file > system environment variables > `config.prod.json` defaults):
 
-| 环境变量 | 用途 | 默认值 |
+| Environment variable | Purpose | Default |
 |----------|------|--------|
-| `FULLA_ENV` | 运行模式（`production` 启用 HTTPS issuer + 强密码严格校验） | development |
-| `FULLA_ISSUER` | JWT issuer（生产必须 `https://`） | http://localhost:5555 |
-| `FULLA_JWT_KEY_PATH` | JWT 签名密钥文件路径 | /app/keys/signing.pem |
-| `FULLA_SIGNING_KEY` | JWT 密钥 PEM 内容（与 `JWT_KEY_PATH` 二选一） | (可选) |
-| `FULLA_DB_HOST` | PostgreSQL 主机 | postgres |
-| `FULLA_DB_PORT` | PostgreSQL 端口 | 5432 |
-| `FULLA_DB_NAME` | 数据库名 | fulla_db_prod |
-| `FULLA_DB_USER` | 数据库用户 | fulla_user |
-| `FULLA_DB_PASSWORD` | 数据库密码 | (必须设置) |
-| `FULLA_REDIS_HOST` | Redis 主机 | redis |
-| `FULLA_REDIS_PORT` | Redis 端口 | 6379 |
-| `FULLA_REDIS_PASSWORD` | Redis 密码 | (必须设置) |
-| `FULLA_LISTEN_PORT` | 后端监听端口 | 5555 |
-| `FULLA_FRONTEND_URL` | 前端 URL（用于重定向等） | http://localhost:5173 |
-| `FULLA_CORS_ALLOW_ORIGINS` | CORS 允许的源（逗号分隔，覆盖 JSON 数组） | config 中的 localhost 列表 |
-| `FULLA_VUE_REDIRECT_URI` | vue-client OAuth 回调 URI | config 中的 localhost 值 |
-| `FULLA_GOOGLE_REDIRECT_URI` | Google OAuth 回调 URI | config 中的 localhost 值 |
-| `FULLA_VUE_CLIENT_SECRET` | vue-client 密钥 | 123456 |
-| `FULLA_AUTO_MIGRATE` | 自动执行数据库迁移 | true |
-| `DETAILED_VALIDATION_ERRORS` | 是否返回字段级校验错误（生产建议 false） | false |
-| `FULLA_GITHUB_CLIENT_ID` / `FULLA_GITHUB_CLIENT_SECRET` | GitHub OAuth（可选） | (空) |
-| `FULLA_GOOGLE_CLIENT_ID` / `FULLA_GOOGLE_CLIENT_SECRET` | Google OAuth（可选） | (空) |
-| `FULLA_SMTP_HOST` | SMTP 服务器主机（未设置则邮件走 Console 模式） | (可选) |
-| `FULLA_SMTP_PORT` | SMTP 端口 | 465 |
-| `FULLA_SMTP_USER` | SMTP 用户名（完整邮箱地址） | (可选) |
-| `FULLA_SMTP_PASSWORD` | SMTP 授权码（非邮箱登录密码） | (可选) |
-| `FULLA_SMTP_FROM_NAME` | 发件人显示名称 | OAuth2 Platform |
-| `FULLA_SMTP_SSL` | 是否启用 SSL | true |
+| `FULLA_ENV` | Run mode (`production` enables strict HTTPS issuer + strong-password validation) | development |
+| `FULLA_ISSUER` | JWT issuer (must be `https://` in production) | http://localhost:5555 |
+| `FULLA_JWT_KEY_PATH` | Path to the JWT signing key file | /app/keys/signing.pem |
+| `FULLA_SIGNING_KEY` | JWT key PEM content (either this or `JWT_KEY_PATH`) | (optional) |
+| `FULLA_DB_HOST` | PostgreSQL host | postgres |
+| `FULLA_DB_PORT` | PostgreSQL port | 5432 |
+| `FULLA_DB_NAME` | Database name | fulla_db_prod |
+| `FULLA_DB_USER` | Database user | fulla_user |
+| `FULLA_DB_PASSWORD` | Database password | (must be set) |
+| `FULLA_REDIS_HOST` | Redis host | redis |
+| `FULLA_REDIS_PORT` | Redis port | 6379 |
+| `FULLA_REDIS_PASSWORD` | Redis password | (must be set) |
+| `FULLA_LISTEN_PORT` | Backend listen port | 5555 |
+| `FULLA_FRONTEND_URL` | Frontend URL (used for redirects etc.) | http://localhost:5173 |
+| `FULLA_CORS_ALLOW_ORIGINS` | CORS allowed origins (comma-separated; overrides the JSON array) | localhost list from config |
+| `FULLA_VUE_REDIRECT_URI` | vue-client OAuth callback URI | localhost value from config |
+| `FULLA_GOOGLE_REDIRECT_URI` | Google OAuth callback URI | localhost value from config |
+| `FULLA_VUE_CLIENT_SECRET` | vue-client secret | 123456 |
+| `FULLA_AUTO_MIGRATE` | Run database migrations automatically | true |
+| `DETAILED_VALIDATION_ERRORS` | Whether to return field-level validation errors (false recommended in production) | false |
+| `FULLA_GITHUB_CLIENT_ID` / `FULLA_GITHUB_CLIENT_SECRET` | GitHub OAuth (optional) | (empty) |
+| `FULLA_GOOGLE_CLIENT_ID` / `FULLA_GOOGLE_CLIENT_SECRET` | Google OAuth (optional) | (empty) |
+| `FULLA_SMTP_HOST` | SMTP server host (unset means email stays in Console mode) | (optional) |
+| `FULLA_SMTP_PORT` | SMTP port | 465 |
+| `FULLA_SMTP_USER` | SMTP username (full email address) | (optional) |
+| `FULLA_SMTP_PASSWORD` | SMTP authorization code (not the mailbox login password) | (optional) |
+| `FULLA_SMTP_FROM_NAME` | Sender display name | OAuth2 Platform |
+| `FULLA_SMTP_SSL` | Whether to enable SSL | true |
 
-> **邮件模式说明**：仅当 `FULLA_SMTP_HOST` + `FULLA_SMTP_USER` + `FULLA_SMTP_PASSWORD` 三项均非空时启用真实 SMTP 发送；否则邮件只输出到后端日志。详见上文"邮件服务（SMTP）配置说明"。
+> **Email mode note**: real SMTP sending is enabled only when all three of `FULLA_SMTP_HOST` + `FULLA_SMTP_USER` + `FULLA_SMTP_PASSWORD` are non-empty; otherwise email is only written to the backend log. See "Email service (SMTP) configuration notes" above.
 >
-> **CORS 数组覆盖**：`FULLA_CORS_ALLOW_ORIGINS` 是逗号分隔的字符串（如 `https://a.com,https://b.com`），后端启动时自动分割成 JSON 数组覆盖 `config.prod.json` 的 `custom_config.cors.allow_origins`。CORS 校验代码要求该字段是数组，因此**必须**用逗号分隔形式，不要写成 JSON 数组字面量。
+> **CORS array override**: `FULLA_CORS_ALLOW_ORIGINS` is a comma-separated string (e.g. `https://a.com,https://b.com`) that the backend splits into a JSON array at startup to override `custom_config.cors.allow_origins` from `config.prod.json`. The CORS validation code requires this field to be an array, so you **must** use the comma-separated form — never write it as a JSON array literal.
 
-### Nginx 配置
+### Nginx configuration
 
-`deploy/nginx/nginx.conf` 包含：
-- HTTP → HTTPS 自动重定向
-- TLS 1.2/1.3 配置
-- 限流规则（登录 5次/分钟/IP，API 30次/秒/IP）
-- `/metrics` 端点限制内网访问
-- HSTS 头
+`deploy/nginx/nginx.conf` includes:
+- Automatic HTTP → HTTPS redirection
+- TLS 1.2/1.3 configuration
+- Rate limiting rules (login: 5 requests/min/IP; API: 30 requests/s/IP)
+- `/metrics` endpoint restricted to internal-network access
+- HSTS headers
 
-### 前端配置
+### Frontend configuration
 
-前端（用户端 OAuth2Frontend）通过 Vite 环境变量配置，**在镜像构建时注入**到 SPA bundle（不是运行时读取）。`docker-compose.prod.yml` 的 `fulla-frontend.build.args` 从 `.env.docker` 透传这些变量，`Dockerfile` 的 `frontend-builder` 阶段用 `ARG`/`ENV` 暴露给 Vite。
+The frontend (the user-facing OAuth2Frontend) is configured through Vite environment variables that are **injected at image build time** into the SPA bundle (they are not read at runtime). `fulla-frontend.build.args` in `docker-compose.prod.yml` passes these variables through from `.env.docker`, and the `frontend-builder` stage of the `Dockerfile` exposes them to Vite via `ARG`/`ENV`.
 
-| 变量 | 用途 | 生产值 |
+| Variable | Purpose | Production value |
 |------|------|--------|
-| `VITE_API_BASE_URL` | API 基础 URL | **(空)** — SPA 同域走相对路径，填值会破坏 nginx 反代路由 |
+| `VITE_API_BASE_URL` | API base URL | **(empty)** — the SPA uses same-origin relative paths; setting a value breaks the nginx reverse-proxy routing |
 | `VITE_CLIENT_ID` | OAuth2 Client ID | vue-client |
-| `VITE_REDIRECT_URI` | OAuth2 回调 URI | https://your-domain.com/callback |
-| `VITE_GITHUB_CLIENT_ID` | GitHub "Sign in with GitHub" 按钮（可选） | (空则不显示按钮) |
+| `VITE_REDIRECT_URI` | OAuth2 callback URI | https://your-domain.com/callback |
+| `VITE_GITHUB_CLIENT_ID` | GitHub "Sign in with GitHub" button (optional) | (button hidden when empty) |
 
-> **管理后台（OAuth2Admin）无需配置**：源码不读取任何 `import.meta.env`，所有 API 调用走相对路径 `/api/admin/*`，由 nginx 反代到后端。改域名时只需保证 nginx `/admin/` 路由正确，无需重建 admin 镜像。
+> **The admin console (OAuth2Admin) needs no configuration**: its source code reads no `import.meta.env` at all; every API call uses the relative path `/api/admin/*`, which nginx reverse-proxies to the backend. When changing domains you only need to keep the nginx `/admin/` route correct — no admin image rebuild required.
 >
-> **改域名需重建前端镜像**：由于 VITE 变量在构建期固化，更换域名后必须 `docker compose ... up -d --build fulla-frontend`（管理后台不受影响）。
+> **Changing the domain requires rebuilding the frontend image**: because VITE variables are baked in at build time, after switching domains you must run `docker compose ... up -d --build fulla-frontend` (the admin console is unaffected).
 
 ---
 
-## 数据库初始化
+## Database initialization
 
-首次部署时，后端会自动执行数据库迁移（`FULLA_AUTO_MIGRATE=true`）。
+On first deployment the backend runs database migrations automatically (`FULLA_AUTO_MIGRATE=true`).
 
-如需手动初始化：
+To initialize manually:
 
 ```bash
-# 进入 postgres 容器
+# Enter the postgres container
 docker exec -it fulla-postgres psql -U fulla_user -d fulla_db
 
-# 或从宿主机执行迁移
+# Or run the migrations from the host
 docker exec -it fulla-postgres sh -c '
   for f in /docker-entrypoint-initdb.d/migrations/V*.sql; do
     psql -U fulla_user -d fulla_db -f "$f"
@@ -582,35 +583,31 @@ docker exec -it fulla-postgres sh -c '
 '
 ```
 
-### 创建管理员账号
+### Create the administrator account
 
-首次部署后，执行 seed 脚本创建默认管理员：
+After the first deployment, run the seed scripts to create the default administrator:
 
 ```bash
-# 验证 seed 文件存在
-ls apps/server/seed/dev_*.sql || echo "错误：Seed 文件缺失，请检查项目结构"
+# Verify the seed files exist
+ls apps/server/seed/dev_*.sql || echo "Error: seed files missing, check the project structure"
 
-# 创建管理员账号
+# Create the administrator account
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_user.sql
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_console_client.sql
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_vue_client.sql
 ```
 
-**重要**：生产环境部署后立即修改 admin 密码！
+**Important**: change the admin password immediately after deploying to production!
 
 ---
 
-## 性能调优（推荐配置）
+## Performance tuning (recommended configuration)
 
-> 本节是官方推荐的生产性能基线（分析依据为维护者基准档案，关键结论与实测
-> 数据已直接收录本节）。
-> 基准测试以本节配置为准——写进本节的配置即"官方配置"。
+> This section is the officially recommended production performance baseline (the analysis draws on the maintainers' benchmark archives; key conclusions and measured data are incorporated directly in this section). Benchmarks treat the configuration in this section as authoritative — whatever is written here is the "official configuration".
 
-### 1. 开启 Redis L2 缓存（吞吐档推荐，须配套扩容 Redis 连接池）
+### 1. Enable the Redis L2 cache (recommended for the throughput tier; requires enlarging the Redis connection pool accordingly)
 
-读路径（introspect / userinfo 的 token 查询、client 查询）命中 Redis，不再落到
-PostgreSQL。`config.prod.json` 出厂保持关闭（`cache.enabled: false`）——开启前
-**必须**同步扩容 `redis_clients[0].number_of_connections`（见下方实测数据）：
+On the read path (token and client lookups for introspect / userinfo), requests hit Redis instead of falling through to PostgreSQL. `config.prod.json` ships with the cache disabled (`cache.enabled: false`) — before enabling it you **must** also enlarge `redis_clients[0].number_of_connections` (see the measured data below):
 
 ```json
 "cache": {
@@ -623,24 +620,13 @@ PostgreSQL。`config.prod.json` 出厂保持关闭（`cache.enabled: false`）�
 }
 ```
 
-语义说明：token 缓存 TTL 不超过 60s 且吊销即时失效（含负缓存）；client
-缓存 TTL 300s。要求部署内 Redis 可用（生产 compose 已含 fulla-redis）。
-多实例部署注意：写路径失效的 Redis DEL 对全实例即时生效，但 userinfo 的
-进程内 piggyback memo（2s 一次性）只在处理写请求的那台实例被同步清除，
-其它实例最长滞后 2s（TTL 自兜底，可接受）。
+Semantics: the token cache TTL never exceeds 60s and revocations take effect immediately (negative cache included); the client cache TTL is 300s. It requires Redis to be available inside the deployment (the production compose already includes fulla-redis). Note for multi-instance deployments: the Redis DEL issued by write-path invalidation takes effect immediately across all instances, but the in-process piggyback memo for userinfo (a 2s one-shot) is only synchronously cleared on the instance that handled the write request; other instances lag by at most 2s (the TTL self-heals, which is acceptable).
 
-**实测（2026-08-18 基准环境，10s 快测）**：cache on + Redis 池 20 时 S6 反而
--18%（池排队）；Redis 池扩到 64 后 S2 +39%、S3 +59%、S6 +6%。结论：**cache
-收益以 Redis 池 ≥ 预期并发为前提**，出厂默认关闭 + 本节指引是安全姿势。
-另注意：introspect 的正向缓存受 N2 判别器约束（仅在 token 走过发放/校验
-路径后才回填），S3 的收益主要来自 client 缓存与 PG 调优。
+**Measured (2026-08-18 benchmark environment, 10s quick test)**: with the cache on and a Redis pool of 20, S6 actually regressed by -18% (pool queuing); after enlarging the Redis pool to 64, S2 +39%, S3 +59%, S6 +6%. Conclusion: **cache gains presuppose a Redis pool ≥ the expected concurrency**; the factory default of disabled plus the guidance in this section is the safe posture. Also note: the introspect positive cache is constrained by the N2 discriminator (it is only backfilled after a token has gone through the issuance/validation path), so the S3 gains come mainly from the client cache and the PG tuning.
 
-### 2. PostgreSQL 实例调优
+### 2. PostgreSQL instance tuning
 
-出厂默认（`shared_buffers=128MB`、`checkpoint_timeout=5min`、
-`max_wal_size=1GB`）面向小内存机器，在高频写入下产生周期性 checkpoint
-刷盘尖峰。为 16GB / 8 vCPU 主机推荐的调优（按内存等比缩放
-`shared_buffers` ≈ 25% RAM）：
+The factory defaults (`shared_buffers=128MB`, `checkpoint_timeout=5min`, `max_wal_size=1GB`) target small-memory machines and produce periodic checkpoint flush spikes under high write rates. Recommended tuning for a 16GB / 8 vCPU host (scale `shared_buffers` proportionally with memory, ≈ 25% of RAM):
 
 ```yaml
   fulla-postgres:
@@ -668,168 +654,123 @@ PostgreSQL。`config.prod.json` 出厂保持关闭（`cache.enabled: false`）�
       - autovacuum_vacuum_scale_factor=0.02
 ```
 
-该配置为基准环境实测采用的形态，完整可运行示例见
-`benchmarks/fulla/docker-compose.bench.yml`（bench overlay，叠加在
-`deploy/docker/docker-compose.yml` 之上）。纯 conf 调优对现有数据卷无
-兼容性影响，可随时启用/回退。**注**：bench overlay 已将 `shared_buffers`
-调至 1GB（2026-08-22 三臂 A/B 验证与 4GB 等效）；上表 4GB 仍为 16GB 主机的
-PG 官方推荐起点。
+This is the exact form used in the measured benchmark environment; a complete runnable example lives in `benchmarks/fulla/docker-compose.bench.yml` (a bench overlay layered on top of `deploy/docker/docker-compose.yml`). Pure conf-level tuning has no compatibility impact on existing data volumes and can be enabled or rolled back at any time. **Note**: the bench overlay has since lowered `shared_buffers` to 1GB (verified in the 2026-08-22 three-arm A/B test to be equivalent to 4GB); the 4GB value above remains the officially recommended PG starting point for 16GB hosts.
 
-**版本与升级注记**：deploy compose 自 2026-08-18 起使用 `postgres:17-alpine`
-（与客户端 libpq 17.x 对齐，基准在 17 上实测）。**存量 15 版数据卷不能直接
-在 17 上启动**（大版本数据目录不兼容）——升级前先 `pg_dump`/`pg_restore`
-或用 `pg_upgrade`；全新部署无此步骤。
+**Version and upgrade note**: since 2026-08-18 the deploy compose uses `postgres:17-alpine` (aligned with the client-side libpq 17.x; benchmarks were measured on 17). **Existing data volumes from version 15 cannot start directly on 17** (major-version data-directory incompatibility) — run `pg_dump`/`pg_restore` or use `pg_upgrade` before upgrading; fresh deployments can skip this step.
 
-### 3. 会话留存（session_timeout）——按 API 流量调尺寸
+### 3. Session retention (session_timeout) — size it to your API traffic
 
-**机制（drogon 上游设计行为，[drogon#278](https://github.com/an-tao/drogon/issues/278)，本仓验证 2026-08-22）**：
-`enable_session: true` 时，**每个不带会话 cookie 的请求都会创建一个 Session
-并在 SessionManager 中持有到 `session_timeout` 到期**（淘汰机制本身正常，
-已实测验证）。机器/API 流量（token / introspect / userinfo / discovery ——
-客户端从不带 cookie）按请求付费。
+**Key point**: with `enable_session: true`, the Drogon framework layer creates a Session for every request that arrives without a session cookie and holds it until `session_timeout` expires (upstream [drogon#278](https://github.com/an-tao/drogon/issues/278) behavior, verified by measurement in this repo on 2026-08-22). API traffic (which never carries a cookie) pays per request: **about 750 B retained per request** (`API_QPS × session_timeout × 750 B`), plus a throughput tax of roughly -54% across all endpoints.
 
-**实测代价（生产 LTO 构建，2026-08-22，三场 60s c128 风暴实测）**：
+The full **retention formula, sizing quick-reference table, and tier-specific guidance** (interactive workloads under 100 QPS keep the default 3600s; API workloads lower it per the table; the benchmark tier uses 30s) lives in [Session management · sizing quick reference](../domains/session-management.md) — that document is the single source of truth on this topic, and this section keeps only the operational essentials.
 
-| 项 | 实测值 |
-|---|---|
-| 每请求留存 | **~750 B**（三场 60s c128 风暴：744/755/759 B/req，生产 LTO 构建） |
-| 稳态常驻公式 | `API_QPS × session_timeout × 750 B` |
-| discovery 吞吐税 | **~-54%**（生产 LTO 构建同窗口 6 轮交错 OFF/ON：164.6k → 76.3k QPS） |
+### 4. Docker network topology (optional on the native engine; unavailable under Docker Desktop)
 
-> ⚠ 吞吐税影响所有端点（session 创建在 drogon 框架层、先于路由）。历史
-> 基准（S1 87-104k）均为 session 开启状态下的测量值；无 session 真天花板
-> ~165k。修复需上游惰性化，跟踪 [drogon#278](https://github.com/an-tao/drogon/issues/278)。
+If you run the **native Docker Engine** (installed directly on a Linux server), you can put backend + PG + redis in `network_mode: host`: backend↔PG/Redis traffic goes over loopback, eliminating the per-packet veth traversal.
 
-**尺寸速查**（按公式，交互登录写→读间隔为毫秒级，TTL 不影响流内正确性 ——
-S4 登录/authcode 全阶梯在 120s 下验证通过，机制与 TTL 大小无关）：
+**Do not use this under Docker Desktop (WSL2 integration)** (measured 2026-08-18): `host` is the engine VM's netns, not the distro's netns, so ports listened on in host mode are completely unreachable from the distro (127.0.0.1, the shared eth0 IP, and host.docker.internal all time out; only published ports are forwarded). The benchmark environment therefore kept the bridge + published-ports topology, identical across all four products (fairness is unaffected).
 
-| API_QPS（无 cookie） | TTL=3600（出厂） | TTL=300 | TTL=120 | TTL=30 |
-|---|---|---|---|---|
-| 100 | ~0.3 GB | ~23 MB | ~9 MB | ~2 MB |
-| 1,000 | **~2.7 GB** | ~225 MB | ~90 MB | ~23 MB |
-| 10,000 | **~27 GB（OOM 区）** | ~2.2 GB | ~0.9 GB | ~225 MB |
-
-**指引**：
-- 交互为主、API 量小（&lt;100 QPS）的部署：出厂 3600s 保持不动（SSO 体验完整）。
-- API 流量可观的部署：按上表把 `session_timeout`（与 `session_max_age` 同步）
-  调到公式可承受档；2 分钟 idle 过期对浏览器 SSO 体验的影响可接受（OIDC
-  惯例 idle 窗口常见 5-15 分钟，向下兼容）。
-- 基准档采用 30s（`config.bench.json`，`QPS × 30 × 750 B` 封顶）。
-- **注**：吞吐税（生产构建 ~-54% discovery；ASan 构建曾测得 -24%，系插装
-  压低基线所致的低估）与 TTL 无关、开 session 即存在；根修
-  需上游惰性/按路径建 session（跟踪 [drogon#278](https://github.com/an-tao/drogon/issues/278)）。
-
-### 4. Docker 网络拓扑（原生引擎可选；Docker Desktop 下不可用）
-
-若使用**原生 Docker Engine**（Linux 服务器直装），可将 backend + PG + redis
-置于 `network_mode: host`：backend↔PG/Redis 走 loopback，省去每包 veth 穿越。
-
-**Docker Desktop（WSL2 集成）下不要使用**（2026-08-18 实测）：`host` 是引擎
-VM 的 netns 而非发行版的 netns，host 模式监听端口对发行版完全不可达
-（127.0.0.1、共享 eth0 IP、host.docker.internal 均超时；仅发布端口被转发）。
-基准环境因此保持 bridge + 发布端口拓扑，四产品一致（公平性不受影响）。
-
-跨机部署（nginx 前置、独立 DB）不受此项影响。
+Cross-machine deployments (nginx fronting, standalone DB) are unaffected by this item.
 
 ---
 
-## 运维操作
+## Operational tasks
 
-### 查看日志
+### View logs
 
 ```bash
-# 所有服务
+# All services
 docker compose -f deploy/docker/docker-compose.prod.yml logs -f
 
-# 单个服务
+# A single service
 docker compose -f deploy/docker/docker-compose.prod.yml logs -f fulla-backend
 docker compose -f deploy/docker/docker-compose.prod.yml logs -f nginx
 ```
 
-### 重启服务
+### Restart services
 
 ```bash
-# 重启单个服务
+# Restart a single service
 docker compose -f deploy/docker/docker-compose.prod.yml restart fulla-backend
 
-# 重建并重启（代码更新后）
+# Rebuild and restart (after code updates)
 docker compose -f deploy/docker/docker-compose.prod.yml up -d --build fulla-backend
 docker compose -f deploy/docker/docker-compose.prod.yml up -d --build fulla-frontend
 docker compose -f deploy/docker/docker-compose.prod.yml up -d --build fulla-admin
 ```
 
-### 更新部署
+### Update the deployment
 
 ```bash
 git pull
 docker compose -f deploy/docker/docker-compose.prod.yml up -d --build
 ```
 
-### 数据库备份
+### Database backup
 
 ```bash
-# 备份
+# Backup
 docker exec fulla-postgres pg_dump -U fulla_user fulla_db > backup_$(date +%Y%m%d).sql
 
-# 恢复
+# Restore
 docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < backup_20260526.sql
 ```
 
-### 监控
+### Monitoring
 
 - Prometheus: `http://your-server:9090`
-- 后端指标: `https://your-domain.com/metrics`（仅内网可访问）
-- 健康检查: `https://your-domain.com/health`
+- Backend metrics: `https://your-domain.com/metrics` (internal network only)
+- Health check: `https://your-domain.com/health`
 
 ---
 
-## 故障排除
+## Troubleshooting
 
-### 容器启动失败
+### Container fails to start
 
 ```bash
-# 查看容器状态
+# View container status
 docker compose -f deploy/docker/docker-compose.prod.yml ps
 
-# 查看失败容器日志
+# View the failed container's logs
 docker compose -f deploy/docker/docker-compose.prod.yml logs fulla-backend
 ```
 
-### 数据库连接失败
+### Database connection failure
 
 ```bash
-# 检查 postgres 是否就绪
+# Check whether postgres is ready
 docker exec fulla-postgres pg_isready -U fulla_user
 
-# 检查网络连通性
+# Check network connectivity
 docker exec fulla-backend curl -s http://fulla-postgres:5432 || echo "Cannot reach postgres"
 ```
 
-### 证书问题
+### Certificate problems
 
 ```bash
-# 检查证书是否存在
+# Check that the certificates exist
 ls -la deploy/nginx/ssl/
 
-# 检查证书有效期
+# Check the certificate validity period
 openssl x509 -in deploy/nginx/ssl/fullchain.pem -noout -dates
 ```
 
-### 前端 404
+### Frontend 404
 
-如果前端页面刷新后 404，检查 nginx.conf 中的 SPA fallback 配置：
+If frontend pages return 404 after a refresh, check the SPA fallback configuration in nginx.conf:
 - OAuth2Frontend: `try_files $uri $uri/ /index.html`
 - OAuth2Admin: `try_files $uri $uri/ /admin/index.html`
 
 ---
 
-## 安全清单
+## Security checklist
 
-- [ ] 所有密码使用强随机值（`openssl rand -base64 32`）
-- [ ] TLS 证书有效且自动续期
-- [ ] `.env.docker` 文件权限设为 600
-- [ ] `deploy/keys/signing.pem` 权限设为 600
-- [ ] 首次部署后修改 admin 默认密码
-- [ ] Prometheus 端口 9090 不对外暴露（或加认证）
-- [ ] 定期备份数据库
-- [ ] 监控磁盘空间（日志、数据库）
+- [ ] All passwords use strong random values (`openssl rand -base64 32`)
+- [ ] TLS certificates are valid and auto-renew
+- [ ] `.env.docker` file permissions set to 600
+- [ ] `deploy/keys/signing.pem` permissions set to 600
+- [ ] Default admin password changed after the first deployment
+- [ ] Prometheus port 9090 not exposed to the public (or protected by authentication)
+- [ ] Database backed up regularly
+- [ ] Disk space monitored (logs, database)

--- a/docs/operate/docker-deployment.md
+++ b/docs/operate/docker-deployment.md
@@ -1,12 +1,12 @@
-# Docker 部署与容器编排指南 (Docker Deployment)
+# Docker Deployment and Container Orchestration Guide
 
-本文档详细说明如何使用 Docker Compose 在本地或生产环境部署完整的 OAuth2 服务栈。
+This document explains how to deploy the complete OAuth2 service stack with Docker Compose, locally or in production.
 
 ---
 
-## 1. 服务栈架构
+## 1. Service Stack Architecture
 
-`docker-compose.yml` 编排以下 6 个服务：
+`docker-compose.yml` orchestrates the following 6 services:
 
 ```
 Internet
@@ -34,20 +34,20 @@ Internet
               prometheus (9090:9090)
 ```
 
-| 服务 | 镜像/构建 | 对外端口 | 说明 |
+| Service | Image/build | Exposed port | Notes |
 |---|---|---|---|
-| `fulla-frontend` | `deploy/docker/Dockerfile` (`frontend-runtime`) | `8080:80` | Vue SPA (用户端) + Nginx |
-| `fulla-admin` | `frontends/admin/Dockerfile` | `8081:80` | 管理后台前端 |
-| `fulla-backend` | `deploy/docker/Dockerfile` (`backend-runtime`) | `5555:5555` | Drogon C++ 后端 |
-| `fulla-postgres` | `postgres:17-alpine` | `5433:5432` | PostgreSQL（宿主机 5433，避开本地冲突）|
-| `fulla-redis` | `redis:7-alpine` | `6380:6379` | Redis（宿主机 6380，避开本地冲突）|
-| `fulla-prometheus` | `prom/prometheus:latest` | `9090:9090` | 指标采集 |
+| `fulla-frontend` | `deploy/docker/Dockerfile` (`frontend-runtime`) | `8080:80` | Vue SPA (user-facing) + Nginx |
+| `fulla-admin` | `frontends/admin/Dockerfile` | `8081:80` | Admin console frontend |
+| `fulla-backend` | `deploy/docker/Dockerfile` (`backend-runtime`) | `5555:5555` | Drogon C++ backend |
+| `fulla-postgres` | `postgres:17-alpine` | `5433:5432` | PostgreSQL (host port 5433, avoiding local conflicts)|
+| `fulla-redis` | `redis:7-alpine` | `6380:6379` | Redis (host port 6380, avoiding local conflicts)|
+| `fulla-prometheus` | `prom/prometheus:latest` | `9090:9090` | Metrics collection |
 
 ---
 
-## 2. 快速启动
+## 2. Quick Start
 
-详见 [Docker 容器和镜像规范指南](#镜像--容器--网络命名规范)。
+See the [Docker image and container specification guide](#image--container--network-naming-conventions).
 
 ```bash
 # 第一次或代码变更后：重新构建并启动（在项目根目录执行）
@@ -71,9 +71,11 @@ docker-compose -f deploy/docker/docker-compose.yml down -v
 
 ---
 
-## 3. 环境变量与密钥注入
+## 3. Environment Variables and Secret Injection
 
-`fulla-backend` 在 `docker-compose.yml` 的 `environment` 节中通过环境变量注入敏感配置，**完全覆盖 `config.json` 中的默认值**。开发环境默认值（仅用于本地评估）如下：
+`fulla-backend` receives sensitive configuration through environment variables in the `environment`
+section of `docker-compose.yml`, **fully overriding the defaults in `config.json`**. The development
+defaults (for local evaluation only) are:
 
 ```yaml
 environment:
@@ -90,14 +92,14 @@ environment:
   ...
 ```
 
-> **WARNING** **生产环境安全提示**：
-> - **禁止**将真实密码直接写在 `docker-compose.yml` 中并提交到 Git。
-> - 推荐使用 **Docker Secrets** 或外部密钥管理（Vault、AWS Secrets Manager）。
-> - 最低要求：使用 `.env` 文件，并将其加入 `.gitignore`。
+> **WARNING** **Production security notes**:
+> - **Never** write real passwords directly into `docker-compose.yml` and commit them to Git.
+> - **Docker Secrets** or an external secret manager (Vault, AWS Secrets Manager) is recommended.
+> - Minimum requirement: use an `.env` file and add it to `.gitignore`.
 
-### 使用 `.env` 文件（推荐）
+### Using an `.env` file (recommended)
 
-仓库提供了示例文件 `deploy/env/docker.env.example`（以及 `deploy/env/server.env.example`）。复制为 `.env.docker`（已在 `.gitignore` 中排除）并填入生产值：
+The repository ships the example files `deploy/env/docker.env.example` (and `deploy/env/server.env.example`). Copy one to `.env.docker` (already excluded via `.gitignore`) and fill in production values:
 
 ```env
 FULLA_DB_PASSWORD=your_strong_password
@@ -109,13 +111,13 @@ FULLA_SMTP_PORT=465
 ...
 ```
 
-然后 `docker-compose.yml` 中通过 `${VAR_NAME:-default}` 引用即可。
+Then reference the values from `docker-compose.yml` via `${VAR_NAME:-default}`.
 
 ---
 
-## 4. 数据持久化
+## 4. Data Persistence
 
-通过命名 Volume 实现数据持久化，容器重启不丢数据：
+Data persistence is achieved through named volumes, so container restarts do not lose data:
 
 ```yaml
 volumes:
@@ -123,7 +125,10 @@ volumes:
   redisdata: # Redis RDB / AOF 文件
 ```
 
-数据库初始化由后端在启动时自动完成（`FULLA_AUTO_MIGRATE=true`，按文件名顺序执行 `apps/server/migrations/V*.sql`，再执行 `apps/server/seed/*.sql`）。`docker-compose.yml` 同时把迁移与种子脚本挂进 postgres 容器的子目录：
+Database initialization is performed automatically by the backend at startup (`FULLA_AUTO_MIGRATE=true`
+executes `apps/server/migrations/V*.sql` in filename order, followed by `apps/server/seed/*.sql`).
+`docker-compose.yml` also mounts the migration and seed scripts into subdirectories of the
+postgres container:
 
 ```yaml
 volumes:
@@ -131,13 +136,15 @@ volumes:
   - ../../apps/server/seed:/docker-entrypoint-initdb.d/seed:ro
 ```
 
-> **WARNING** **注意**：postgres entrypoint **不会**递归进入 `/docker-entrypoint-initdb.d` 的子目录，因此这两个挂载对首次初始化是 **no-op**，真正的 schema 初始化由后端的 `FULLA_AUTO_MIGRATE` 完成。
+> **WARNING** **Note**: the postgres entrypoint does **not** recurse into subdirectories of
+> `/docker-entrypoint-initdb.d`, so these two mounts are **no-ops** for first-time
+> initialization; actual schema initialization is performed by the backend's `FULLA_AUTO_MIGRATE`.
 
 ---
 
-## 5. Prometheus 监控配置
+## 5. Prometheus Monitoring Configuration
 
-`prometheus.yml` 配置 Prometheus 采集 `fulla-backend` 的 `/metrics` 端点：
+`prometheus.yml` configures Prometheus to scrape the `/metrics` endpoint of `fulla-backend`:
 
 ```yaml
 scrape_configs:
@@ -146,17 +153,17 @@ scrape_configs:
       - targets: ["fulla-backend:5555"]
 ```
 
-Prometheus 与 fulla-backend 位于同一 Docker 网络 `oauth2-net`，使用服务名直接访问（无需暴露宿主机端口）。
+Prometheus sits on the same Docker network as fulla-backend, `oauth2-net`, and reaches it directly by service name (no host port needs to be exposed).
 
-访问 `http://localhost:9090` 即可查看 Prometheus UI。
+Visit `http://localhost:9090` for the Prometheus UI.
 
 ---
 
-## 6. 生产部署建议
+## 6. Production Deployment Recommendations
 
-### 6.1 在 Nginx 前端服务添加 SSL 终结
+### 6.1 Add SSL termination in front of the frontend service
 
-前端 `fulla-frontend` 的 Nginx 负责静态文件托管，应在其前面增加一层带 SSL 的 Nginx/Traefik：
+The Nginx inside `fulla-frontend` serves static files; put an SSL-terminating Nginx/Traefik layer in front of it:
 
 ```nginx
 server {
@@ -179,11 +186,11 @@ server {
 }
 ```
 
-> **重要**：转发 `X-Forwarded-For` 头，确保后端的 Hodor 插件能正确获取真实客户端 IP。
+> **Important**: forward the `X-Forwarded-For` header so the backend's Hodor plugin can obtain the real client IP.
 
-### 6.2 屏蔽 `/metrics` 端点
+### 6.2 Block the `/metrics` endpoint
 
-Prometheus `/metrics` 端点不应暴露到公网，在 Nginx 中添加：
+The Prometheus `/metrics` endpoint must not be exposed to the public internet. Add to Nginx:
 
 ```nginx
 location /metrics {
@@ -191,15 +198,15 @@ location /metrics {
 }
 ```
 
-或通过 Docker 不对外暴露 `fulla-backend:5555`，仅允许 Prometheus 内网访问。
+Alternatively, do not expose `fulla-backend:5555` through Docker at all, allowing access only to Prometheus on the internal network.
 
-### 6.3 数据库连接池调优
+### 6.3 Database connection pool tuning
 
-生产环境建议将 `config.prod.json` 的 `number_of_connections` 从 `4` 调整为 `10-50`，根据实际并发量测试确定。
+For production, consider raising `number_of_connections` in `config.prod.json` from `4` to `10-50`, determined by testing against actual concurrency.
 
 ---
 
-## 7. 健康检查与故障排查
+## 7. Health Checks and Troubleshooting
 
 ```bash
 # 检查所有容器状态
@@ -219,17 +226,17 @@ docker-compose down -v
 docker-compose up -d --build
 ```
 
-## 镜像 / 容器 / 网络命名规范
+## Image / Container / Network Naming Conventions
 
-| 镜像用途 | 名称 | 构建目标 | 说明 |
+| Image purpose | Name | Build target | Notes |
 |---------|------|--------------------|------|
-| 生产后端 | `fulla-backend` | `backend-runtime` | 仅运行时，体积小；GHCR 多架构发布 |
-| 调试后端 | `fulla-backend-debug` | `backend-dev` | 含完整编译工具链 |
-| 生产前端 | `fulla-frontend` | `frontend-runtime` | Nginx + 静态资源 |
+| Production backend | `fulla-backend` | `backend-runtime` | Runtime only, small footprint; multi-arch GHCR release |
+| Debug backend | `fulla-backend-debug` | `backend-dev` | Includes the full compilation toolchain |
+| Production frontend | `fulla-frontend` | `frontend-runtime` | Nginx + static assets |
 
-容器命名：`fulla-{service}[-debug]`（backend/frontend/postgres/redis）；网络：Release 为 `oauth2-net`，Debug 为 `fulla-debug-net`（历史保留名见 compose 文件）。三份 compose 矩阵：`docker-compose.yml`（开发，6 服务）、`docker-compose.debug.yml`（调试，3 服务）、`docker-compose.prod.yml`（生产，8 服务含 Nginx 与 migrate 作业）。**所有 compose 命令在仓库根目录执行并带 `-f deploy/docker/...`**。
+Container naming: `fulla-{service}[-debug]` (backend/frontend/postgres/redis); networks: `oauth2-net` for Release, `fulla-debug-net` for Debug (see the compose files for legacy retained names). Three compose matrices: `docker-compose.yml` (development, 6 services), `docker-compose.debug.yml` (debug, 3 services), and `docker-compose.prod.yml` (production, 8 services including Nginx and a migrate job). **All compose commands are run from the repository root with `-f deploy/docker/...`**.
 
-## 调试环境（挂载源码 / GDB）
+## Debug Environment (source mounts / GDB)
 
 ```bash
 docker build -f deploy/docker/Dockerfile --target backend-dev -t fulla-backend-debug:v1.0.0 .
@@ -237,7 +244,7 @@ docker compose -f deploy/docker/docker-compose.debug.yml up -d
 docker compose -f deploy/docker/docker-compose.debug.yml run --rm debug-env bash
 ```
 
-## 自动化验证
+## Automated Verification
 
-- `deploy/docker/docker-quick-verify-debug.sh`（容器内全流程：依赖检查 → 等 PG/Redis 就绪 → 建库 → 并行编译 → 单测）；
-- `scripts/backend/full_test_docker.bat`（宿主一键：起容器 → 初始化 → ORM 重生成 → 编译 → 测试 → 起服 → OAuth2/Admin 端点测试 → 清理）。
+- `deploy/docker/docker-quick-verify-debug.sh` (full in-container pipeline: dependency check → wait for PG/Redis readiness → create the database → parallel build → unit tests);
+- `scripts/backend/full_test_docker.bat` (one-click on the host: start containers → initialize → regenerate the ORM → build → test → start the server → OAuth2/Admin endpoint tests → cleanup).

--- a/docs/operate/observability.md
+++ b/docs/operate/observability.md
@@ -1,86 +1,86 @@
-# OAuth2 可观测性设计文档 (Observability)
+# OAuth2 Observability Design
 
-本系统集成了完整的 Prometheus 监控指标与结构化上下文日志，支持生产环境的实时监控与问题排查。
+The system integrates complete Prometheus monitoring metrics and structured, context-aware logging, supporting real-time monitoring and troubleshooting in production.
 
 ## 1. Prometheus Metrics
 
-系统通过 Exporter 暴露标准的 Prometheus 指标。
+The system exposes standard Prometheus metrics through an exporter.
 
-### 1.1 指标列表
+### 1.1 Metric List
 
-| 指标名称 | 类型 | 标签 (Labels) | 说明 |
+| Metric | Type | Labels | Description |
 |----------|------|--------------|------|
-| `oauth2_requests_total` | Counter | `endpoint`, `status` | OAuth2 请求总数 |
-| `oauth2_login_failures_total` | Counter | `reason` | 登录失败次数 |
-| `oauth2_introspect_requests_total` | Counter | `client_id` | Token Introspection 请求总数 |
-| `oauth2_introspect_errors_total` | Counter | `client_id`, `error` | Introspection 错误次数 |
-| `oauth2_revocation_requests_total` | Counter | `client_id` | Token Revocation 请求总数 |
-| `oauth2_revocation_errors_total` | Counter | `client_id`, `error` | Revocation 错误次数 |
-| `oauth2_latency_seconds` | Histogram | `operation`, `storage` | 关键步骤（含存储后端）耗时分布 |
-| `oauth2_active_tokens` | Gauge | — | 当前活跃（未过期）Token 估算值 |
+| `oauth2_requests_total` | Counter | `endpoint`, `status` | Total OAuth2 requests |
+| `oauth2_login_failures_total` | Counter | `reason` | Login failures |
+| `oauth2_introspect_requests_total` | Counter | `client_id` | Total token introspection requests |
+| `oauth2_introspect_errors_total` | Counter | `client_id`, `error` | Introspection errors |
+| `oauth2_revocation_requests_total` | Counter | `client_id` | Total token revocation requests |
+| `oauth2_revocation_errors_total` | Counter | `client_id`, `error` | Revocation errors |
+| `oauth2_latency_seconds` | Histogram | `operation`, `storage` | Latency distribution of key steps (including storage backend) |
+| `oauth2_active_tokens` | Gauge | — | Current estimate of active (unexpired) tokens |
 
-> 指标由 `libs/drogon/src/observability/Metrics.cc` 与 `libs/drogon/src/adapters/DrogonMetrics.cc` 统一发射（经 `LOG_INFO` 的 `[METRIC]` 结构化日志，供 PromExporter/日志采集端消费），定义见 `libs/drogon/include/fulla/drogon/observability/Metrics.h`。
+> Metrics are emitted uniformly by `libs/drogon/src/observability/Metrics.cc` and `libs/drogon/src/adapters/DrogonMetrics.cc` (as `[METRIC]` structured logs via `LOG_INFO`, consumed by PromExporter/log collectors); definitions live in `libs/drogon/include/fulla/drogon/observability/Metrics.h`.
 
-### 1.2 监控面板示例 (Grafana)
+### 1.2 Sample Dashboard Panels (Grafana)
 
-建议配置以下面板：
+Recommended panels:
 
 - **QPS & Error Rate**: `rate(oauth2_requests_total[1m])` vs `rate(oauth2_login_failures_total[1m])`
 - **P99 Latency**: `histogram_quantile(0.99, rate(oauth2_latency_seconds_bucket[1m]))`
-- **Business**: Active Tokens trend.
+- **Business**: Active tokens trend.
 
-## 2. Structured Logging (结构化日志)
+## 2. Structured Logging
 
-系统采用上下文感知的结构化日志，便于 Splunk/ELK 收集分析。
+The system uses context-aware structured logging that Splunk/ELK can easily collect and analyze.
 
-### 2.1 Audit Logs (审计日志)
+### 2.1 Audit Logs
 
-关键安全操作（如颁发 Token）会输出带有 `[AUDIT]` 标记的日志。
+Critical security operations (such as token issuance) emit logs tagged with `[AUDIT]`.
 
-**格式**:
+**Format**:
 `[AUDIT] Action={Action} User={UserId} Client={ClientId} Success={True/False} IP={RemoteAddr}`
 
-**示例**:
+**Example**:
 
 ```
 2026-01-18 10:00:00 INFO [AUDIT] Action=IssueToken User=admin Client=vue-client Success=True
 2026-01-18 10:05:00 WARN [AUDIT] Action=ExchangeCode User=admin Client=vue-client Success=False Reason="Replay Detected"
 ```
 
-### 2.2 Contextual Logs (上下文日志)
+### 2.2 Contextual Logs
 
-在请求处理链路中，所有日志自动附带 `RequestId`，用于关联分布式追踪。
+Along the request-processing chain, every log line automatically carries a `RequestId` for correlation in distributed tracing.
 
 ```cpp
 LOG_INFO << "Processing request"; // 输出: [ReqId: abc-123] Processing request
 ```
 
-## 3. 配置与集成
+## 3. Configuration and Integration
 
-### 3.1 开启 Metrics
+### 3.1 Enabling Metrics
 
-默认情况下，Metrics Exporter 监听 `/metrics` 端点（需在 Drogon 配置文件中开启 Exporter）。
+By default the metrics exporter listens on the `/metrics` endpoint (the exporter must be enabled in the Drogon configuration file).
 
-### 3.2 日志级别
+### 3.2 Log Levels
 
-系统统一使用六级日志，等级与 Drogon/Trantor 的内置级别一一对应（trace < debug < info < warn < error < fatal）：
+The system uses six log levels throughout, mapping one-to-one to Drogon/Trantor's built-in levels (trace < debug < info < warn < error < fatal):
 
-| 等级 | 含义 | 典型场景 |
+| Level | Meaning | Typical scenarios |
 |------|------|----------|
-| `trace` | 最细粒度追踪 | 函数入参 / 出参、循环迭代、逐行执行轨迹，用于深度调试定位 |
-| `debug` | 调试信息 | 变量值、分支走向、内部状态变化，开发阶段排查问题用 |
-| `info` | 常规信息 | 服务启动 / 停止、关键流程节点、用户登录、任务完成等正常业务事件 |
-| `warn` | 警告 | 可恢复的异常、降级处理、配置使用默认值、资源接近阈值等，系统仍能正常运行 |
-| `error` | 错误 | 功能失败、请求异常、数据库连接失败等，影响单次操作但服务整体可用 |
-| `fatal` | 致命错误 | 导致服务崩溃、无法继续运行的严重故障，需立即告警并人工介入 |
+| `trace` | Finest-grained tracing | Function inputs/outputs, loop iterations, line-by-line execution traces — for deep debugging and pinpointing |
+| `debug` | Debug information | Variable values, branch decisions, internal state changes — for troubleshooting during development |
+| `info` | Routine information | Service start/stop, key flow milestones, user logins, task completion and other normal business events |
+| `warn` | Warnings | Recoverable anomalies, degraded handling, configuration falling back to defaults, resources nearing thresholds — the system still runs normally |
+| `error` | Errors | Feature failures, request errors, database connection failures — affect a single operation but the service remains available overall |
+| `fatal` | Fatal errors | Severe faults that crash the service or prevent it from running; requires immediate alerting and human intervention |
 
-**约定**：
+**Conventions**:
 
-- 生产环境默认开启 `info` 及以上级别；`trace`/`debug` 按需动态开启。
-- 等级越高输出越少，`fatal` 应极少出现。
-- `apps/server/config/config.prod.json` 默认为 `INFO`，`config.dev.json` 默认为 `DEBUG`，`config.json`/`config.ci.json` 默认为 `DEBUG`。
+- Production enables `info` and above by default; `trace`/`debug` are enabled dynamically on demand.
+- Higher levels log less; `fatal` should be extremely rare.
+- `apps/server/config/config.prod.json` defaults to `INFO`, `config.dev.json` defaults to `DEBUG`, and `config.json`/`config.ci.json` default to `DEBUG`.
 
-**动态调整**：修改配置文件 `app.log.log_level` 字段即可，可选值为 `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`（不区分大小写）：
+**Dynamic adjustment**: edit the `app.log.log_level` field in the configuration file; allowed values are `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL` (case-insensitive):
 
 ```json
 "app": {
@@ -90,10 +90,10 @@ LOG_INFO << "Processing request"; // 输出: [ReqId: abc-123] Processing request
 }
 ```
 
-**代码约定**：
+**Code conventions**:
 
-- Domain 层（`libs/common`、`libs/oauth2`、`libs/identity`）**不得**直接使用 Drogon 的 `LOG_*` 宏，必须经 `fulla::common::ports::ILogger` 端口，以便单元测试可用 `FakeLogger` 捕获并断言。
-- Adapter / 基础设施层（`libs/drogon`、`libs/storage-*`、`apps/server`）可直接使用 `LOG_*` 宏。
-- 六级对应关系：`LogLevel::Trace`→`LOG_TRACE`、`Debug`→`LOG_DEBUG`、`Info`→`LOG_INFO`、`Warn`→`LOG_WARN`、`Error`→`LOG_ERROR`、`Fatal`→`LOG_FATAL`。
+- The domain layer (`libs/common`, `libs/oauth2`, `libs/identity`) **must not** use Drogon's `LOG_*` macros directly; it must go through the `fulla::common::ports::ILogger` port so that unit tests can capture and assert with `FakeLogger`.
+- The adapter / infrastructure layer (`libs/drogon`, `libs/storage-*`, `apps/server`) may use `LOG_*` macros directly.
+- Six-level mapping: `LogLevel::Trace`→`LOG_TRACE`, `Debug`→`LOG_DEBUG`, `Info`→`LOG_INFO`, `Warn`→`LOG_WARN`, `Error`→`LOG_ERROR`, `Fatal`→`LOG_FATAL`.
 
-> 关于测试输出的最小化策略（ctest 默认仅打印失败用例与汇总），见 [testing-guide.md](../contribute/testing-guide.md)。
+> For the test-output minimization strategy (ctest prints only failed cases and a summary by default), see [testing-guide.md](../contribute/testing-guide.md).

--- a/docs/operate/postgresql-major-upgrade.md
+++ b/docs/operate/postgresql-major-upgrade.md
@@ -1,32 +1,37 @@
-# PostgreSQL 大版本升级 Runbook（15 → 17）
+# PostgreSQL Major-Version Upgrade Runbook (15 → 17)
 
-> 适用范围：使用本仓库 `deploy/docker/docker-compose.prod.yml`（或 Helm chart）
-> 且带**持久数据卷**的存量部署。PG 大版本**拒绝挂载**旧版本的数据目录——
-> 直接 `docker compose up`（镜像已升到 `postgres:17-alpine`）会导致数据库容器
-> 循环重启，数据不会损坏但服务不可用。升级前必须走本 runbook。
+> Scope: existing deployments using this repository's `deploy/docker/docker-compose.prod.yml`
+> (or the Helm chart) with **persistent data volumes**. A PG major version **refuses to
+> mount** an older version's data directory — a plain `docker compose up` (with the image
+> already bumped to `postgres:17-alpine`) will leave the database container crash-looping;
+> data is not corrupted, but the service is unavailable. You must follow this runbook
+> before upgrading.
 >
-> 全新部署无此问题（17 数据目录由初始化直接生成）。
+> Fresh deployments are unaffected (the 17 data directory is created directly by
+> initialization).
 >
-> Fulla 自身在 PG 15 vs 17 的基准差异在噪声带内（2026-08-18 A/B 实测），
-> 升级动机是与服务端 libpq 17.x 客户端对齐及基准环境一致性，**没有吞吐诉求**。
-> 不急于升级的部署可以继续用 15 跑（把 compose 里的镜像 tag 钉回
-> `postgres:15-alpine` 即可，与应用兼容）。
+> fulla's own benchmark difference between PG 15 and 17 is within the noise band (2026-08-18
+> A/B measurements). The motivation for the upgrade is alignment with the server-side libpq
+> 17.x client and benchmark-environment consistency — **there is no throughput requirement
+> behind it**. Deployments in no hurry can keep running 15 (pin the compose image tag back
+> to `postgres:15-alpine`; it is compatible with the application).
 
-## 路线选择
+## Choosing a Route
 
-| 路线 | 停机窗口 | 适用 |
+| Route | Downtime window | Fits |
 |---|---|---|
-| A. dump/restore（推荐） | 与数据量成正比（GB 级通常分钟级） | 中小数据量；操作简单、可交叉验证 |
-| B. pg_upgrade（原地） | 通常 &lt;1 分钟 | 大数据量（数十 GB+）不想长停机 |
+| A. dump/restore (recommended) | Proportional to data size (GB-scale usually minutes) | Small-to-medium data volumes; simple to operate, cross-verifiable |
+| B. pg_upgrade (in place) | Usually &lt;1 minute | Large data volumes (tens of GB+) that cannot tolerate a long downtime |
 
-两条路线都要求：**升级前完成一次全量备份并保留旧数据卷**，验证通过后再清理。
+Both routes require: **complete a full backup and keep the old data volume before
+upgrading**; clean up only after verification passes.
 
-## 路线 A：dump/restore（推荐）
+## Route A: dump/restore (recommended)
 
-以 prod compose 为例（凭据来自 `.env`：`POSTGRES_USER`/`POSTGRES_PASSWORD`/
-`POSTGRES_DB`；compose project 名以实际为准，下同）。
+Using the prod compose as the example (credentials come from `.env`: `POSTGRES_USER`/
+`POSTGRES_PASSWORD`/`POSTGRES_DB`; substitute the actual compose project name, same below).
 
-### 1. 停应用、留旧库
+### 1. Stop the application, keep the old database
 
 ```bash
 cd deploy/docker
@@ -34,7 +39,7 @@ docker compose -f docker-compose.prod.yml stop fulla-backend
 # 旧 PG（15）保持运行，用它导出
 ```
 
-### 2. 全量导出
+### 2. Full export
 
 ```bash
 docker compose -f docker-compose.prod.yml exec -T fulla-postgres \
@@ -44,7 +49,7 @@ docker compose -f docker-compose.prod.yml exec -T fulla-postgres \
 grep -c "CREATE TABLE" backup_pg15_*.sql
 ```
 
-### 3. 切换数据卷
+### 3. Switch the data volume
 
 ```bash
 docker compose -f docker-compose.prod.yml down
@@ -55,10 +60,11 @@ docker volume rm <project>_pgdata 2>/dev/null || true
 #     cp -a /src /dst/pgdata_pg15_backup
 ```
 
-> 简化写法：也可以直接 `docker volume rm` 旧卷——前提是步骤 2 的 dump 文件
-> 已安全存放在宿主机并校验过。留底副本是给"验证失败回滚"用的保险。
+> Simplified variant: you may also just `docker volume rm` the old volume — provided the
+> dump file from step 2 is safely stored on the host and verified. The retained copy is
+> insurance for "rollback if verification fails".
 
-### 4. 启动 17 并导入
+### 4. Start 17 and import
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d fulla-postgres
@@ -68,25 +74,27 @@ docker compose -f docker-compose.prod.yml exec -T fulla-postgres \
   < backup_pg15_$(date +%Y%m%d).sql 2>&1 | grep -i "error\|fatal" || echo "IMPORT CLEAN"
 ```
 
-> 服务端配置了启动自动迁移（`FULLA_AUTO_MIGRATE=true` 时），导入旧 schema 后
-> 首次启动会自动补齐新增迁移（V025 分区等，幂等）。
+> With the server's startup auto-migration configured (`FULLA_AUTO_MIGRATE=true`), the
+> first startup after importing the old schema automatically applies the newer migrations
+> (V025 partitioning etc., idempotent).
 
-### 5. 验证后放流量
+### 5. Verify, then restore traffic
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d
 curl -fsS http://<backend>/health/ready
 ```
 
-按 [verification-checklist.md](../operate/verification-checklist) 走一遍核心路径
-（登录 → 授权码 → token → introspect → userinfo）。通过后保留 dump 文件与
-旧卷留底至少一个回归周期，再清理。
+Run the core paths from [verification-checklist.md](../operate/verification-checklist)
+(login → authorization code → token → introspect → userinfo). After passing, keep the dump
+file and the old-volume copy for at least one regression cycle before cleaning up.
 
-## 路线 B：pg_upgrade（原地，大数据量）
+## Route B: pg_upgrade (in place, large data volumes)
 
-pg_upgrade 需要同时存在新旧两套 binary 与数据目录。容器化下的最省事做法是
-官方 `postgres:17` 镜像内置的 `/usr/local/bin/pg_upgrade`（alpine 镜像不含，
-需用非 alpine tag 或自行挂载工具镜像）：
+pg_upgrade needs both the old and new binaries and data directories present at once. The
+easiest approach under containers is the official `postgres:17` image's built-in
+`/usr/local/bin/pg_upgrade` (the alpine image does not include it; use a non-alpine tag or
+mount a tooling image yourself):
 
 ```bash
 # 1) 停应用与旧库
@@ -111,23 +119,27 @@ docker run --rm \
 # 4) 把 compose 的 pgdata 卷指向升级后的卷（或交换卷名），up -d，验证同路线 A。
 ```
 
-pg_upgrade 成功后按提示执行 `vacuumdb --all --analyze`（或等自动 analyze）。
+After pg_upgrade succeeds, run `vacuumdb --all --analyze` as instructed (or wait for the automatic analyze).
 
-## Helm 部署
+## Helm Deployments
 
-Chart 内置 PostgreSQL 的镜像 tag 在 `deploy/helm/fulla/values.yaml`
-（`postgresql.image`）。有状态集的 PVC 同样是大版本绑定的数据目录：
+The chart's built-in PostgreSQL image tag lives in `deploy/helm/fulla/values.yaml`
+(`postgresql.image`). The StatefulSet's PVC is likewise a major-version-bound data
+directory:
 
-1. `kubectl scale deploy/fulla --replicas=0`（停应用）；
-2. 按上面任一路线导出/升级 PVC 中的数据；
-3. 更新 values 后 `helm upgrade`，验证就绪后恢复副本。
+1. `kubectl scale deploy/fulla --replicas=0` (stop the application);
+2. Export/upgrade the data in the PVC via either route above;
+3. Update the values, run `helm upgrade`, and restore the replicas once ready.
 
-外接数据库（自管 PG / RDS 类）的部署不涉及本仓库配置，走云厂商或 DBA 的
-大版本升级流程即可。
+Deployments with external databases (self-managed PG / RDS-style) do not involve this
+repository's configuration; follow your cloud provider's or DBA's major-version upgrade
+process.
 
-## 回滚
+## Rollback
 
-- 路线 A：`down` → 恢复旧卷留底（或恢复 `postgres:15-alpine` tag + 原卷）→
-  `up -d`。应用镜像与 PG 15 兼容（libpq 17 客户端连 15 服务端没有问题）。
-- 路线 B：旧卷未被修改（只读挂载），换回即可。
-- 已在新库写入新数据后回滚会丢这部分数据——回滚决策要在放流量验证之前做。
+- Route A: `down` → restore the retained old volume (or restore the `postgres:15-alpine`
+  tag + the original volume) → `up -d`. The application image is compatible with PG 15
+  (a libpq 17 client connecting to a 15 server is fine).
+- Route B: the old volume was untouched (mounted read-only); simply switch back to it.
+- Rolling back after new data has been written to the new database loses that data — make
+  the rollback decision before restoring verification traffic.

--- a/docs/operate/verification-checklist.md
+++ b/docs/operate/verification-checklist.md
@@ -1,12 +1,12 @@
-# 部署验证清单
+# Deployment Verification Checklist
 
-本文档提供完整的部署验证步骤，确保 fulla 全栈系统在 Windows Docker Desktop 或 Linux 生产环境上正确运行。
+This document provides complete deployment verification procedures to ensure the fulla full-stack system runs correctly on Windows Docker Desktop or in a Linux production environment.
 
 ---
 
-## 快速验证（5 分钟）
+## Quick Verification (5 Minutes)
 
-### 1. 检查所有容器状态
+### 1. Check All Container Statuses
 
 ```powershell
 # Windows
@@ -16,9 +16,9 @@ docker compose -f deploy/docker/docker-compose.yml ps
 docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker ps
 ```
 
-**预期结果**：所有容器状态为 `Up` 或 `Up (healthy)`
+**Expected result**: all containers show a status of `Up` or `Up (healthy)`
 
-| 容器名 | 状态 | 端口映射 |
+| Container | Status | Port Mapping |
 |--------|------|---------|
 | fulla-frontend | Up | 8080:80 |
 | fulla-admin | Up | 8081:80 |
@@ -27,50 +27,50 @@ docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker p
 | fulla-redis | Up | 6380:6379 |
 | fulla-prometheus | Up | 9090:9090 |
 
-### 2. 健康检查
+### 2. Health Check
 
 ```powershell
-# 后端健康端点
+# Backend health endpoint
 curl http://localhost:5555/health
 
-# 预期输出
+# Expected output
 {"status":"healthy","timestamp":"2026-08-26T10:30:00Z"}
 ```
 
-### 3. 数据库连接测试
+### 3. Database Connection Test
 
 ```powershell
-# 进入 postgres 容器
+# Enter the postgres container
 docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "\dt"
 
-# 预期输出：OAuth2 相关表列表
+# Expected output: list of OAuth2-related tables
 # oauth2_clients, oauth2_codes, oauth2_access_tokens, oauth2_refresh_tokens,
-# oauth2_scopes, users, roles, user_roles, organizations, audit_logs 等（V026 后共 21 张）
+# oauth2_scopes, users, roles, user_roles, organizations, audit_logs, etc. (21 tables in total after V026)
 ```
 
-### 4. 前端访问测试
+### 4. Frontend Access Test
 
-在浏览器中打开：
-- **用户前端**：http://localhost:8080 或 https://your-domain.com
-- **管理后台**：http://localhost:8081 或 https://your-domain.com/admin
+Open the following in a browser:
+- **User frontend**: http://localhost:8080 or https://your-domain.com
+- **Admin console**: http://localhost:8081 or https://your-domain.com/admin
 
-**预期结果**：页面正常加载，无 404 或 502 错误
+**Expected result**: pages load normally with no 404 or 502 errors
 
 ---
 
-## 完整验证（30 分钟）
+## Full Verification (30 Minutes)
 
-## 阶段一：基础设施验证
+## Phase 1: Infrastructure Verification
 
-### 1.1 PostgreSQL 验证
+### 1.1 PostgreSQL Verification
 
 ```powershell
-# 连接测试
+# Connection test
 docker exec fulla-postgres pg_isready -U fulla_user
 
-# 预期输出：/var/run/postgresql:5432 - accepting connections
+# Expected output: /var/run/postgresql:5432 - accepting connections
 
-# 表结构检查
+# Table structure check
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT table_name 
 FROM information_schema.tables 
@@ -78,67 +78,67 @@ WHERE table_schema = 'public'
 ORDER BY table_name;
 "
 
-# 预期表列表（V002-V026 实际 schema，均带 oauth2_ 前缀）：
+# Expected table list (V002-V026 actual schema, all with the oauth2_ prefix):
 # - oauth2_access_tokens, oauth2_refresh_tokens, oauth2_codes
 # - oauth2_clients, oauth2_scopes, oauth2_client_scopes
 # - oauth2_user_consents, oauth2_subject_mappings, oauth2_device_codes
 # - users, roles, permissions, user_roles, role_permissions
-# - organizations, audit_logs, webauthn_credentials 等
+# - organizations, audit_logs, webauthn_credentials, etc.
 
-# 数据库版本检查
+# Database version check
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT version();"
 
-# 预期：PostgreSQL 17.x（deploy compose 默认 postgres:17-alpine；
-#       显式钉回 15 的存量部署此处应为 15.x，见 docs/operate/postgresql-major-upgrade.md）
+# Expected: PostgreSQL 17.x (deploy compose defaults to postgres:17-alpine;
+#           existing deployments explicitly pinned to 15 should show 15.x here, see docs/operate/postgresql-major-upgrade.md)
 ```
 
-### 1.2 Redis 验证
+### 1.2 Redis Verification
 
 ```powershell
-# 进入 redis 容器
+# Enter the redis container
 docker exec -it fulla-redis redis-cli -a redis_secret_pass ping
 
-# 预期输出：PONG
+# Expected output: PONG
 
-# 测试读写
+# Test read/write
 docker exec fulla-redis redis-cli -a redis_secret_pass SET test_key "hello"
 docker exec fulla-redis redis-cli -a redis_secret_pass GET test_key
 
-# 预期输出："hello"
+# Expected output: "hello"
 
-# 检查内存使用
+# Check memory usage
 docker exec fulla-redis redis-cli -a redis_secret_pass INFO memory
 
-# 预期：used_memory_human 显示合理的内存占用
+# Expected: used_memory_human shows a reasonable amount of memory usage
 ```
 
-### 1.3 网络连通性验证
+### 1.3 Network Connectivity Verification
 
 ```powershell
-# 从后端容器测试数据库连接
+# Test database connectivity from the backend container
 docker exec fulla-backend ping -c 3 fulla-postgres
 
-# 预期：3 packets transmitted, 3 received, 0% packet loss
+# Expected: 3 packets transmitted, 3 received, 0% packet loss
 
-# 从后端容器测试 Redis 连接
+# Test Redis connectivity from the backend container
 docker exec fulla-backend ping -c 3 fulla-redis
 
-# 预期：3 packets transmitted, 3 received, 0% packet loss
+# Expected: 3 packets transmitted, 3 received, 0% packet loss
 
-# 检查 DNS 解析
+# Check DNS resolution
 docker exec fulla-backend nslookup fulla-postgres
 
-# 预期：返回 fulla-postgres 的容器 IP 地址（如 172.x.x.x）
+# Expected: returns the container IP address of fulla-postgres (e.g., 172.x.x.x)
 ```
 
 ---
 
-## 阶段二：数据库初始化验证
+## Phase 2: Database Initialization Verification
 
-### 2.1 检查 Seed 数据
+### 2.1 Check Seed Data
 
 ```powershell
-# 检查管理员用户（角色经 user_roles 关联，users 表本身没有 role 列）
+# Check the admin user (roles are linked through user_roles; the users table itself has no role column)
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT u.username, u.email, r.name AS role, u.created_at
 FROM users u
@@ -147,56 +147,56 @@ LEFT JOIN roles r ON r.id = ur.role_id
 WHERE u.username = 'admin';
 "
 
-# 预期输出：
+# Expected output:
 # username |       email       | role  |         created_at
 # ----------+-------------------+-------+----------------------------
 # admin    | admin@example.com | admin | 2026-xx-xx xx:xx:xx
 
-# 检查默认客户端（表名带 oauth2_ 前缀；名称列是 name）
+# Check the default clients (the table name carries the oauth2_ prefix; the name column is name)
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT client_id, name, client_type, token_endpoint_auth_method
 FROM oauth2_clients
 WHERE client_id IN ('admin-console', 'vue-client');
 "
 
-# 预期输出：admin-console 与 vue-client 均为 PUBLIC（token_endpoint_auth_method = none）
+# Expected output: both admin-console and vue-client are PUBLIC (token_endpoint_auth_method = none)
 
-# 检查默认 Scopes（scope 名称列是 name）
+# Check the default scopes (the scope name column is name)
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT name, description
 FROM oauth2_scopes
 LIMIT 5;
 "
 
-# 预期输出：openid, profile, email, admin 等标准 scope
+# Expected output: standard scopes such as openid, profile, email, admin
 ```
 
-### 2.2 验证数据库迁移
+### 2.2 Verify Database Migrations
 
 ```powershell
-# 检查 migrations 表（如果有的话）
+# Check the migrations table (if present)
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "\d schema_migrations"
 
-# 或检查表结构完整性
+# Or check table structure integrity
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT COUNT(*) AS table_count 
 FROM information_schema.tables 
 WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
 "
 
-# 预期：table_count >= 15（V026 后实测 21 张 public 表）
+# Expected: table_count >= 15 (measured 21 public tables after V026)
 ```
 
 ---
 
-## 阶段三：后端 API 验证
+## Phase 3: Backend API Verification
 
-### 3.1 获取管理员令牌
+### 3.1 Obtain an Admin Token
 
-`admin-console` 是 **PUBLIC 客户端**（`token_endpoint_auth_method=none`，无 client_secret，不支持 password grant），令牌必须走 **授权码 + PKCE** 两步流程（F-011：PUBLIC 客户端强制 PKCE）。以下等价于 `scripts/backend/test-admin-endpoints.sh` 的 setup 步骤：
+`admin-console` is a **PUBLIC client** (`token_endpoint_auth_method=none`, no client_secret, password grant not supported). Tokens must go through the two-step **authorization code + PKCE** flow (F-011: PKCE is mandatory for PUBLIC clients). The following is equivalent to the setup step in `scripts/backend/test-admin-endpoints.sh`:
 
 ```bash
-# 1) 登录换取授权码（表单编码；code_challenge = BASE64URL(SHA256(code_verifier))）
+# 1) Log in to obtain an authorization code (form-encoded; code_challenge = BASE64URL(SHA256(code_verifier)))
 CODE_VERIFIER=$(head -c 32 /dev/urandom | basenc --base64url | tr -d '=' | tr -d '+/' | head -c 43)
 CODE_CHALLENGE=$(printf '%s' "$CODE_VERIFIER" | openssl dgst -sha256 -binary | basenc --base64url | tr -d '=')
 
@@ -207,13 +207,13 @@ LOGIN_RESP=$(curl -s -X POST http://localhost:5555/oauth2/login \
   -d "code_challenge=$CODE_CHALLENGE&code_challenge_method=S256&json=true")
 CODE=$(echo "$LOGIN_RESP" | jq -r '.code')
 
-# 2) 授权码换令牌（表单编码；PUBLIC 客户端只带 client_id，不能携带任何 secret）
+# 2) Exchange the authorization code for tokens (form-encoded; a PUBLIC client sends only client_id and must not include any secret)
 curl -s -X POST http://localhost:5555/oauth2/token \
   -d "grant_type=authorization_code&code=$CODE" \
   -d "redirect_uri=http://localhost:5174/admin/callback" \
   -d "client_id=admin-console&code_verifier=$CODE_VERIFIER"
 
-# 预期响应（保存 access_token）：
+# Expected response (save the access_token):
 {
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
   "token_type": "Bearer",
@@ -222,22 +222,22 @@ curl -s -X POST http://localhost:5555/oauth2/token \
   "scope": "openid profile admin"
 }
 
-# 设置环境变量（后续测试使用）
+# Set an environment variable (used by the tests below)
 export TOKEN="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
 ```
 
-> Windows 下可使用仓库自带的 `scripts/backend/test-admin-endpoints.ps1` 完成同样的登录+令牌流程。
+> On Windows, use the repository-provided `scripts/backend/test-admin-endpoints.ps1` to run the same login + token flow.
 
-### 3.2 验证令牌内省（Token Introspection）
+### 3.2 Verify Token Introspection
 
 ```bash
-# 内省令牌（RFC 7662，表单编码）
+# Introspect the token (RFC 7662, form-encoded)
 curl -s -X POST http://localhost:5555/oauth2/introspect \
   -d "token=$TOKEN" \
   -d "token_type_hint=access_token" \
   -d "client_id=admin-console"
 
-# 预期响应：
+# Expected response:
 {
   "active": true,
   "client_id": "admin-console",
@@ -249,68 +249,68 @@ curl -s -X POST http://localhost:5555/oauth2/introspect \
   "iss": "http://localhost:5555"
 }
 
-# 测试无效令牌
+# Test an invalid token
 curl -s -X POST http://localhost:5555/oauth2/introspect \
   -d "token=invalid_token" \
   -d "token_type_hint=access_token" \
   -d "client_id=admin-console"
 
-# 预期响应：{"active": false}
+# Expected response: {"active": false}
 ```
 
-### 3.3 刷新令牌（Refresh Token）
+### 3.3 Refresh a Token
 
 ```bash
-# 使用 refresh_token 获取新的 access_token（表单编码；
-# PUBLIC 客户端只带 client_id —— 携带 client_secret 反而会被 F-017 拒绝）
+# Use the refresh_token to obtain a new access_token (form-encoded;
+# a PUBLIC client sends only client_id — including a client_secret would actually be rejected by F-017)
 curl -s -X POST http://localhost:5555/oauth2/token \
   -d "grant_type=refresh_token" \
   -d "refresh_token=tGzv3JH7xN1yQ9X2..." \
   -d "client_id=admin-console"
 
-# 预期响应：返回新的 access_token 和 refresh_token
+# Expected response: returns a new access_token and refresh_token
 {
-  "access_token": "新的 access token...",
+  "access_token": "new access token...",
   "token_type": "Bearer",
   "expires_in": 3600,
-  "refresh_token": "新的 refresh token...",
+  "refresh_token": "new refresh token...",
   "scope": "openid profile admin"
 }
 ```
 
-### 3.4 撤销令牌（Token Revocation）
+### 3.4 Revoke a Token
 
 ```bash
-# 撤销令牌（RFC 7009，表单编码；客户端认证方式须与注册的
-# token_endpoint_auth_method 一致 —— PUBLIC 客户端仅 client_id）
+# Revoke the token (RFC 7009, form-encoded; the client authentication method must match
+# the registered token_endpoint_auth_method — a PUBLIC client uses only client_id)
 curl -s -X POST http://localhost:5555/oauth2/revoke \
   -d "token=$TOKEN" \
   -d "token_type_hint=access_token" \
   -d "client_id=admin-console"
 
-# 预期响应：HTTP 200 OK（空响应体）
+# Expected response: HTTP 200 OK (empty response body)
 
-# 验证令牌已被撤销
+# Verify the token has been revoked
 curl -s -X POST http://localhost:5555/oauth2/introspect \
   -d "token=$TOKEN" \
   -d "token_type_hint=access_token" \
   -d "client_id=admin-console"
 
-# 预期响应：{"active": false}
+# Expected response: {"active": false}
 ```
 
 ---
 
-## 阶段四：管理后台 API 验证
+## Phase 4: Admin Console API Verification
 
-### 4.1 用户管理 API
+### 4.1 User Management API
 
 ```powershell
-# 获取用户列表
+# Get the user list
 curl -X GET http://localhost:5555/api/admin/users \
   -H "Authorization: Bearer $TOKEN"
 
-# 预期响应：用户列表 JSON
+# Expected response: user list JSON
 {
   "users": [
     {
@@ -327,7 +327,7 @@ curl -X GET http://localhost:5555/api/admin/users \
   "per_page": 20
 }
 
-# 创建新用户
+# Create a new user
 curl -X POST http://localhost:5555/api/admin/users \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -338,7 +338,7 @@ curl -X POST http://localhost:5555/api/admin/users \
     "role": "user"
   }'
 
-# 预期响应：HTTP 201 Created
+# Expected response: HTTP 201 Created
 {
   "user_id": 2,
   "username": "testuser",
@@ -347,21 +347,21 @@ curl -X POST http://localhost:5555/api/admin/users \
   "created_at": "2026-08-26T10:30:00Z"
 }
 
-# 获取单个用户详情
+# Get a single user's details
 curl -X GET http://localhost:5555/api/admin/users/2 \
   -H "Authorization: Bearer $TOKEN"
 
-# 预期响应：显示 testuser 的详细信息
+# Expected response: shows the details of testuser
 ```
 
-### 4.2 客户端管理 API
+### 4.2 Client Management API
 
 ```powershell
-# 获取客户端列表
+# Get the client list
 curl -X GET http://localhost:5555/api/admin/clients \
   -H "Authorization: Bearer $TOKEN"
 
-# 预期响应：客户端列表（客户端 secret 一律不回显；哈希仅存于库中）
+# Expected response: client list (client secrets are never echoed back; only hashes are stored in the database)
 {
   "clients": [
     {
@@ -377,7 +377,7 @@ curl -X GET http://localhost:5555/api/admin/clients \
   "total": 1
 }
 
-# 创建新客户端
+# Create a new client
 curl -X POST http://localhost:5555/api/admin/clients \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -391,17 +391,17 @@ curl -X POST http://localhost:5555/api/admin/clients \
     "scopes": ["openid", "profile", "email"]
   }'
 
-# 预期响应：HTTP 201 Created（响应含新生成客户端的元数据；secret 不回显）
+# Expected response: HTTP 201 Created (the response contains the newly created client's metadata; the secret is not echoed back)
 ```
 
-### 4.3 Scope 管理 API
+### 4.3 Scope Management API
 
 ```powershell
-# 获取所有 scopes
+# Get all scopes
 curl -X GET http://localhost:5555/api/admin/scopes \
   -H "Authorization: Bearer $TOKEN"
 
-# 预期响应：scope 列表（scope 名称字段为 name，与 oauth2_scopes 表一致）
+# Expected response: scope list (the scope name field is name, consistent with the oauth2_scopes table)
 {
   "scopes": [
     {"name": "openid", "description": "OpenID Connect"},
@@ -411,7 +411,7 @@ curl -X GET http://localhost:5555/api/admin/scopes \
   ]
 }
 
-# 创建新 scope
+# Create a new scope
 curl -X POST http://localhost:5555/api/admin/scopes \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -420,41 +420,41 @@ curl -X POST http://localhost:5555/api/admin/scopes \
     "description": "Read access to user resources"
   }'
 
-# 预期响应：HTTP 201 Created
+# Expected response: HTTP 201 Created
 ```
 
 ---
 
-## 阶段五：前端功能验证
+## Phase 5: Frontend Feature Verification
 
-### 5.1 用户前端验证
+### 5.1 User Frontend Verification
 
-| 测试项 | 操作步骤 | 预期结果 |
+| Test Item | Steps | Expected Result |
 |--------|---------|---------|
-| 访问首页 | 打开 http://localhost:8080 | 显示登录页面 |
-| 用户注册 | 填写注册表单（用户名、邮箱、密码） | 注册成功，跳转到登录页 |
-| 用户登录 | 使用刚注册的账号登录 | 登录成功，跳转到个人资料页 |
-| 访问个人资料 | 点击"个人资料"菜单 | 显示用户信息（用户名、邮箱） |
-| 修改密码 | 输入旧密码和新密码 | 密码修改成功，需要重新登录 |
-| 退出登录 | 点击"退出"按钮 | 退出成功，跳转到登录页 |
+| Visit the home page | Open http://localhost:8080 | The login page is displayed |
+| User registration | Fill in the registration form (username, email, password) | Registration succeeds and redirects to the login page |
+| User login | Log in with the account just registered | Login succeeds and redirects to the profile page |
+| View profile | Click the "Profile" menu | User information is displayed (username, email) |
+| Change password | Enter the old and new passwords | The password change succeeds and the user must log in again |
+| Log out | Click the "Log out" button | Logout succeeds and redirects to the login page |
 
-### 5.2 管理后台验证
+### 5.2 Admin Console Verification
 
-| 测试项 | 操作步骤 | 预期结果 |
+| Test Item | Steps | Expected Result |
 |--------|---------|---------|
-| 访问管理后台 | 打开 http://localhost:8081/admin | 显示管理后台登录页 |
-| 管理员登录 | 使用 admin/admin 登录 | 登录成功，显示仪表板 |
-| 应用管理 | 点击"应用"菜单 | 显示客户端列表（至少有 admin-console） |
-| 创建应用 | 点击"新建应用"，填写表单 | 应用创建成功，出现在列表中 |
-| 用户管理 | 点击"用户"菜单 | 显示用户列表（至少有 admin 和刚注册的用户） |
-| Token 管理 | 点击"Token"菜单 | 显示 active tokens 列表 |
+| Open the admin console | Open http://localhost:8081/admin | The admin console login page is displayed |
+| Admin login | Log in with admin/admin | Login succeeds and the dashboard is displayed |
+| App management | Click the "Apps" menu | The client list is displayed (contains at least admin-console) |
+| Create an app | Click "New App" and fill in the form | The app is created successfully and appears in the list |
+| User management | Click the "Users" menu | The user list is displayed (contains at least admin and the newly registered user) |
+| Token management | Click the "Token" menu | The list of active tokens is displayed |
 
-### 5.3 OAuth2 授权码流程验证
+### 5.3 OAuth2 Authorization Code Flow Verification
 
 ```bash
-# 步骤 1：构建授权 URL（在浏览器中访问）
-# 注意：redirect_uri 必须与客户端注册值精确匹配（vue-client 种子注册的是
-#       http://127.0.0.1:8080/callback —— 用 localhost 会被拒绝）
+# Step 1: Build the authorization URL (visit it in a browser)
+# Note: the redirect_uri must exactly match the client's registered value
+#       (vue-client's seed registration uses http://127.0.0.1:8080/callback — using localhost will be rejected)
 # http://localhost:5555/oauth2/authorize?
 #   response_type=code&
 #   client_id=vue-client&
@@ -462,29 +462,29 @@ curl -X POST http://localhost:5555/api/admin/scopes \
 #   scope=openid profile email&
 #   state=random_state_value
 
-# 预期：重定向到登录页面
+# Expected: redirect to the login page
 
-# 步骤 2：用户登录
-# 使用测试账号登录（如 testuser）
+# Step 2: User login
+# Log in with a test account (e.g., testuser)
 
-# 预期：显示授权确认页面
+# Expected: the authorization consent page is displayed
 
-# 步骤 3：用户授权
-# 点击"授权"按钮
+# Step 3: User consent
+# Click the "Authorize" button
 
-# 预期：重定向到 redirect_uri，携带 authorization code
+# Expected: redirect to the redirect_uri carrying the authorization code
 # http://127.0.0.1:8080/callback?code=xxx&state=random_state_value
 
-# 步骤 4：交换令牌（vue-client 是 PUBLIC 客户端 → 必须带 PKCE code_verifier，
-#          且不能携带 client_secret）
+# Step 4: Exchange the token (vue-client is a PUBLIC client → must include the PKCE code_verifier
+#          and must not include a client_secret)
 curl -s -X POST http://localhost:5555/oauth2/token \
   -d "grant_type=authorization_code" \
-  -d "code=从回调中获取的code" \
+  -d "code=<code obtained from the callback>" \
   -d "redirect_uri=http://127.0.0.1:8080/callback" \
   -d "client_id=vue-client" \
-  -d "code_verifier=登录时使用的PKCE_verifier"
+  -d "code_verifier=<PKCE verifier used at login>"
 
-# 预期响应：返回 access_token 和 refresh_token
+# Expected response: returns an access_token and refresh_token
 {
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
   "token_type": "Bearer",
@@ -496,130 +496,130 @@ curl -s -X POST http://localhost:5555/oauth2/token \
 
 ---
 
-## 阶段五·补充：邮件服务验证
+## Phase 5 Supplement: Email Service Verification
 
-邮件服务有两种模式，由后端 `getEmailService()` 根据 `FULLA_SMTP_*` 环境变量决定。
+The email service has two modes, selected by the backend's `getEmailService()` based on the `FULLA_SMTP_*` environment variables.
 
-### 5.4 确认邮件服务模式
+### 5.4 Confirm the Email Service Mode
 
 ```powershell
-# 查看后端启动日志中的邮件服务模式
+# Check the email service mode in the backend startup logs
 docker logs fulla-backend 2>&1 | grep -i "Email service"
 ```
 
-**预期输出（二选一）**：
+**Expected output (one of the following)**:
 
-- Console 模式（未配置 SMTP）：`Email service: Console (set FULLA_SMTP_* env vars to enable SMTP)`
-- SMTP 模式（已配置）：`Email service: SMTP (smtp.163.com:465)`
+- Console mode (SMTP not configured): `Email service: Console (set FULLA_SMTP_* env vars to enable SMTP)`
+- SMTP mode (configured): `Email service: SMTP (smtp.163.com:465)`
 
-### 5.5 邮箱验证邮件
+### 5.5 Email Address Verification Message
 
-**操作**：登录用户前端 → Profile 页面 → 点击"发送邮箱验证"
+**Steps**: log in to the user frontend → Profile page → click "Send Email Verification"
 
-| 模式 | 验证方式 |
+| Mode | Verification Method |
 |------|---------|
-| Console 模式 | 邮件内容打到后端日志，从中复制验证链接 |
-| SMTP 模式 | 收件箱应收到真实邮件 |
+| Console mode | The message content is written to the backend logs; copy the verification link from there |
+| SMTP mode | A real message should arrive in the inbox |
 
-**Console 模式下查看验证链接**：
+**To view the verification link in Console mode**:
 
 ```powershell
 docker logs fulla-backend --tail 50 2>&1 | grep -A 5 -iE "verify|email"
-# 预期：含 "verify-email?token=xxx" 的链接
+# Expected: a link containing "verify-email?token=xxx"
 ```
 
-**SMTP 模式下验证邮件发送**：
+**To verify message delivery in SMTP mode**:
 
 ```powershell
-# 触发发送后，检查后端是否有 SMTP 错误
+# After triggering the send, check the backend for SMTP errors
 docker logs fulla-backend --tail 50 2>&1 | grep -iE "smtp|email|curl"
-# 预期：无 ERROR 级别日志；收件箱收到 "Verify Your Email" 邮件
+# Expected: no ERROR-level logs; a "Verify Your Email" message arrives in the inbox
 ```
 
-### 5.6 密码重置邮件
+### 5.6 Password Reset Message
 
-**操作**：前端"忘记密码"页面 → 输入邮箱 → 提交
+**Steps**: frontend "Forgot Password" page → enter the email address → submit
 
-- **预期响应**（防枚举）：无论邮箱是否存在，统一返回 `If the email exists, a reset link has been sent`
-- Console 模式下，重置链接同样打到后端日志
+- **Expected response** (anti-enumeration): regardless of whether the email address exists, the same message is returned: `If the email exists, a reset link has been sent`
+- In Console mode, the reset link is likewise written to the backend logs
 
-### 5.7 启用真实 SMTP（可选，详见部署指南）
+### 5.7 Enable Real SMTP (Optional; see the deployment guide for details)
 
-如需真实邮件发送，在 `.env.docker` 设置 `FULLA_SMTP_HOST` / `FULLA_SMTP_USER` / `FULLA_SMTP_PASSWORD` 三项后重启后端：
+For real message delivery, set `FULLA_SMTP_HOST` / `FULLA_SMTP_USER` / `FULLA_SMTP_PASSWORD` in `.env.docker` and restart the backend:
 
 ```powershell
 docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d fulla-backend
 docker logs fulla-backend 2>&1 | grep -i "Email service"
-# 预期：Email service: SMTP (...)
+# Expected: Email service: SMTP (...)
 ```
 
-> **注意**：邮件验证链接使用 `FULLA_FRONTEND_URL`。本地部署为 `http://localhost:8080`，从其他机器点击会失效。
+> **Note**: email verification links use `FULLA_FRONTEND_URL`. In a local deployment this is `http://localhost:8080`; clicking the link from another machine will not work.
 
 ---
 
-## 阶段六：安全性验证
+## Phase 6: Security Verification
 
-### 6.1 错误响应验证
+### 6.1 Error Response Verification
 
 ```bash
-# 测试无效客户端 ID（token 端点，表单编码）
+# Test an invalid client ID (token endpoint, form-encoded)
 curl -s -X POST http://localhost:5555/oauth2/token \
   -d "grant_type=authorization_code&code=x" \
   -d "client_id=invalid-client&code_verifier=x"
 
-# 预期响应：HTTP 401 Unauthorized
+# Expected response: HTTP 401 Unauthorized
 {
   "error": "invalid_client",
   "error_description": "Client authentication failed"
 }
 
-# 测试错误密码（登录端点 —— 注意：失败计数会触发 F-018 限流，别连刷超过阈值）
+# Test a wrong password (login endpoint — note: failed attempts trigger F-018 rate limiting, so do not exceed the threshold with repeated attempts)
 curl -s -X POST http://localhost:5555/oauth2/login \
   -d "username=admin&password=wrong-password" \
   -d "client_id=admin-console&redirect_uri=http://localhost:5174/admin/callback" \
   -d "scope=openid&state=t&code_challenge=x&code_challenge_method=S256"
 
-# 预期响应：HTTP 401 Unauthorized（错误码经 ErrorCatalog，防枚举口径统一）
+# Expected response: HTTP 401 Unauthorized (error codes go through the ErrorCatalog, ensuring a unified anti-enumeration posture)
 {
   "error": "invalid_grant",
   "error_description": "Invalid username or password"
 }
 
-# 测试缺少必需参数
+# Test a missing required parameter
 curl -s -X POST http://localhost:5555/oauth2/token \
   -d "grant_type=authorization_code"
 
-# 预期响应：HTTP 400 Bad Request
+# Expected response: HTTP 400 Bad Request
 {
   "error": "invalid_request",
   "error_description": "Missing required parameter: client_id"
 }
 ```
 
-### 6.2 令牌过期验证
+### 6.2 Token Expiration Verification
 
 ```powershell
-# 等待令牌过期（3600 秒），或修改后端配置为较短的过期时间进行测试
+# Wait for the token to expire (3600 seconds), or change the backend configuration to a shorter expiration time for testing
 
-# 或使用已撤销的令牌
+# Or use an already-revoked token
 curl -X GET http://localhost:5555/api/admin/users \
   -H "Authorization: Bearer revoked_token"
 
-# 预期响应：HTTP 401 Unauthorized
+# Expected response: HTTP 401 Unauthorized
 {
   "error": "invalid_token",
   "error_description": "The access token expired or has been revoked"
 }
 ```
 
-### 6.3 Scope 授权验证
+### 6.3 Scope Authorization Verification
 
 ```powershell
-# 请求超出授权范围的资源（如果实现了 scope-based access control）
+# Request a resource beyond the granted scope (if scope-based access control is implemented)
 curl -X GET http://localhost:5555/api/admin/users \
   -H "Authorization: Bearer $token_with_limited_scope"
 
-# 预期响应：HTTP 403 Forbidden
+# Expected response: HTTP 403 Forbidden
 {
   "error": "insufficient_scope",
   "error_description": "The request requires higher privileges than provided by the access token"
@@ -628,53 +628,53 @@ curl -X GET http://localhost:5555/api/admin/users \
 
 ---
 
-## 阶段七：性能和监控验证
+## Phase 7: Performance and Monitoring Verification
 
-### 7.1 Prometheus 指标验证
+### 7.1 Prometheus Metrics Verification
 
 ```powershell
-# 访问 Prometheus UI
-# 打开浏览器：http://localhost:9090
+# Access the Prometheus UI
+# Open in a browser: http://localhost:9090
 
-# 查询示例指标（权威清单见 docs/operate/observability.md）：
-# - oauth2_requests_total：总请求数（按 endpoint/status 维度）
-# - oauth2_latency_seconds：关键步骤耗时直方图
-# - oauth2_active_tokens：当前活跃令牌数
-# - oauth2_login_failures_total：登录失败次数
+# Example metric queries (the authoritative list is in docs/operate/observability.md):
+# - oauth2_requests_total: total number of requests (by endpoint/status dimensions)
+# - oauth2_latency_seconds: latency histogram for key steps
+# - oauth2_active_tokens: current number of active tokens
+# - oauth2_login_failures_total: number of login failures
 
-# 预期：指标正常采集，有数据
+# Expected: metrics are collected normally and data is present
 ```
 
-### 7.2 日志验证
+### 7.2 Log Verification
 
 ```powershell
-# 查看后端日志
+# View backend logs
 docker logs fulla-backend --tail 50
 
-# 预期：无 ERROR 级别日志，正常的 INFO/DEBUG 日志
+# Expected: no ERROR-level logs, normal INFO/DEBUG logs
 
-# 查看 nginx 日志（Linux 生产环境）
+# View nginx logs (Linux production environment)
 docker logs oauth2-nginx --tail 50
 
-# 预期：正常的访问日志，无 5xx 错误
+# Expected: normal access logs, no 5xx errors
 
-# 实时跟踪日志
+# Follow logs in real time
 docker compose -f deploy/docker/docker-compose.yml logs -f fulla-backend
 ```
 
-### 7.3 数据库性能验证
+### 7.3 Database Performance Verification
 
 ```powershell
-# 检查数据库连接数
+# Check the number of database connections
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT count(*) AS connections 
 FROM pg_stat_activity 
 WHERE datname = 'fulla_db';
 "
 
-# 预期：connections 为合理值（通常 < 20）
+# Expected: connections is a reasonable value (usually < 20)
 
-# 检查慢查询（如果有 pg_stat_statements 扩展）
+# Check slow queries (if the pg_stat_statements extension is available)
 docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
 SELECT query, calls, total_time, mean_time 
 FROM pg_stat_statements 
@@ -682,89 +682,89 @@ ORDER BY mean_time DESC
 LIMIT 5;
 "
 
-# 预期：无明显的慢查询（mean_time < 100ms）
+# Expected: no significant slow queries (mean_time < 100ms)
 ```
 
 ---
 
-## 故障排除检查点
+## Troubleshooting Checkpoints
 
-### 问题 1：容器无法启动
+### Problem 1: Containers fail to start
 
-**检查步骤**：
+**Check steps**:
 
 ```powershell
-# 查看容器状态
+# View container status
 docker compose -f deploy/docker/docker-compose.yml ps
 
-# 查看失败容器的日志
+# View the failed container's logs
 docker logs fulla-backend
 
-# 检查资源占用
+# Check resource usage
 docker stats
 
-# 验证配置文件
+# Validate the configuration file
 docker compose -f deploy/docker/docker-compose.yml config
 ```
 
-### 问题 2：数据库连接失败
+### Problem 2: Database connection failures
 
-**检查步骤**：
+**Check steps**:
 
 ```powershell
-# 验证 postgres 容器健康状态
+# Verify the postgres container health status
 docker exec fulla-postgres pg_isready -U fulla_user
 
-# 检查网络连通性
+# Check network connectivity
 docker exec fulla-backend ping fulla-postgres
 
-# 验证环境变量
+# Verify environment variables
 docker exec fulla-backend env | grep FULLA_DB
 
-# 查看数据库日志
+# View database logs
 docker logs fulla-postgres
 ```
 
-### 问题 3：前端无法访问后端 API
+### Problem 3: Frontend cannot reach the backend API
 
-**检查步骤**：
+**Check steps**:
 
 ```powershell
-# 从前端容器测试后端连接
+# Test the backend connection from the frontend container
 docker exec fulla-frontend curl -s http://fulla-backend:5555/health
 
-# 检查 nginx 配置（生产环境）
+# Check the nginx configuration (production environment)
 docker exec oauth2-nginx nginx -t
 
-# 查看后端 CORS 配置
+# View the backend CORS configuration
 docker logs fulla-backend | grep -i cors
 ```
 
-### 问题 4：令牌验证失败
+### Problem 4: Token verification failures
 
-**检查步骤**：
+**Check steps**:
 
 ```powershell
-# 验证 JWT 密钥存在
+# Verify that the JWT keys exist
 docker exec fulla-backend ls -la /app/keys/
 
-# 检查令牌签名
-# 复制 access_token 到 https://jwt.io 解码验证
+# Check the token signature
+# Copy the access_token to https://jwt.io to decode and verify it
 
-# 查看后端日志中的认证错误
+# View authentication errors in the backend logs
 docker logs fulla-backend | grep -i "auth\|token"
 ```
 
 ---
 
-## 自动化验证脚本
+## Automated Verification Script
 
-### 完整验证脚本（PowerShell）
+### Full Verification Script (PowerShell)
 
-保存为 `verify-deployment.ps1`：
+Save as `verify-deployment.ps1`:
 
 ```powershell
-# fulla 部署验证脚本
+# fulla deployment verification script
 param(
     [string]$BackendUrl = "http://localhost:5555",
     [string]$FrontendUrl = "http://localhost:8080",
@@ -773,45 +773,45 @@ param(
 }
 
 function Test-ContainerStatus {
-    Write-Host "`n[1/8] 检查容器状态..." -ForegroundColor Cyan
+    Write-Host "`n[1/8] Checking container status..." -ForegroundColor Cyan
     $containers = docker compose -f deploy/docker/docker-compose.yml ps
     if ($LASTEXITCODE -eq 0) {
-        Write-Host "[+] 所有容器运行正常" -ForegroundColor Green
+        Write-Host "[+] All containers are running normally" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "[-] 容器状态异常" -ForegroundColor Red
+        Write-Host "[-] Container status abnormal" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-BackendHealth {
-    Write-Host "`n[2/8] 检查后端健康..." -ForegroundColor Cyan
+    Write-Host "`n[2/8] Checking backend health..." -ForegroundColor Cyan
     try {
         $response = Invoke-RestMethod -Uri "$BackendUrl/health" -Method Get
         if ($response.status -eq "healthy") {
-            Write-Host "[+] 后端健康检查通过" -ForegroundColor Green
+            Write-Host "[+] Backend health check passed" -ForegroundColor Green
             return $true
         }
     } catch {
-        Write-Host "[-] 后端健康检查失败: $_" -ForegroundColor Red
+        Write-Host "[-] Backend health check failed: $_" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-DatabaseConnection {
-    Write-Host "`n[3/8] 检查数据库连接..." -ForegroundColor Cyan
+    Write-Host "`n[3/8] Checking database connection..." -ForegroundColor Cyan
     $result = docker exec fulla-postgres pg_isready -U fulla_user 2>&1
     if ($LASTEXITCODE -eq 0 -and $result -match "accepting connections") {
-        Write-Host "[+] 数据库连接正常" -ForegroundColor Green
+        Write-Host "[+] Database connection is normal" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "[-] 数据库连接失败" -ForegroundColor Red
+        Write-Host "[-] Database connection failed" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-DatabaseTables {
-    Write-Host "`n[4/8] 检查数据库表结构..." -ForegroundColor Cyan
+    Write-Host "`n[4/8] Checking database table structure..." -ForegroundColor Cyan
     $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
         SELECT COUNT(*) FROM information_schema.tables 
         WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
@@ -819,73 +819,73 @@ function Test-DatabaseTables {
     
     $tableCount = [int]$result.Trim()
     if ($tableCount -ge 20) {
-        Write-Host "[+] 数据库表结构完整 ($tableCount 张表)" -ForegroundColor Green
+        Write-Host "[+] Database table structure complete ($tableCount tables)" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "[-] 数据库表结构不完整 (仅 $tableCount 张表)" -ForegroundColor Red
+        Write-Host "[-] Database table structure incomplete (only $tableCount tables)" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-SeedData {
-    Write-Host "`n[5/8] 检查种子数据..." -ForegroundColor Cyan
+    Write-Host "`n[5/8] Checking seed data..." -ForegroundColor Cyan
     $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
         SELECT COUNT(*) FROM users WHERE username = 'admin';
     " 2>&1
     
     $count = [int]$result.Trim()
     if ($count -eq 1) {
-        Write-Host "[+] 管理员账号已创建" -ForegroundColor Green
+        Write-Host "[+] Admin account has been created" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "[-] 管理员账号未创建" -ForegroundColor Red
+        Write-Host "[-] Admin account has not been created" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-RedisConnection {
-    Write-Host "`n[6/8] 检查 Redis 连接..." -ForegroundColor Cyan
+    Write-Host "`n[6/8] Checking Redis connection..." -ForegroundColor Cyan
     $result = docker exec fulla-redis redis-cli -a redis_secret_pass ping 2>&1
     if ($result -match "PONG") {
-        Write-Host "[+] Redis 连接正常" -ForegroundColor Green
+        Write-Host "[+] Redis connection is normal" -ForegroundColor Green
         return $true
     } else {
-        Write-Host "[-] Redis 连接失败" -ForegroundColor Red
+        Write-Host "[-] Redis connection failed" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-DiscoveryEndpoint {
-    Write-Host "`n[7/8] 测试 OIDC 发现端点..." -ForegroundColor Cyan
-    # 完整登录流程（PKCE）见上文阶段三；脚本化部署检查用发现端点验证
-    # 后端 OAuth2 栈已就绪，且不依赖具体凭证。
+    Write-Host "`n[7/8] Testing the OIDC discovery endpoint..." -ForegroundColor Cyan
+    # For the full login flow (PKCE), see Phase 3 above; scripted deployment checks use the discovery
+    # endpoint to verify that the backend OAuth2 stack is ready without depending on specific credentials.
     try {
         $response = Invoke-RestMethod -Uri "$BackendUrl/.well-known/openid-configuration" -Method Get
         if ($response.issuer -and $response.token_endpoint) {
-            Write-Host "[+] OIDC 发现端点正常 (issuer: $($response.issuer))" -ForegroundColor Green
+            Write-Host "[+] OIDC discovery endpoint is normal (issuer: $($response.issuer))" -ForegroundColor Green
             return $true
         }
     } catch {
-        Write-Host "[-] OIDC 发现端点失败: $_" -ForegroundColor Red
+        Write-Host "[-] OIDC discovery endpoint failed: $_" -ForegroundColor Red
         return $false
     }
 }
 
 function Test-FrontendAccess {
-    Write-Host "`n[8/8] 检查前端访问..." -ForegroundColor Cyan
+    Write-Host "`n[8/8] Checking frontend access..." -ForegroundColor Cyan
     try {
         $response = Invoke-WebRequest -Uri $FrontendUrl -Method Get -UseBasicParsing
         if ($response.StatusCode -eq 200) {
-            Write-Host "[+] 前端页面可访问" -ForegroundColor Green
+            Write-Host "[+] Frontend page is accessible" -ForegroundColor Green
             return $true
         }
     } catch {
-        Write-Host "[-] 前端页面访问失败: $_" -ForegroundColor Red
+        Write-Host "[-] Frontend page access failed: $_" -ForegroundColor Red
         return $false
     }
 }
 
-# 执行所有测试
+# Run all tests
 $results = @()
 $results += Test-ContainerStatus
 $results += Test-BackendHealth
@@ -896,106 +896,106 @@ $results += Test-RedisConnection
 $results += Test-DiscoveryEndpoint
 $results += Test-FrontendAccess
 
-# 汇总结果
+# Summarize the results
 $passed = ($results | Where-Object { $_ -eq $true }).Count
 $total = $results.Count
 
 Write-Host "`n" -NoNewline
 Write-Host ("=" * 60) -ForegroundColor DarkGray
-Write-Host "验证结果: $passed / $total 通过" -ForegroundColor $(if ($passed -eq $total) { "Green" } else { "Yellow" })
+Write-Host "Verification results: $passed / $total passed" -ForegroundColor $(if ($passed -eq $total) { "Green" } else { "Yellow" })
 Write-Host ("=" * 60) -ForegroundColor DarkGray
 
 if ($passed -eq $total) {
-    Write-Host "`n[+] 部署验证完全通过！系统可以投入使用。" -ForegroundColor Green
+    Write-Host "`n[+] Deployment verification fully passed! The system is ready for use." -ForegroundColor Green
     exit 0
 } else {
-    Write-Host "`n[-] 部署验证失败，请检查上述错误项。" -ForegroundColor Red
+    Write-Host "`n[-] Deployment verification failed; please review the failed items above." -ForegroundColor Red
     exit 1
 }
 ```
 
-**使用方法**：
+**Usage**:
 
 ```powershell
-# 基本验证
+# Basic verification
 .\verify-deployment.ps1
 
-# 详细模式
+# Verbose mode
 .\verify-deployment.ps1 -Verbose
 
-# 自定义端点
+# Custom endpoints
 .\verify-deployment.ps1 -BackendUrl "https://your-domain.com" -FrontendUrl "https://your-domain.com"
 ```
 
 ---
 
-## 验证报告模板
+## Verification Report Template
 
-完成验证后，建议填写以下报告模板：
+After completing verification, fill in the following report template:
 
 ```markdown
-## fulla 部署验证报告
+## fulla Deployment Verification Report
 
-**验证日期**：YYYY-MM-DD
-**验证环境**：Windows Docker Desktop / Linux 生产服务器
-**验证人员**：[姓名]
+**Verification date**: YYYY-MM-DD
+**Verification environment**: Windows Docker Desktop / Linux production server
+**Verified by**: [Name]
 
-### 验证结果汇总
+### Verification Results Summary
 
-| 阶段 | 状态 | 备注 |
+| Phase | Status | Notes |
 |------|------|------|
-| 基础设施验证 | 通过 | 所有容器正常运行 |
-| 数据库初始化验证 | 通过 | 21 张表（V026），管理员账号已创建 |
-| 后端 API 验证 | 通过 | 令牌端点、内省、撤销功能正常 |
-| 管理后台 API 验证 | 通过 | 用户、客户端、Scope 管理正常 |
-| 前端功能验证 | 通过 | 用户登录、注册、个人资料功能正常 |
-| 安全性验证 | 通过 | 错误处理、令牌验证正常 |
-| 性能和监控验证 | 部分通过 | Prometheus 正常，需要优化慢查询 |
+| Infrastructure verification | Passed | All containers running normally |
+| Database initialization verification | Passed | 21 tables (V026), admin account created |
+| Backend API verification | Passed | Token endpoint, introspection, and revocation working normally |
+| Admin console API verification | Passed | User, client, and scope management working normally |
+| Frontend feature verification | Passed | User login, registration, and profile features working normally |
+| Security verification | Passed | Error handling and token verification working normally |
+| Performance and monitoring verification | Partially passed | Prometheus normal; slow queries need optimization |
 
-### 发现的问题
+### Issues Found
 
-1. **问题描述**：[具体问题]
-   - **影响范围**：[哪些功能受影响]
-   - **解决方案**：[如何解决]
-   - **状态**：[待解决 | 已解决]
+1. **Issue description**: [specific issue]
+   - **Impact scope**: [affected functionality]
+   - **Resolution**: [how it was resolved]
+   - **Status**: [Open | Resolved]
 
-### 优化建议
+### Optimization Suggestions
 
-1. [建议 1]
-2. [建议 2]
+1. [Suggestion 1]
+2. [Suggestion 2]
 
-### 下一步行动
+### Next Actions
 
-- [ ] 部署到生产环境
-- [ ] 配置 Let's Encrypt 证书
-- [ ] 设置监控告警
-- [ ] 执行性能压测
+- [ ] Deploy to production
+- [ ] Configure Let's Encrypt certificates
+- [ ] Set up monitoring alerts
+- [ ] Run performance load tests
 
-### 签名确认
+### Sign-off
 
-验证人员：__________  日期：__________
-审核人员：__________  日期：__________
+Verified by: __________  Date: __________
+Reviewed by: __________  Date: __________
 ```
 
 ---
 
-## 总结
+## Summary
 
-本验证清单涵盖了 fulla 系统的所有核心功能：
+This verification checklist covers all core functionality of the fulla system:
 
-- **基础设施**：Docker 容器、网络、存储卷
-- **数据层**：PostgreSQL 数据库、Redis 缓存
-- **业务层**：OAuth2 核心流程、管理后台 API
-- **表现层**：Vue.js 用户前端、管理后台
-- **安全性**：认证、授权、令牌管理
-- **可观测性**：日志、指标、健康检查
+- **Infrastructure**: Docker containers, networking, storage volumes
+- **Data layer**: PostgreSQL database, Redis cache
+- **Business layer**: OAuth2 core flows, admin console APIs
+- **Presentation layer**: Vue.js user frontend, admin console
+- **Security**: authentication, authorization, token management
+- **Observability**: logs, metrics, health checks
 
-**验证通过标准**：
-- 所有容器状态为 `Up`
-- 后端健康检查通过
-- 数据库表结构完整（V026 后共 21 张 public 表）
-- 管理员账号可用
-- OAuth2 核心流程（授权、令牌、内省、撤销）正常
-- 前端页面可访问并完成基本操作
+**Pass criteria**:
+- All containers have a status of `Up`
+- Backend health check passes
+- Database table structure is complete (21 public tables in total after V026)
+- The admin account is usable
+- OAuth2 core flows (authorization, tokens, introspection, revocation) work correctly
+- Frontend pages are accessible and basic operations complete successfully
 
-完成本清单验证后，系统即可投入生产使用。
+Once this checklist has been fully verified, the system is ready for production use.

--- a/docs/sdk/sdk-integration-guide.md
+++ b/docs/sdk/sdk-integration-guide.md
@@ -1,40 +1,28 @@
-# SDK 集成指南（发布产物消费）
+# SDK Integration Guide (Consuming Release Artifacts)
 
-如何获取并集成 Fulla 的发布产物：SDK 二进制包（库 + 头 +
-`fulla-*Config.cmake`）与 GHCR 容器镜像。运行时行为承诺（线程 / ABI /
-异常 / 日志 / 插件注册）见 [SDK Runtime Contract](sdk-runtime-contract)，
-本文只讲"怎么拿、怎么接"。发布流水线为
-`.github/workflows/release.yml`（严格 SemVer tag `vX.Y.Z` 触发）。
+How to obtain and integrate fulla's release artifacts: the SDK binary package (libraries + headers + `fulla-*Config.cmake`) and the GHCR container images. For runtime behavior guarantees (threading / ABI / exceptions / logging / plugin registration), see the [SDK Runtime Contract](sdk-runtime-contract) — this document covers only how to obtain and wire everything up. The release pipeline is `.github/workflows/release.yml` (triggered by a strict SemVer tag `vX.Y.Z`).
 
-> 非 C++ 消费者：官方维护的 **Python**（PyPI [`fulla-oauth2`](https://pypi.org/project/fulla-oauth2/)）与
-> **Go**（`github.com/voidvec/fulla/clients/go`）HTTP 客户端开箱即用，
-> 见 [clients/](https://github.com/voidvec/fulla/tree/master/clients)。
+> Non-C++ consumers: the officially maintained **Python** (PyPI [`fulla-oauth2`](https://pypi.org/project/fulla-oauth2/)) and **Go** (`github.com/voidvec/fulla/clients/go`) HTTP clients work out of the box; see [clients/](https://github.com/voidvec/fulla/tree/master/clients).
 
 ---
 
-## 1. 发布产物清单
+## 1. Release Artifact Inventory
 
-| 产物 | 位置 | 说明 |
+| Artifact | Location | Notes |
 |------|------|------|
-| SDK 包 `fulla-sdk-<ver>-linux-x86_64.tar.gz` | GitHub Release 附件 | 8 个静态库 + `include/fulla/**` 头 + `lib/cmake/fulla-*/{Config,ConfigVersion,Targets}.cmake`（附 `.sha256`） |
-| 后端镜像 | `ghcr.io/voidvec/fulla-backend:<ver>` | 多架构（amd64 + arm64），入口 `:5555`，`/health` 探活 |
-| 用户前端镜像 | `ghcr.io/voidvec/fulla-frontend:<ver>` | nginx 静态托管，`:80` |
-| 管理台镜像 | `ghcr.io/voidvec/fulla-admin:<ver>` | nginx 静态托管 `/admin`，`:80` |
+| SDK package `fulla-sdk-<ver>-linux-x86_64.tar.gz` | GitHub Release attachment | 8 static libraries + `include/fulla/**` headers + `lib/cmake/fulla-*/{Config,ConfigVersion,Targets}.cmake` (with `.sha256`) |
+| Backend image | `ghcr.io/voidvec/fulla-backend:<ver>` | Multi-arch (amd64 + arm64), entry port `:5555`, `/health` liveness probe |
+| User frontend image | `ghcr.io/voidvec/fulla-frontend:<ver>` | nginx static hosting, `:80` |
+| Admin console image | `ghcr.io/voidvec/fulla-admin:<ver>` | nginx static hosting of `/admin`, `:80` |
 
-镜像另有 `latest` 标签；`<ver>-amd64` / `<ver>-arm64` 为单架构中间标签。
-服务器可执行文件**不在** SDK 包内——产品部署走镜像通道。
+The images also carry a `latest` tag; `<ver>-amd64` / `<ver>-arm64` are single-arch intermediate tags. The server executable is **not** part of the SDK package — product deployment goes through the image channel.
 
-## 2. SDK 包前置条件（先读）
+## 2. SDK Package Prerequisites (Read This First)
 
-- **v1.x 只承诺源码级 SemVer，不承诺二进制 ABI**（契约 §2）。发布的
-  `linux-x86_64` 静态库按 Release 流水线的工具链编译（ubuntu-24.04 /
-  gcc / libstdc++ / C++17 / Conan 锁定依赖）；工具链不匹配时**请改用源码
-  集成**（`add_subdirectory` 或自行 `cmake --install`，同一 SDK 面）。
-- 第三方依赖（Drogon / OpenSSL / jsoncpp 等）**不在包内**。消费方用仓库根
-  的 `conanfile.py` + `conan.lock` 解析同版本依赖，保证 `find_dependency`
-  闭包与库编译时一致。
+- **v1.x guarantees only source-level SemVer, not binary ABI** (Contract §2). The published `linux-x86_64` static libraries are compiled with the Release pipeline's toolchain (ubuntu-24.04 / gcc / libstdc++ / C++17 / Conan-locked dependencies); if your toolchain does not match, **fall back to source integration** (`add_subdirectory`, or run `cmake --install` yourself — the same SDK surface).
+- Third-party dependencies (Drogon / OpenSSL / jsoncpp, etc.) are **not** included in the package. Consumers resolve the same dependency versions using the repository root's `conanfile.py` + `conan.lock`, ensuring the `find_dependency` closure matches what the libraries were compiled against.
 
-## 3. find_package 集成步骤
+## 3. find_package Integration Steps
 
 ```bash
 # 1) 解包
@@ -52,7 +40,7 @@ cmake -S . -B build \
 cmake --build build -j
 ```
 
-CMakeLists 侧：
+On the CMakeLists side:
 
 ```cmake
 # 全栈宿主：一个包拉全闭包（common/oauth2/identity/storage-*/Drogon/OpenSSL/CURL）
@@ -65,61 +53,38 @@ find_package(fulla-storage-memory CONFIG REQUIRED)
 target_link_libraries(my-engine PRIVATE fulla::oauth2 fulla::storage::memory)
 ```
 
-可用包与导出目标：`fulla-common`→`fulla::common`（另含
-`fulla::common::testing`）、`fulla-oauth2`→`fulla::oauth2`、
-`fulla-identity`→`fulla::identity`、
-`fulla-storage-{memory,redis,postgres}`→`fulla::storage::{memory,redis,postgres}`、
-`fulla-drogon`→`fulla::drogon`。版本兼容为 SameMajorVersion
-（`find_package(fulla-drogon 1.0 CONFIG REQUIRED)` 可锁 major）。
+Available packages and exported targets: `fulla-common`→`fulla::common` (also provides `fulla::common::testing`), `fulla-oauth2`→`fulla::oauth2`, `fulla-identity`→`fulla::identity`, `fulla-storage-{memory,redis,postgres}`→`fulla::storage::{memory,redis,postgres}`, and `fulla-drogon`→`fulla::drogon`. Version compatibility is SameMajorVersion (`find_package(fulla-drogon 1.0 CONFIG REQUIRED)` pins the major version).
 
-参考消费方（随仓库 CI 持续验证）：
+Reference consumers (continuously verified by the repository CI):
 
-- `examples/full-stack-host/`：完整 HTTP 宿主，`find_package(fulla-drogon)`
-  复用产品 controllers / OAuth2Plugin / views。Release 流水线用它对**安装
-  前缀**做消费冒烟（`ctest -L SdkSmoke` 则对 build-tree 做同样验证）。
-- `examples/third-party-host/`：最小引擎消费方，只链 Domain 层四个包。
+- `examples/full-stack-host/`: a complete HTTP host that uses `find_package(fulla-drogon)` to reuse the product controllers / OAuth2Plugin / views. The Release pipeline uses it to run a consumption smoke test against the **install prefix** (`ctest -L SdkSmoke` performs the same verification against the build tree).
+- `examples/third-party-host/`: a minimal engine consumer that links only the four Domain-layer packages.
 
-## 4. 插件注册与 whole-archive（H1/F1/H5 口径）
+## 4. Plugin Registration and whole-archive (H1/F1/H5 Framing)
 
-- 插件本体当前以 **OBJECT 库**链入宿主，目标文件逐个直接链接，自注册符号
-  不会被裁剪——**当前不需要 whole-archive**。
-- 发布的 SDK 包中 `fulla::drogon` 是常规静态库，但插件注册走
-  `config.json` `plugins[].name = "OAuth2Plugin"` 反射 + 显式
-  `registerAllControllers()`（见 full-stack-host 的 main.cc），同样不依赖
-  链接器保留未引用符号。若消费方自建**依赖静态初始化自注册**的封装，须
-  自行 `-Wl,--whole-archive` 包裹对应库。
-- 类名 / config schema 稳定性承诺见契约 §6。
+- The plugin itself is currently linked into the host as an **OBJECT library**: the object files are linked in directly, one by one, so self-registration symbols cannot be stripped — **whole-archive is not needed today**.
+- In the published SDK package, `fulla::drogon` is a regular static library, but plugin registration goes through `config.json` `plugins[].name = "OAuth2Plugin"` reflection plus an explicit `registerAllControllers()` (see full-stack-host's main.cc); likewise, it does not rely on the linker retaining unreferenced symbols. If a consumer builds a wrapper that **depends on static-initialization self-registration**, they must wrap the corresponding library with `-Wl,--whole-archive` themselves.
+- For the class-name / config-schema stability guarantees, see Contract §6.
 
-## 5. 镜像使用
+## 5. Using the Images
 
 ```bash
 docker pull ghcr.io/voidvec/fulla-backend:1.0.0
 ```
 
-三镜像与 `deploy/docker/docker-compose.yml` 的构建目标一一对应
-（`backend-runtime` / `frontend-runtime` / `frontends/admin/Dockerfile`），
-环境变量与挂载约定直接照搬 compose 文件的 `fulla-backend` 段
-（`FULLA_DB_HOST` / `FULLA_REDIS_HOST` / `FULLA_AUTO_MIGRATE` 等）。
+The three images correspond one-to-one to the build targets in `deploy/docker/docker-compose.yml` (`backend-runtime` / `frontend-runtime` / `frontends/admin/Dockerfile`); environment variables and mount conventions are taken directly from the compose file's `fulla-backend` service section (`FULLA_DB_HOST` / `FULLA_REDIS_HOST` / `FULLA_AUTO_MIGRATE`, etc.).
 
-## 6. 发布流程（维护者）
+## 6. Release Process (Maintainers)
 
-1. 确认三源版本一致（`cmake/Version.cmake` 为单一事实源；api-diff 在 CI
-   强制其与根 `CMakeLists.txt`、`conanfile.py` 一致）且 API 基线已按
-   SemVer 规则更新（`tools/api-diff/`）。
-2. （可选）本地刷新 CHANGELOG.md：
+1. Confirm that the three version sources agree (`cmake/Version.cmake` is the single source of truth; api-diff enforces in CI that it matches the root `CMakeLists.txt` and `conanfile.py`) and that the API baseline has been updated according to SemVer rules (`tools/api-diff/`).
+2. (Optional) Refresh CHANGELOG.md locally:
    `git cliff --unreleased --tag vX.Y.Z --prepend CHANGELOG.md`
-   （配置见根目录 `cliff.toml`；发布工作流只生成 Release notes，
-   不会从 tag ref 回推提交）。
-3. 打严格 SemVer tag：`git tag v1.0.1 && git push origin v1.0.1`。带后缀
-   的 tag（如 `v1.0.0-rc1`）**不会**触发发布。
-4. `release.yml` 自动执行：tag/版本一致性校验 → SDK 打包 + 安装树消费
-   冒烟 → amd64/arm64 原生构建三镜像 → 多架构 manifest（`<ver>` +
-   `latest`）→ cosign keyless 按 digest 签名三镜像 + syft 生成 SPDX
-   SBOM（三镜像 + 源码树）→ GitHub Release（git-cliff 生成 notes，
-   挂 SDK 附件与全部 SBOM）。
-5. `workflow_dispatch` 手动触发 = 干跑（全量构建但不推送、不发 Release）。
+   (configuration lives in the root `cliff.toml`; the release workflow only generates the Release notes and never back-fills commits from the tag ref).
+3. Create a strict SemVer tag: `git tag v1.0.1 && git push origin v1.0.1`. Tags with a suffix (e.g. `v1.0.0-rc1`) do **not** trigger a release.
+4. `release.yml` then runs automatically: tag/version consistency checks → SDK packaging + install-tree consumption smoke test → native builds of the three images for amd64/arm64 → multi-arch manifest (`<ver>` + `latest`) → cosign keyless signing of the three images by digest + syft-generated SPDX SBOMs (three images + source tree) → GitHub Release (notes generated by git-cliff, with the SDK attachment and all SBOMs attached).
+5. A manual `workflow_dispatch` trigger = dry run (full build, but nothing is pushed and no Release is published).
 
-### 验证发布产物（消费方）
+### Verifying Release Artifacts (Consumers)
 
 ```sh
 # 镜像签名（keyless：身份 = release.yml 工作流，无需公钥分发）
@@ -133,11 +98,11 @@ sha256sum -c fulla-sdk-<ver>-linux-x86_64.tar.gz.sha256
 ```
 
 
-## Quickstart：嵌入你自己的 Drogon 宿主
+## Quickstart: Embedding fulla into Your Own Drogon Host
 
-除 `find_package` 外只需两步（详见上文第 3 节的包引入）：
+Only two steps beyond `find_package` (for the package import, see Section 3 above):
 
-**1. 在宿主 `config.json` 激活插件**（自动注册协议路由与 Filter）：
+**1. Activate the plugin in the host's `config.json`** (protocol routes and Filters are registered automatically):
 
 ```json
 {
@@ -155,7 +120,7 @@ sha256sum -c fulla-sdk-<ver>-linux-x86_64.tar.gz.sha256
 }
 ```
 
-**2. 用 `AuthorizationFilter` 保护业务 API**（全限定名 `fulla::drogon::filters::AuthorizationFilter`）：
+**2. Protect business APIs with `AuthorizationFilter`** (fully qualified name `fulla::drogon::filters::AuthorizationFilter`):
 
 ```cpp
 METHOD_LIST_BEGIN
@@ -164,6 +129,6 @@ ADD_METHOD_TO(UserApi::getProfile, "/api/me", drogon::Get,
 METHOD_LIST_END
 ```
 
-注意：链接 `fulla::drogon` 后 Controller/Filter 由 Drogon 启动时自动注册，勿手动调用初始化宏；PostgreSQL 存储需先执行 `apps/server/migrations/`（或 `FULLA_AUTO_MIGRATE=true`）。
+Note: once `fulla::drogon` is linked, Controllers/Filters are registered automatically at Drogon startup — do not invoke the initialization macros manually; the PostgreSQL storage requires running `apps/server/migrations/` first (or setting `FULLA_AUTO_MIGRATE=true`).
 
-> 本节合并自已退役的 plugin-integration.md（docs 治理 A2）。
+> This section was merged in from the retired plugin-integration.md (docs governance A2).

--- a/docs/sdk/sdk-runtime-contract.md
+++ b/docs/sdk/sdk-runtime-contract.md
@@ -1,72 +1,45 @@
 # SDK Runtime Contract
 
-对外契约声明：Fulla SDK（`fulla::common` / `fulla::oauth2` /
-`fulla::identity` / `fulla::storage-*` / `fulla::drogon`）在 v1.x
-期间对消费者承诺的线程模型、ABI、异常、日志与依赖边界。
+External contract statement: the threading model, ABI, exceptions, logging, and dependency boundaries that the fulla SDK (`fulla::common` / `fulla::oauth2` / `fulla::identity` / `fulla::storage-*` / `fulla::drogon`) commits to for consumers during v1.x.
 
-本文档是对外承诺的单一出处；SDK 头文件注释与本文冲突时以本文为准并修头。
+This document is the single source of truth for external commitments; wherever SDK header comments conflict with it, this document prevails and the headers are to be fixed.
 
 ---
 
-## 1. 线程模型
+## 1. Threading Model
 
-- Domain 服务（`libs/oauth2`、`libs/identity`）**不自持事件循环**；所有异步
-  操作经回调返回。
-- **回调可能在任意 Drogon IO 线程触发，不保证是调用线程**。消费者不得假设
-  线程亲和性；需要回到特定线程时由消费者自行投递。
-- 只读单例（如 `JwkManager`）遵循 **init-once-then-read-only**：在服务开始
-  接受请求前完成一次性 `init()`，之后以 `shared_ptr<const T>` 发布，运行期
-  不再变更。消费者在 SDK 装配完成后并发读取是安全的。
-- 服务对象持有 `shared_ptr` 仓储句柄保证生命周期；异步续体一律捕获
-  `auto self = shared_from_this()`，禁止 `[this]` / `[&]`。
+- Domain services (`libs/oauth2`, `libs/identity`) **do not own an event loop**; all asynchronous operations return via callbacks.
+- **Callbacks may fire on any Drogon IO thread — the calling thread is not guaranteed**. Consumers must not assume thread affinity; when work must return to a specific thread, the consumer is responsible for dispatching it there.
+- Read-only singletons (e.g. `JwkManager`) follow **init-once-then-read-only**: a one-shot `init()` completes before the service starts accepting requests; the object is then published as `shared_ptr<const T>` and never mutated afterwards. Concurrent reads by consumers are safe once SDK assembly is complete.
+- Service objects hold `shared_ptr` repository handles to guarantee lifetimes; async continuations always capture `auto self = shared_from_this()` — `[this]` / `[&]` are forbidden.
 
-## 2. ABI 稳定性
+## 2. ABI Stability
 
-- v1.x **仅支持 `find_package` 源码集成，不承诺二进制 ABI**。
-- 语义化版本只覆盖**源码级 API**：公共头 `include/fulla/**` 遵循
-  SemVer，破坏性变更必须升 major（由 api-diff 工具在 CI 强制）。
-- 跨编译器 / 跨 STL 混用预编译二进制不在支持范围；进入 Conan 二进制包
-  分发阶段后再单独制定 ABI 策略。
-- 弃用流程：`[[deprecated]]` 标注 + 至少一个 minor 周期过渡后方可移除。
+- v1.x **supports `find_package` source integration only and makes no binary-ABI commitment**.
+- Semantic versioning covers the **source-level API** only: public headers under `include/fulla/**` follow SemVer, and breaking changes require a major-version bump (enforced in CI by the api-diff tool).
+- Mixing precompiled binaries across compilers / STLs is out of scope; a dedicated ABI policy will be defined separately once the project moves to Conan binary-package distribution.
+- Deprecation process: `[[deprecated]]` annotation + at least one minor-cycle transition period before removal.
 
-## 3. 异常安全约定
+## 3. Exception-Safety Contract
 
-- Domain 公共 API 以 `Result<T, Error>` 返回**可预期错误**，不用异常表达
-  业务失败。
-- 仅在不可恢复的编程错误（契约违反、断言级问题）抛异常。
-- 存储底层异常（如 `DrogonDbException`）**必须在 Adapter 层
-  （`libs/storage-*`、`libs/drogon`）捕获并转为 `Error`，不得穿透到
-  Domain 回调**。消费者在 Domain 回调内无需 try/catch 存储异常。
+- Domain public APIs return **expected errors** via `Result<T, Error>`; exceptions are not used to express business failure.
+- Exceptions are thrown only for unrecoverable programming errors (contract violations, assertion-level problems).
+- Storage-level exceptions (e.g. `DrogonDbException`) **must be caught in the Adapter layer (`libs/storage-*`, `libs/drogon`) and converted to `Error` — they must not leak into Domain callbacks**. Consumers need no try/catch for storage exceptions inside Domain callbacks.
 
-## 4. 日志抽象
+## 4. Logging Abstraction
 
-- Domain 代码经 `common::ports::ILogger` 端口输出日志，**不直接使用
-  Drogon `LOG_*` 宏**（arch-guard 强制 Domain 层不 include drogon 头）。
-- SDK 默认提供 Drogon 日志适配实现（`libs/drogon` Adapter）；脱离 Drogon
-  宿主的消费者可注入自己的 `ILogger` 实现替换。
+- Domain code emits logs through the `common::ports::ILogger` port and **does not use Drogon `LOG_*` macros directly** (arch-guard enforces that the Domain layer does not include drogon headers).
+- The SDK provides a default Drogon logging adapter implementation (the `libs/drogon` Adapter); consumers hosted outside Drogon can inject their own `ILogger` implementation as a replacement.
 
-## 5. 依赖声明
+## 5. Dependency Declarations
 
-- 特性面依赖由根 `conanfile.py` 的 **`with_webauthn` / `with_identity` /
-  `with_social` option 显式 gate**，不作为传递依赖的隐式惊喜。
-  NOTE: 真实 WebAuthn（FIDO2）需要的 CBOR 解码依赖（`libcbor`）曾在此
-  声明，但当前 WebAuthn 控制器是非加密 stub（不消费任何 CBOR），
-  `libcbor` 已作为死依赖移除；待真实 WebAuthn 加密落地时需重新添加
-  （详见 `conanfile.py` 对应注释）。
-- 关闭选项（如 `-o with_webauthn=False`）会同步映射到 CMake 侧
-  `WITH_*` 变量并裁剪对应编译面，消费者可据此收缩依赖表面。
+- Feature-surface dependencies are **explicitly gated by the root `conanfile.py`'s `with_webauthn` / `with_identity` / `with_social` options**, not smuggled in as transitive surprises.
+  NOTE: the CBOR decoding dependency (`libcbor`) required by real WebAuthn (FIDO2) used to be declared here, but the current WebAuthn controller is a non-cryptographic stub (it consumes no CBOR), so `libcbor` has been removed as a dead dependency; it must be re-added once real WebAuthn cryptography lands (see the corresponding comment in `conanfile.py`).
+- Disabling an option (e.g. `-o with_webauthn=False`) maps through to the CMake-side `WITH_*` variables and prunes the corresponding compiled surface, so consumers can shrink their dependency footprint accordingly.
 
-## 6. 插件注册与配置契约（宿主集成）
+## 6. Plugin Registration and Configuration Contract (Host Integration)
 
-- `OAuth2Plugin` 类名与 config `plugins[].name` 反射加载契约**保持稳定**
-  （方案 A）：各 config（`config.{json,dev,ci,prod,bench}.json`）中
-  `"plugins":[{"name":"OAuth2Plugin","config":{...}}]` 的类名字符串与
-  `config{}` 块 schema 是产品配置契约的一部分，v1.x 不改名。
-- 插件本体以 CMake **OBJECT 库**形态链接进宿主：目标文件逐个直接链入，
-  不存在静态库按需抽取丢弃自注册符号的问题，因此**当前不需要
-  whole-archive**。
-- 若未来改为**静态库形态分发**插件本体，链接器可能裁剪插件自注册符号导致
-  Drogon 反射 "plugin not found"——届时必须引入 whole-archive（或等价
-  强制链接方案）；`OAuth2Plugin` 无 `AutoCreation` 参数可用，不适用免
-  whole-archive 方案。
-- 第三方宿主集成示例见 `examples/third-party-host/`。
+- The `OAuth2Plugin` class name and the config `plugins[].name` reflective-loading contract **remain stable** (Option A): the class-name string in `"plugins":[{"name":"OAuth2Plugin","config":{...}}]` across the configs (`config.{json,dev,ci,prod,bench}.json`) and the schema of the `config{}` block are part of the product configuration contract and will not be renamed in v1.x.
+- The plugin itself is linked into the host as a CMake **OBJECT library**: object files are linked in directly, one by one, so there is no static-library on-demand extraction that could drop self-registration symbols — **whole-archive is not needed today**.
+- If the plugin is ever **distributed in static-library form**, the linker may strip its self-registration symbols and Drogon reflection will fail with "plugin not found" — at that point whole-archive (or an equivalent forced-linking scheme) becomes mandatory; `OAuth2Plugin` has no `AutoCreation` parameter available, so a whole-archive-free scheme is not applicable.
+- See `examples/third-party-host/` for a third-party host integration example.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,16 +1,21 @@
 // fulla.dev — Docusaurus site.
-// Core decision (docs/documentation-governance.md §四): the repo's docs/ tree
-// IS the site source (docs.path below points one level up). No content copies,
-// no sync scripts — a drifted duplicate is exactly what the governance kills.
-// Local-only process docs live in docs-local/ (outside this tree, gitignored).
+// Core decision (docs/documentation-governance.md §4): the repo's docs trees
+// ARE the site source (docs.path below points one level up for the default
+// en locale; the zh-CN translation tree lives under website/i18n/zh-CN/).
+// No content copies between locales' structure — same layout, same URLs.
+// Local-only process docs live in docs-local/ (outside the trees, gitignored).
 
 const lightCodeTheme = require('prism-react-renderer').themes.github;
 const darkCodeTheme = require('prism-react-renderer').themes.dracula;
+// Locale-aware labels for config strings: Docusaurus sets DOCUSAURUS_CURRENT_LOCALE
+// when loading the config for each locale's build pass.
+const CURRENT_LOCALE = process.env.DOCUSAURUS_CURRENT_LOCALE || 'en';
+const L = (en, zh) => (CURRENT_LOCALE === 'zh-CN' ? zh : en);
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'fulla',
-  tagline: '高性能开源 IAM 内核 · C++17',
+  tagline: 'High-performance open-source IAM core · C++17',
   url: 'https://fulla.dev',
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -18,12 +23,16 @@ const config = {
   organizationName: 'voidvec',
   projectName: 'fulla',
 
-  // Chinese-primary site (governance v3 §四): docs are simplified Chinese;
-  // English lives in README.md on GitHub. i18n ready if an English locale
-  // is ever added (Docusaurus native, low switching cost).
+  // English-primary site (governance v4): '/' serves English, '/zh-CN'
+  // serves the Chinese translation, navbar carries a locale switcher.
+  // Both locales build in CI; translation duty = same-PR dual writes.
   i18n: {
-    defaultLocale: 'zh-CN',
-    locales: ['zh-CN'],
+    defaultLocale: 'en',
+    locales: ['en', 'zh-CN'],
+    localeConfigs: {
+      en: { label: 'English', htmlLang: 'en' },
+      'zh-CN': { label: '简体中文', htmlLang: 'zh-CN' },
+    },
   },
 
   presets: [
@@ -36,6 +45,7 @@ const config = {
           routeBasePath: '/docs',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/voidvec/fulla/edit/master/docs',
+          editLocalizedFiles: true,
           showLastUpdateTime: true,
           exclude: [
             'README.md',
@@ -80,14 +90,18 @@ const config = {
         title: 'fulla',
         logo: { alt: 'fulla', src: 'img/favicon.svg' },
         items: [
-          { to: '/docs/intro', label: '文档', position: 'left' },
+          { to: '/docs/intro', label: L('Docs', '文档'), position: 'left' },
           { to: '/docs/domains/api-reference', label: 'API', position: 'left' },
           {
             href: 'https://github.com/voidvec/fulla/blob/master/benchmarks/competitors/results/COMPARISON.md',
-            label: '性能基准',
+            label: L('Benchmarks', '性能基准'),
             position: 'left',
           },
           { to: '/docs/adr/ADR-0001', label: 'ADR', position: 'left' },
+          {
+            type: 'localeDropdown',
+            position: 'right',
+          },
           {
             href: 'https://github.com/voidvec/fulla',
             label: 'GitHub',
@@ -99,33 +113,36 @@ const config = {
         style: 'dark',
         links: [
           {
-            title: '文档',
+            title: L('Docs', '文档'),
             items: [
-              { label: '开始', to: '/docs/intro' },
-              { label: '架构总览', to: '/docs/architecture/architecture-overview' },
-              { label: 'API 参考', to: '/docs/domains/api-reference' },
-              { label: 'SDK 集成', to: '/docs/sdk/sdk-integration-guide' },
+              { label: L('Get Started', '开始'), to: '/docs/intro' },
+              { label: L('Architecture', '架构总览'), to: '/docs/architecture/architecture-overview' },
+              { label: L('API Reference', 'API 参考'), to: '/docs/domains/api-reference' },
+              { label: L('SDK Integration', 'SDK 集成'), to: '/docs/sdk/sdk-integration-guide' },
             ],
           },
           {
-            title: '资源',
+            title: L('Resources', '资源'),
             items: [
-              { label: '生产部署', to: '/docs/operate/deployment' },
-              { label: '性能基准', href: 'https://github.com/voidvec/fulla/blob/master/benchmarks/competitors/results/COMPARISON.md' },
-              { label: 'OpenAPI 契约', href: 'https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml' },
-              { label: '架构决策记录', to: '/docs/adr/ADR-0001' },
+              { label: L('Production Deployment', '生产部署'), to: '/docs/operate/deployment' },
+              { label: L('Benchmarks', '性能基准'), href: 'https://github.com/voidvec/fulla/blob/master/benchmarks/competitors/results/COMPARISON.md' },
+              { label: L('OpenAPI Contract', 'OpenAPI 契约'), href: 'https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml' },
+              { label: L('ADRs', '架构决策记录'), to: '/docs/adr/ADR-0001' },
             ],
           },
           {
-            title: '社区',
+            title: L('Community', '社区'),
             items: [
               { label: 'GitHub', href: 'https://github.com/voidvec/fulla' },
-              { label: '中文 Wiki', href: 'https://github.com/voidvec/fulla/wiki' },
-              { label: '问题反馈', href: 'https://github.com/voidvec/fulla/issues' },
+              { label: L('Chinese Wiki', '中文 Wiki'), href: 'https://github.com/voidvec/fulla/wiki' },
+              { label: L('Issues', '问题反馈'), href: 'https://github.com/voidvec/fulla/issues' },
             ],
           },
         ],
-        copyright: `Copyright © 2026 Luca · MIT License · 本站内容来自仓库 docs/ 目录（单一事实源）`,
+          copyright: L(
+            'Copyright © 2026 Luca · MIT License · Site content from the repo’s docs tree (single source of truth)',
+            'Copyright © 2026 Luca · MIT License · 本站内容来自仓库 docs 目录（单一事实源）',
+          ),
       },
       prism: {
         theme: lightCodeTheme,

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0001.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0001.md
@@ -1,0 +1,19 @@
+---
+adr: 0001
+title: 产品主线与双可嵌入 SDK 的架构及依赖铁律
+date: 2026-08-26
+status: Accepted
+source: sdk-refactor design.md §2/§4.1/§5.2（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+仓库同时承载一个可直接部署的授权服务器产品与可复用的协议引擎。若不约束依赖方向，Domain 代码会被框架类型渗透，SDK 消费方将被迫引入 Drogon。
+
+## 决策
+
+以产品为主线交付，同时沉淀 fulla::oauth2 与 fulla::identity 两个可嵌入 SDK。Domain 三包（common/oauth2/identity）禁止 include Drogon（允许 jsoncpp）；oauth2 与 identity 互不编译依赖；跨包端口全部下沉 common；apps/server 是唯一装配点负责依赖注入；tools/arch-guard 在 CI 强制以上全部。
+
+## 后果与现状对照
+
+libs/ 下 7 个库目录（8 个 CMake 包，含 `common/testing`）与 include/fulla/*/ports/ 均按此落地；arch-guard（tools/arch-guard）是 CI 门禁。消费方可只用引擎 + 任意单存储后端。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0002.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0002.md
@@ -1,0 +1,19 @@
+---
+adr: 0002
+title: Drogon 自注册符号的链接与插件兼容策略
+date: 2026-08-26
+status: Accepted
+source: sdk-refactor design.md §5.5/§5.7（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+C++ 静态库中 Drogon 依赖静态初始化自注册；whole-archive 链接在多平台/多消费方场景 fragile 且拖入全部符号。
+
+## 决策
+
+Controller 采用 `HttpController<T,false>` + 显式 `registerController`，不依赖 whole-archive；OAuth2Plugin 保持类名与各 config（`config.{json,dev,ci,prod,bench}.json`）plugins 块的零改动（方案 A）。边界：若插件改为静态库分发，消费方仍需 whole-archive 才能拉入自注册符号。
+
+## 后果与现状对照
+
+SDK Smoke（find_package 全栈消费方）在 CI 验证该策略；examples/ 提供参考宿主。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0003.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0003.md
@@ -1,0 +1,19 @@
+---
+adr: 0003
+title: ErrorCatalog 单一权威来源与双通道错误处理
+date: 2026-08-26
+status: Accepted
+source: error-code-message-standardization design.md（AD-1..AD-6）+ auth-flow-error-code-gaps（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+错误码/文案/HTTP 状态分散在控制器内导致漂移；应用侧与协议侧错误体格式天然不同。
+
+## 决策
+
+全部错误码（含 OAuth2 协议码）的 code/numeric/category/HTTP 状态/默认文案以编译期 ErrorCatalog 为唯一权威；Application 端点走 ErrorResponder 错误信封，协议端点走 RFC 6749 错误体（含 Filter 层）；前端错误目录镜像后端并构建期校验（errorAdapter 纯函数）。原则：不同失败原因不得折叠进同一 code；例外：防枚举场景（账户锁定与密码错误同码）是刻意设计。
+
+## 后果与现状对照
+
+ErrorCatalog.cc（525 行）+ 单测强制文档同步（api-reference 错误表由测试校验）；PR#85 的 4006 即按此流程新增。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0004.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0004.md
@@ -1,0 +1,19 @@
+---
+adr: 0004
+title: Opaque Access Token 与凭据哈希存储、版本化迁移
+date: 2026-08-26
+status: Accepted
+source: production_hardening_spec.md §五（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+JWT access token 会扩大泄漏面且难以即时吊销；明文存储 token/secret 使数据库泄漏等于凭据泄漏。
+
+## 决策
+
+Access Token 保持 Opaque 随机串，资源服务器经 introspection（RFC 7662）验证，不引入 JWT access token（id_token 仍为 JWT）；数据库只存 SHA-256(token) 与 secret 哈希；schema 变更一律走只增不改的 V### 版本化迁移。落地注记：决策表原写 Argon2id，实际落地 PBKDF2-SHA256 310K 迭代（PasswordHasher 预留升级位）。
+
+## 后果与现状对照
+
+introspection/revocation 端点为公开契约；V001–V026 追加式演进；迁移不可变由 CI migration-check 门禁。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0005.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0005.md
@@ -1,0 +1,19 @@
+---
+adr: 0005
+title: email 为主登录标识
+date: 2026-08-26
+status: Accepted
+source: email-first-auth-design.md §7（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+username 与 email 双标识并存导致登录歧义与唯一约束冲突。
+
+## 决策
+
+登录标识按是否含 @ 分流（username 字符集与 email 互斥保证无歧义）；email 必填且注册/登录共用 normalizeEmail；username 可选但保留 UNIQUE（NULL 豁免）；登录链路验证最宽容（正则仅限注册/改密）；API 字段名沿用 username 保持兼容；OIDC name 回退 email。
+
+## 后果与现状对照
+
+V020 迁移在库；verification-checklist 等运维文档的登录口径以此为准。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0006.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0006.md
@@ -1,0 +1,19 @@
+---
+adr: 0006
+title: 异步回调生命周期模式
+date: 2026-08-26
+status: Accepted
+source: 并发审计报告四主线 + CacheMap 线程安全语义结论（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+Drogon 异步回调中裸 this 捕获与跨线程无锁访问是历史缺陷的主要来源（11 项审计缺陷）。
+
+## 决策
+
+带异步回调的对象一律 enable_shared_from_this；lambda 捕获 self/weak_ptr，禁止裸 this（禁协程）；初始化用 Meyers Singleton / call_once 消 SIOF；承认并依赖 drogon::CacheMap 自身互斥锁的线程安全（EventLoop* 仅驱动过期定时器，不做 loop 编排）；look-aside 缓存 stampede 属可接受的非线性一致。
+
+## 后果与现状对照
+
+该纪律写入 .claude/rules/db-operations.md 成为项目铁律；并发审计的 11 项缺陷全部修复并有回归测试。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0007.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0007.md
@@ -1,0 +1,19 @@
+---
+adr: 0007
+title: MFA 第二因子登录会话绑定
+date: 2026-08-26
+status: Accepted
+source: mfa-fix 设计档案（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+MFA verify 若不绑定首因子上下文，跨 client 混淆与 redirect_uri 旁路可组合出账户接管。
+
+## 决策
+
+MFA verify 必须校验：client 注册关系 + redirect_uri 白名单 + 与首因子登录一致的 pending 绑定（users.mfa_pending_client_id / mfa_pending_redirect_uri，验证后清 NULL 防重放）。所有新拒绝统一 AUTH_INVALID_CREDENTIALS 401，消除 client 注册枚举 oracle。已知接受的限制：mfa_token 无过期与并发覆盖。
+
+## 后果与现状对照
+
+V022 迁移在库；MfaController 按 pending 绑定实现。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0008.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0008.md
@@ -1,0 +1,19 @@
+---
+adr: 0008
+title: 首方 SPA 登录的凭证暴露面控制
+date: 2026-08-26
+status: Accepted
+source: mfa_auth_code_pkce_design.md §6/§7 + production_hardening_batch1_2 §1.1（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+SPA 登录若把 PKCE verifier/token 持久化到 storage，XSS 即等于会话劫持。
+
+## 决策
+
+首方登录保留 AJAX /oauth2/login（json=true）直取授权码，PKCE verifier 由闭包持有不持久化；第三方走 authorize 整页跳转 + sessionStorage 中转；access_token 仅存内存不落 localStorage；后端整页托管登录页方案经评审后搁置。安全表述采用修正口径：缩小暴露窗口而非根除泄露。
+
+## 后果与现状对照
+
+frontends/user 的 authService/http 按此实现；第三方集成路径在 oidc-guide 说明。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0009.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0009.md
@@ -1,0 +1,19 @@
+---
+adr: 0009
+title: ORM 生成模型豁免重命名与迁移冻结
+date: 2026-08-26
+status: Accepted
+source: repo-structure-refactor design.md §0/§1.2（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+drogon_ctl 生成的模型类若参与人工重命名，重生成即漂移；已应用迁移若被修改，多环境 schema 校验即失效。
+
+## 决策
+
+drogon_ctl 生成的 14 个模型类名/命名空间永不重命名（凌驾于统一命名风格之上，仅允许整目录搬迁）；已合并的 V### 迁移文件冻结，schema 变更只追加新版本。
+
+## 后果与现状对照
+
+该决策穿越 repo 重构与 SDK 重构两次验证；migration-check（M5）在 CI 强制迁移不可变；2026-08 更名工程中 oauth2_* 表名/类名保持正是此 ADR 的应用。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0010.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0010.md
@@ -1,0 +1,19 @@
+---
+adr: 0010
+title: 限流选型 Hodor
+date: 2026-08-26
+status: Accepted
+source: hodor-rate-limiter-migration 设计档案（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+自研 Redis 固定窗口限流 Filter 维护成本高且与存储耦合。
+
+## 决策
+
+全局侧限流采用 Drogon 官方 Hodor 插件：令牌桶、进程内 CacheMap（零外部依赖）、IP/用户/全局三级、trust_ips 白名单、纯 JSON 配置；弃用自研 Redis 固定窗口。拒绝体收编为错误信封 VALIDATION_RATE_LIMITED（429）。仅在 config.prod.json 挂载；认证侧防爆破由 F-018 失败计数限流另行承担（两者作用面不同）。
+
+## 后果与现状对照
+
+config.prod.json plugins 块在用；见 security-architecture 的限流节。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0011.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0011.md
@@ -1,0 +1,19 @@
+---
+adr: 0011
+title: 集成测试平台分档
+date: 2026-08-26
+status: Accepted
+source: http-integration-test-coverage-plan.md（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+Windows/macOS 无法容器化 PG/Redis，DB-backed 测试若三平台全跑则矩阵不可行。
+
+## 决策
+
+DB-backed 集成/契约测试只在 Linux CI 腿运行（配 PG/Redis 服务容器）；Windows/macOS 跑 memory-only 配置（FULLA_MEMORY_TESTS_ONLY=ON 剔除 SchemaSetup）；测试进程内起全量 app + SchemaManager 播种；社交登录/WebAuthn 控制器的覆盖不作为 HTTP 测试达标条件。
+
+## 后果与现状对照
+
+ci.yml 三平台矩阵按此分档；本地 full_test 走真实 DB。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0012.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0012.md
@@ -1,0 +1,19 @@
+---
+adr: 0012
+title: C++17 锁定与协程排除
+date: 2026-08-26
+status: Accepted
+source: async-refactor-assessment.md 蒸馏（原始档案已出库，git 历史可溯）
+---
+
+## 背景
+
+回调风格被诟病为回调地狱；C++20 协程可消除回调但带来 ABI/调试/栈追溯成本。
+
+## 决策
+
+保持 C++17 与回调风格：协程被排除的原因是 MSVC/gcc 对协程 ABI 仍不稳、栈追溯与崩溃报告在协程帧上失效、Drogon 官方 CoroMapper 与本项目 Mapper+Criteria 纪律（含 JOIN 禁令）不兼容。触发重评条件：工具链协程支持成熟且出现无法用回调表达的复杂控制流。
+
+## 后果与现状对照
+
+回调纪律由 ADR-0006 的生命周期模式约束；db-operations.md 明确禁 CoroMapper。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/oauth-oidc-compliance-audit.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/oauth-oidc-compliance-audit.md
@@ -1,0 +1,831 @@
+---
+title: 档案 · OAuth/OIDC 规范性审查报告（2026-08-07 基线）
+date: 2026-08-07
+status: 已整改（31 项发现全部修复并有回归测试守护）
+sidebar_label: 档案 · 合规尽调报告
+---
+
+> 本报告是 2026-08-07 对 fulla（时名 authforge）的完整 OAuth/OIDC 合规尽调
+> **基线快照**：逐条附 file:line 证据与规范章节引文。报告发布后所有发现均已在
+> 后续版本中修复（含 F-002 Critical 凭据哈希不一致等），并沉淀为回归测试；
+> 保留本档案作为第三方评估者可核查的信任资产。当前安全设计见
+> [security-architecture.md](../architecture/security-architecture.md)。
+
+# OAuth/OIDC 规范性审查报告 — fulla
+
+| 项目 | 内容 |
+|---|---|
+| 审查对象 | fulla (`test/coverage-push` 分支, 2026-08-07) |
+| 审查范围 | RFC 6749 / 6750 / 7662 / 7009 / 7636 / 8252 / 8628 / 8414 / 7519/7517/7515 / 7591/7592 / 9068 / 9700 + OIDC Core 1.0 / Discovery 1.0 / RP-Initiated Logout / Back-Channel Logout |
+| 审查方法 | 静态代码审查 + 规范条款逐条核验；所有判断附 `file:line` 证据 + 规范章节引文 |
+| 不在范围 | 动态渗透测试、性能/可用性评估、前端 SPA 实现审查 |
+| 评级分档 | 核心规范按 MUST/SHOULD 分档；OIDC profile 按「核心 MUST」「扩展 SHOULD」分档 |
+
+> 配套文档：审查计划（检查要点、检查方法、判定标准）见 `oauth-oidc-compliance-audit-plan.md`。本报告为评估结果（符合性评级、发现、整改）。
+
+---
+
+## 1. 执行摘要
+
+### 1.1 总体符合度
+
+fulla 在 **OAuth 2.0 核心（RFC 6749）的"快乐路径"**上基本合规：授权码与刷新令牌的生成、哈希存储、单次性、轮换、重用级联吊销都按规范实现；PKCE 的 S256 算法是规范正确的 `base64url(raw digest)`；introspect/revoke 的客户端认证模型近期（commit 246db32）已修正为 RFC 7662/7009 要求的客户端凭证模型。
+
+但存在 **若干违反 MUST 的实质性偏差**，集中在三类：
+
+1. **令牌端点客户端认证不完整** —— `refresh_token` grant 完全跳过客户端认证（违反 RFC 6749 §3.2.1 MUST）。
+2. **client_secret 哈希写入/校验算法不一致** —— 注册/管理路径写无盐大写 SHA-256，校验路径算有盐小写 SHA-256（违反 RFC 6749 §10.6 凭证保护 MUST，且事实上导致动态注册的客户端无法认证）。
+3. **OIDC 扩展能力大面积缺失** —— `prompt`/`max_age`/`auth_time`/`acr`/`amr`/`azp`/RP-Initiated Logout/nonce 防重放/id_token-on-refresh 均未实现，使本项目实际只能算"OAuth2 + 一个最小 id_token 签发"，而非完整 OIDC Provider。
+
+### 1.2 风险等级分布
+
+| 等级 | 数量 | 代表项 |
+|---|---|---|
+| **严重 (Critical)** | 1 | F-002 client_secret 哈希不一致导致动态注册客户端认证失败 |
+| **高 (High)** | 6 | refresh_token 无客户端认证、Redis 非常量时间比较、Redis refresh 存储空操作、authorization 端点错误未按 §4.1.2.1 重定向、device_authorization 未认证机密客户端、WWW-Authenticate Bearer 缺失 |
+| **中 (Medium)** | 9 | id_token 缺 auth_time/acr/amr/azp、refresh 不重发 id_token、PKCE 默认不强制、device slow_down 未发出、iss 硬编码、loopback 例外未实现、token 端点无限流、state 未 urlEncode、token_endpoint_auth_method 未持久化 |
+| **低 (Low)** | 7 | registration_endpoint 未广告、introspection 缺 jti/username、成功响应缺 Cache-Control、jti 不存在、claims_supported 与实际不符、OpenAPI grant_type 枚举缺 device_code、CORS 校验注释 |
+
+### 1.3 最高优先级 5 项
+
+| 编号 | 问题 | 风险 | 修复复杂度 |
+|---|---|---|---|
+| F-002 | client_secret 哈希写/读算法不一致 | Critical | 中（统一算法 + 数据迁移） |
+| F-003 | refresh_token grant 跳过客户端认证 | High | 低（加 `validateClient` 调用） |
+| F-004 | Redis 后端 client_secret 非常量时间比较 | High | 低 |
+| F-005 | Redis 后端 refresh_token 存储为空操作 | High | 中（实现 Redis save/getRefreshToken） |
+| F-007 | authorization 端点错误未按 §4.1.2.1 重定向 | High | 中（区分 redirectable vs client 错误） |
+
+---
+
+## 2. 评级尺度
+
+| 评级 | 定义 |
+|---|---|
+| **符合** | 满足规范条款的 MUST 与 SHOULD，无功能/安全偏差 |
+| **部分符合** | 实现核心要求但缺字段、缺边角 MUST 或不满足 SHOULD |
+| **不符合** | 违反某条 MUST，或实现存在功能性/安全性错误 |
+| **未实现** | 规范定义了能力但代码无对应实现（含 stub、advertised-but-missing） |
+
+OIDC profile 分档（按用户要求）：
+- **核心 MUST 档**：OIDC Core 中标 MUST 的条款（如 id_token 必备 claim、UserInfo 须校验 openid scope）
+- **扩展 SHOULD 档**：OIDC Core 的 SHOULD 条款，以及 Session Management / RP-Initiated Logout / Back-Channel Logout 等独立规范（这些虽非 OIDC Core 的 MUST，但是「可互操作的 OIDC Provider」的事实标配）
+
+风险等级独立于评级：一个"未实现"的扩展 SHOULD 可能只是 Medium，而一个"不符合"的核心 MUST 通常是 High/Critical。
+
+---
+
+## 3. 逐规范符合性评估
+
+### 3.1 RFC 6749 OAuth 2.0 Authorization Framework —— **部分符合**
+
+#### 3.1.1 §1.6 / §3.1.1 协议须运行于 HTTPS；redirect_uri 须 https —— **不符合（Medium）**
+
+- **检查方法**：Grep redirect_uri scheme 校验、loopback 例外。
+- **证据**：`libs/oauth2/include/fulla/oauth2/model/Client.h:86-90` 仅做 `std::find` 精确字符串匹配；`libs/drogon/src/validation/RuleEngine.cc:120-133` 的 regex `^https?://...` 同时接受 http 与 https；无任何代码强制 https 或实现 RFC 8252 §7.3 / RFC 6749 §3.1.2.1 的 loopback 端口通配。
+- **偏差**：redirect_uri 注册与匹配接受任意 scheme，未强制 https，未实现 loopback 例外。
+- **依据**：RFC 6749 §3.1.2.1 "the redirection endpoint SHOULD require the use of TLS"；§1.6 明确 TLS 为 MUST 级别的部署前提。
+- **见**：F-014。
+
+#### 3.1.2 §3.1.2.3 redirect_uri 须精确匹配 —— **符合**
+
+- **证据**：`Client.h:83-90` `isRegisteredRedirectUri` 用 `std::find(..., redirectUri) != ...end()`，注释明示"RFC 6749 §3.1.2.3 requires exact match, not prefix/pattern matching"。authorize 端 `libs/oauth2/src/protocol/ClientService.cc:32-44` 调用之；exchange 端 `PostgresGrantRepository.cc:181-189` 复核之。
+- **判定**：精确匹配、无通配、无前缀。**符合**。
+
+#### 3.1.3 §4.1.2 授权码：TTL ≤10min、一次性、绑定 —— **符合**
+
+- **TTL**：`libs/oauth2/src/protocol/TokenService.cc:151` `authCode.expiresAt = nowSeconds() + authCodeTtl_;`，默认 600s（`OAuth2Plugin.cc:53`），exchange 时校验（`TokenService.cc:226-230`）。
+- **一次性**：`PostgresGrantRepository.cc:165-176` 原子 CAS `UPDATE oauth2_codes SET used=true WHERE code=$1 AND used=false RETURNING *`；Memory 后端 `MemoryGrantRepository.cc:66-95` 用锁 + `used` 标志。
+- **绑定**：`TokenService.cc:144-151` 写入 `clientId/userId/scope/redirectUri/codeChallenge/codeChallengeMethod/nonce`；exchange 时校验 client_id（`:200-204`）、redirect_uri（`PostgresGrantRepository.cc:181-189`）、PKCE（`:206-219`）。
+- **判定**：**符合**。
+
+#### 3.1.4 §4.1.2.1 错误重定向 vs 直接错误 —— **不符合（High）**
+
+- **检查方法**：审 `AuthorizationEndpointController.cc` 各错误分支的响应方式。
+- **证据**：
+  - 无效 client_id → 直接 400（`AuthorizationEndpointController.cc:233-237`）
+  - 无效 redirect_uri → 直接 400（`:257-261`）
+  - scope 失败 → 直接 JSON（`:362-371`）
+  - 仅 consent-deny 一处按规范 `?error=access_denied&state=` 重定向（`SessionController.cc:728-737`）
+- **偏差**：RFC 6749 §4.1.2.1 规定——若请求的 `redirect_uri` 缺失/无效或 `client_id` 未知，AS 应直接告知用户错误（不重定向）；**但若 redirect_uri 与 client_id 均有效**，所有其他错误（access_denied、invalid_scope、unsupported_response_type、server_error 等）都**必须**以 `?error=&state=` 形式 302 重定向到 redirect_uri。本项目对所有非 consent-deny 错误一律直接 4xx，state 在这些情况下不回显。
+- **依据**：RFC 6749 §4.1.2.1。
+- **见**：F-007。
+
+#### 3.1.5 §4.1.3 authorization_code 兑换 —— **部分符合（Medium）**
+
+- **redirect_uri 比较可被绕过**：`PostgresGrantRepository.cc:181-189` 与 `MemoryGrantRepository.cc:80-87` 均以 `if (!redirectUri.empty() && redirectUri != stored)` 守卫比较。RFC 6749 §4.1.3 规定"if the `redirect_uri` was included in the initial authorization request **then** it MUST be included in the token request"——即签发时带了 redirect_uri，兑换时就必须带且必须匹配。当前实现允许兑换时**省略** redirect_uri 从而跳过比较。`RuleSet::oauth2Token`（`RuleSet.cc:360-376`）对 `code` 必填、`client_id` 选填，未强制 redirect_uri 在该场景下的必填性。
+- **client 绑定 / PKCE / 过期**：已实现（见 3.1.3）。
+- **见**：F-009。
+
+#### 3.1.6 §3.2.1 / §4.1.3 token 端点对所有机密客户端 MUST 认证 —— **不符合（High）**
+
+- **检查方法**：跟踪 4 种 grant 在 controller 入口的 `validateClient` 调用。
+- **证据**：
+  - authorization_code → `TokenService.cc:177-187` 先 `validateClient` ✅
+  - client_credentials → `TokenEndpointController.cc:733-775` 先 `validateClient` ✅
+  - device_code → `TokenEndpointController.cc:1227-1276` 先 `validateClient`（按 client_type 分支）✅
+  - **refresh_token → `TokenEndpointController.cc:679-711` 直接 `plugin->refreshAccessToken(refreshTokenStr, clientId, ...)`，无 `validateClient` 调用** ❌
+- **偏差**：refresh_token grant 仅在 `TokenService.cc:387-391` 做 `storedRt->clientId != clientId` 字符串比较，未校验 client_secret。**任何机密客户端只要持有一个他不该有的 refresh_token 字符串，配上任意 client_id 即可刷新**（client_id 必须匹配，但 client_id 不保密，攻击者从被泄漏的 refresh_token 关联日志即可推得）。这违反 RFC 6749 §3.2.1（"The authorization server MUST [...] authenticate the client if the client was issued credentials"）。
+- **依据**：RFC 6749 §3.2.1。
+- **见**：F-003。
+
+#### 3.1.7 §4.4 client_credentials —— **符合**
+
+- **仅限机密客户端**：`TokenEndpointController.cc:765-775` PUBLIC → `unauthorized_client`。
+- **不发 refresh_token**：`:825` 注释明确，`:853` 响应省略。
+- **scope 校验**：`:784-823` 超集 → `invalid_scope`；缺省取客户端注册的 scope 全集；注册 scope 为空且请求省略 → `invalid_scope`。
+- **subject 为 `client:<id>`**（`:839`），符合 RFC 6749 §4.4.3 的 M2M 语义。
+- **判定**：**符合**。
+
+#### 3.1.8 §6 refresh_token —— **部分符合（中，配合 3.1.6 看）**
+
+- **轮换**：每次刷新都发新 access + 新 refresh（`TokenService.cc:400-417`）。
+- **重用检测 + 级联吊销**：原子 CAS `atomicRevokeRefreshToken`（`PostgresTokenRepository.cc:404-446`）+ `revokeTokenFamily`（`:448-492`，按 family_id 批量吊销 refresh 与关联 access），审计 `refresh_token_reuse_detected`（`TokenService.cc:367-373`）。**符合 RFC 6749 §6 的推荐实践**。
+- **绑定 client_id 校验**：`TokenService.cc:387-391` 有比较，但配合 3.1.6 的"无认证"，仅是字符串比较，弱。
+- **Redis 后端失效**：`RedisTokenRepository.cc:155-165` `saveRefreshToken`/`getRefreshToken` 是空操作（注释 line 153-154 明示），`atomicRevokeRefreshToken` 永远返回 nullopt，故 Redis 部署下轮换/级联**完全不工作**。
+- **见**：F-005。
+
+#### 3.1.9 §5.1 成功响应 —— **部分符合（Low）**
+
+- **token_type=Bearer / expires_in**：齐备（`TokenService.cc:293,297,432,434`；`TokenEndpointController.cc:850-851,1147-1148`）。
+- **scope 回显**：client_credentials（`:852`）与 device_code（`:1150-1153`，仅非空时）回显；**authorization_code 与 refresh_token 不回显**（`TokenService.cc:291-299, 430-436`）。RFC 6749 §5.1 规定 scope 若与请求不同则 MUST 回显、相同则 OPTIONAL，缺失属轻微偏差。
+- **Cache-Control: no-store**：RFC 6749 §5.1 RECOMMENDS 此头于所有 token 响应；本项目仅错误响应加（`OAuth2ErrorHandler.cc:74-75`），成功响应不加。
+- **非标 `roles` 字段**：`TokenService.cc:299` 在 authorization_code 响应额外加 `roles`，非 RFC 6749 字段（可接受但应文档化）。
+- **见**：F-019。
+
+#### 3.1.10 §5.2 错误响应 —— **部分符合（Medium）**
+
+- **error 码集合**：覆盖 `invalid_request/invalid_client/invalid_grant/unauthorized_client/unsupported_grant_type/invalid_scope/server_error/access_denied/authorization_pending/expired_token`（`ErrorCatalog.cc:218-236`）。
+- **HTTP 状态映射**：`invalid_client`→401、`server_error`→500、`access_denied`→403、其余→400（`OAuth2ErrorHandler.cc:93-107`、`ErrorCatalog.cc:221-233`）。基本符合 §5.2。
+- **WWW-Authenticate on invalid_client**：协议端点（introspect/revoke）经 `OAuth2ErrorHandler::sendErrorResponse` 在 `authScheme` 非空时正确加 `WWW-Authenticate`（`OAuth2ErrorHandler.cc:85-88`）。但 `/oauth2/token` 的 inline grant 分支（client_credentials/device_code 的 `invalid_client`）直接构造 JSON，**不加** WWW-Authenticate（`TokenEndpointController.cc:718-725, 736-743, 757-762, 1238-1244, 1264-1271`）。违反 §5.2 "MUST include the WWW-Authenticate header"。
+- **validation gate 误用应用信封**：`RuleSet::oauth2Token` 失败经 `HttpResponder` 返回应用信封 `VALIDATION_INVALID_INPUT`（`HttpResponder.cc:57-58, 86`），**不是** RFC 6749 §5.2 的 `error: "invalid_request"`。客户端按 OAuth2 协议解析错误时会失败。
+- **见**：F-006、F-008。
+
+#### 3.1.11 §10.4 / §10.6 凭证保护 —— **不符合（Critical，仅动态注册路径）**
+
+- **access/refresh token 哈希存储**：✅ UPPER-hex SHA-256（`TokenCrypto.cc:26-37`），原值不入库。
+- **client_secret 哈希**：❌ 见 3.6.2。写入路径用无盐大写 SHA-256，校验路径算有盐小写 SHA-256。两套算法永远不会匹配。
+- **常量时间比较**：Postgres ✅（`PostgresClientRepository.cc:14-27, 245-249`），Memory ✅（`MemoryClientRepository.cc:11-24, 163`，但比较的是**明文**），Redis ❌（`RedisClientRepository.cc:174-175` `==`）。
+- **见**：F-002、F-004。
+
+#### 3.1.12 §10.9 维护撤销集 —— **符合**
+
+- access/refresh token 持 `revoked` 标志，`validateAccessToken`（`TokenService.cc:443-479`）查 revoked + expiry。
+- **判定**：撤销即时生效。**符合**。
+
+---
+
+### 3.2 RFC 6750 Bearer Token Usage —— **部分符合**
+
+#### 3.2.1 §2.1 Bearer 头解析 —— **符合**
+
+`OAuth2AuthFilter.cc:39-52` 校验 `Authorization: Bearer ` 前缀，缺失/格式错→401。
+
+#### 3.2.2 §2.3 query 传 token —— **部分符合（Low）**
+
+`AuthorizationFilter.cc:99-107` 接受 `?access_token=`，属 RFC 6750 §2.3 已废弃方式。允许但不推荐。
+
+#### 3.2.3 §3 WWW-Authenticate: Bearer challenge —— **不符合（Medium）**
+
+- **证据**：资源端点（`/api/me`、`/api/admin/*`）401 经 `OAuth2AuthFilter`/`AuthorizationFilter` 返回应用信封 `AUTH_TOKEN_INVALID`，**不**按 RFC 6750 §3 发 `WWW-Authenticate: Bearer realm="...", error="invalid_token", error_description="..."`。
+- **依据**：RFC 6750 §3 "If the request lacks any authentication information [...], the resource server SHOULD NOT respond with the WWW-Authenticate header. [...] otherwise [...] MUST include the WWW-Authenticate header"。
+- **见**：F-006。
+
+#### 3.2.4 §3.1 insufficient_scope —— **不符合（High）**
+
+- **证据**：`OAuth2AuthFilter.cc:73-75` 把 `scope` 写入 attributes 但**从不校验**。Grep 全 `libs/`、`apps/` 无任何资源端点按 scope 拒绝。`/api/admin/*` 的 RBAC 按**用户角色**而非 OAuth scope。
+- **依据**：RFC 6750 §3.1 "If the access token [...] has insufficient scope"，应返回 `insufficient_scope`。
+- **影响**：scope 退化成"签发时校验客户端白名单"的元数据，丧失细粒度资源授权能力。
+- **见**：F-010。
+
+---
+
+### 3.3 RFC 7662 Token Introspection —— **部分符合**
+
+#### 3.3.1 §2.1 客户端认证 MUST —— **符合**
+
+`TokenEndpointController.cc:279-345`：`extractClientCredentials` 取 Basic 或 POST `client_id`/`client_secret`，缺失→`invalid_client`+WWW-Authenticate，`validateClient` 校验。**符合**。
+
+#### 3.3.2 §2.2 响应字段 —— **部分符合（Low）**
+
+- **已发**：`active/client_id/token_type/exp/iat/nbf/sub/aud/iss/scope`（`:377-409`）。
+- **缺失**：`username`、`jti`。`jti` 全代码库不存在（Grep 无结果）。
+- **iss 不一致**：refresh_token 分支硬编码 `iss = "https://oauth.example.com"`（`PostgresTokenRepository.cc:567`），与配置 issuer 不符。
+- **见**：F-016。
+
+#### 3.3.3 §2.2 无效/过期/撤销令牌须 active=false（非 4xx）—— **符合**
+
+`:353-368` repo 返回 `nullopt` → 200 `{active:false}`；repo 层 revoked/expired 返回 `active=false` 对象（`:523-529, 553-558, 574-578`），controller 序列化为完整字段（含 active=false）。**符合**。
+
+#### 3.3.4 §2.3 token_type_hint —— **符合**
+
+`RuleSet.cc:573` 接受但忽略。合规。
+
+---
+
+### 3.4 RFC 7009 Token Revocation —— **符合**
+
+#### 3.4.1 §2.1 客户端认证 + 所有权 —— **符合**
+
+`TokenEndpointController.cc:420-523`：认证 + `introspection->clientId != clientId` → `unauthorized_client`（`:508-522`）。
+
+#### 3.4.2 §2.1 支持 access 与 refresh —— **符合**
+
+`revokeAccessToken` 同时回退尝试 refresh 表（`PostgresTokenRepository.cc:652-677`），命名误导但行为正确。
+
+#### 3.4.3 §2.2.1 成功/未知均返回 200；no-store —— **部分符合（Low）**
+
+`:494-544` 成功/未知均 200。**但** `createSuccessResponse`（`:235-240`）不加 `Cache-Control: no-store`。RFC 7009 §2.2.1 RECOMMENDS 此头。**见**：F-019。
+
+---
+
+### 3.5 RFC 7636 PKCE —— **部分符合**
+
+#### 3.5.1 §4.3 code_challenge_method 仅 plain/S256 —— **部分符合（Medium）**
+
+- authorize 端**不校验**方法集合（`AuthorizationEndpointController.cc:108-109` 透传），任意字符串被接受并存储。仅在 exchange 端 `Pkce.cc:17-26` 拒绝非 `plain/S256`。
+- **依据**：RFC 7636 §4.3 "If the server supports PKCE [...] the server SHOULD reject authorization requests that do not support the requested transformation"。
+- **见**：F-013。
+
+#### 3.5.2 §4.4/§4.6 S256 算法 —— **符合**
+
+`Pkce.cc:17-21` `computeCodeChallenge` 对 S256 = `base64url(sha256(verifier))`，对原始字节而非 hex 字符串编码。**这是规范正确的实现**（`TokenService.h` 顶部注释明确这是修复了旧 `generateSha256Hash` 的 base64(hex-string) bug 的新实现）。`OAuth2Plugin.cc:601-628` 的静态方法也委托到正确实现。
+
+#### 3.5.3 §4.6 exchange 时校验 —— **符合**
+
+`TokenService.cc:206-219`：存了 `codeChallenge` 则必须带 `codeVerifier` 且通过 `validatePkceCodeVerifier`→`verifyCodeVerifier`。
+
+#### 3.5.4 BCP §2.1.1 / RFC 9700 强制 PKCE —— **不符合（Medium）**
+
+- **证据**：`auth.require_pkce_for_public` 默认 OFF（`OAuth2Plugin.cc` 配置读取，`AuthorizationEndpointController.cc:416-441`、`SessionController.cc:555-572` 仅在 flag on 时强制）。且检查名"for public"但实际对任意 client 触发，未区分 client_type。
+- **依据**：RFC 9700 §2.1.1 强烈建议对所有 authorization_code 客户端强制 PKCE。
+- **见**：F-011。
+
+#### 3.5.5 §4.1 code_verifier 格式校验 —— **部分符合（Low）**
+
+`isValidCodeVerifierFormat`（`Pkce.cc:40-63`）已实现 43-128/[A-Za-z0-9-._~]，但**未在 exchange 路径调用**（仅重算比较）。RFC 7636 §4.6 不要求单独格式校验，故不算硬偏差。
+
+---
+
+### 3.6 RFC 8252 Native Apps —— **未实现（按适用性，Medium）**
+
+- **loopback redirect 端口通配**（§7.3）：未实现。redirect_uri 精确匹配，native app 每次新端口都需重新注册。
+- **public client 必须用 PKCE**（§8.1）：见 3.5.4，默认不强制。
+- **判定**：未实现（按适用性评级 Medium；若项目不面向 native app，可标"不适用"）。
+- **见**：F-014。
+
+---
+
+### 3.7 RFC 8628 Device Authorization Grant —— **部分符合**
+
+#### 3.7.1 §3.1.1/§3.4 device_authorization 端点机密客户端认证 —— **不符合（High）**
+
+- **证据**：`DeviceAuthController.cc:156` `plugin->validateClient(clientId, "", ...)` 用**空 secret** 调用。`MemoryClientRepository.cc:150-157`/`PostgresClientRepository.cc:218-225` 对机密客户端空 secret 返回 false，故机密客户端根本无法发起 device flow；公开客户端可发起。
+- **依据**：RFC 8628 §3.1.1 要求机密客户端在 device_authorization 端点认证。
+- **影响**：机密客户端无法用 device flow；公开客户端体验正常但未做 PKCE 关联。
+- **见**：F-015。
+
+#### 3.7.2 §3.2 响应字段 —— **部分符合（Low）**
+
+- `device_code/user_code/verification_uri/expires_in/interval` 齐（`DeviceAuthController.cc:202-213`）。
+- `verification_uri_complete` 缺失（§3.3.1 可选）。
+- **user_code 字符集**：`"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"`（`:75`）剔除歧义字符，符合 §5.2。
+- **token 端点 client_type 分支**：`TokenEndpointController.cc:1227-1276` 正确分支（PUBLIC 仅 client_id；CONFIDENTIAL 需 secret）。✅
+
+#### 3.7.3 §3.5 polling 错误码 —— **不符合（Medium）**
+
+- **已发**：`authorization_pending/expired_token/access_denied/invalid_grant/invalid_request`（`:935-1086`，HTTP 400）✅。
+- **slow_down 未发**：`ErrorCatalog.cc:232,483` 定义了 `slow_down`，但 polling 逻辑**从不**比较轮询频率，永远不返回 `slow_down`。Grep 确认无任何 emission 点。
+- **依据**：RFC 8628 §3.5 "If the client is polling too quickly, the authorization server SHOULD return the `slow_down` error"。
+- **见**：F-012。
+
+---
+
+### 3.8 RFC 8414 + OIDC Discovery 1.0 —— **部分符合**
+
+#### 3.8.1 OIDC Discovery §4 字段完备性 —— **部分符合（Medium）**
+
+`DiscoveryController.cc::oidcDiscovery`（`:152-222`）已发：issuer/authorization_endpoint/token_endpoint/userinfo_endpoint/device_authorization_endpoint/jwks_uri/introspection_endpoint/revocation_endpoint/response_types_supported/grant_types_supported/subject_types_supported/id_token_signing_alg_values_supported/scopes_supported/token_endpoint_auth_methods_supported/claims_supported/code_challenge_methods_supported。
+
+**缺失**：
+- `end_session_endpoint`（OIDC RP-Initiated Logout 必备）❌
+- `registration_endpoint`（实际有 `/oauth2/register` 但未广告）❌
+- `introspection_endpoint_auth_methods_supported` / `revocation_endpoint_auth_methods_supported`（仅 RFC 8414 `metadata()` 有，OIDC discovery 无）❌
+- `response_modes_supported`（仅 metadata 有）❌
+
+#### 3.8.2 OIDC Discovery §3 issuer 精确一致 —— **不符合（High）**
+
+- **配置 issuer**：`baseUrl` 来自 `customConfig["metadata"]["issuer"]`，默认 `http://localhost:5555`（`DiscoveryController.cc:160-167`）。**默认是 http，OIDC Discovery §3 规定 issuer 须使用 https**。
+- **iss claim 来源不一致**：access token 的 `iss` 取自 DB 列 `oauth2_access_tokens.issuer`（`PostgresTokenRepository.cc:537`）；**refresh token 内省 iss 硬编码 `"https://oauth.example.com"`**（`:567`）。签发时 issuer 写入何处未在本次审计深追，但 introspect 的 refresh 分支与配置 issuer 显然不符。
+- **无尾斜杠归一化**：`baseUrl + "/oauth2/..."` 直接拼接（`:171-177`），若 operator 配置带尾斜杠会产生 `//oauth2/...`。
+- **依据**：OIDC Discovery §3 "The issuer value MUST be exactly identical to the Issuer URL [...] The issuer value is a URL [...] using https"。
+- **见**：F-016。
+
+#### 3.8.3 RFC 8414 oauth-authorization-server —— **符合**
+
+`metadata()`（`:57-151`）字段齐全。
+
+---
+
+### 3.9 OIDC Core 1.0 —— **部分符合（核心 MUST 大体满足，扩展 SHOULD 大面积缺失）**
+
+#### 3.9.1 §2 id_token claims（核心 MUST 档）—— **部分符合（Medium）**
+
+- **已发**：`iss/sub/aud/exp/iat/nonce`（`TokenService.cc:306-317`，nonce 仅在非空时）。
+- **缺失**：`auth_time`、`acr`、`amr`、`azp`。
+- **依据**：
+  - OIDC Core §2 `auth_time`：REQUIRED when `max_age` 请求、否则 OPTIONAL。当前 max_age 不支持故可缺，但 §3.1.2.1 又把 max_age 列为支持项……故实际是"不支持 max_age 所以也不发 auth_time"——耦合缺失。
+  - `azp`（§2）：当 aud 多值或与 client 不同时 REQUIRED。本项目 aud 永远等于 clientId，故 azp 可缺（合规）。
+  - `acr/amr`：OPTIONAL 但 claims_supported 应反映实际能力（当前未广告，可接受）。
+- **见**：F-021。
+
+#### 3.9.2 §3.1.2.1 / §3.1.3.7 请求参数 prompt / max_age（核心 MUST 档，OIDC Core 把它们列为 OP 须支持的请求参数）—— **未实现（High）**
+
+- **证据**：全仓 Grep `prompt`/`max_age` 在非测试代码中**零命中**。`AuthorizationEndpointController.cc` 不读这两个参数。
+- **依据**：OIDC Core §3.1.2.1 把 `prompt`、`max_age`、`nonce` 列为 Authorization Endpoint 的请求参数；§3.1.3.7 规定 `auth_time` 与 `max_age` 校验为 MUST。
+- **影响**：客户端无法请求 `prompt=none`（无交互静默登录失败应报错）、`prompt=login`（强制重新认证）、`max_age`（按年龄强制重认证）。这是 OIDC 互操作性的核心能力。
+- **见**：F-022。
+
+#### 3.9.3 §3.1.3.6 id_token 仅对 openid scope 签发 —— **符合**
+
+`TokenService.cc:301-303` `if (jwkManager_ && ... && scope.find("openid") != npos)`。
+
+#### 3.9.4 §5.3 UserInfo —— **部分符合（Medium）**
+
+- **Bearer 校验**：✅ 经 `OAuth2AuthFilter`（`OAuth2AuthFilter.cc:39-55`）。
+- **不校验 openid scope**：❌ `TokenEndpointController.cc:1297-1389` 与 filter 都不查 scope，**任何** access token（含 `client_credentials` 签发的 `sub=client:<id>` M2M token）都能取 userinfo。
+- **CORS**：✅（修正先前误判）全局 `setupCors()`（`apps/server/src/bootstrap/CorsSetup.cc:68-79`）的 `postHandlingAdvice` 对所有响应（含 userinfo）加 `Access-Control-Allow-Origin`（精确白名单，无通配）。**符合** OIDC §7.2.1。
+- **sub 用内部 userId**：§15 推荐 pairwise/stable 标识符，本项目用内部数字 id（非 pairwise）。
+- **email_verified 声明但不返回**：`claims_supported` 含 `email_verified`（`DiscoveryController.cc:212`），但 userinfo 不返回（`TokenEndpointController.cc:1345-1383`）。
+- **依据**：OIDC Core §5.3 "The UserInfo Endpoint MUST accept Access Tokens [...] The information returned [...] SHOULD be scoped to the OpenID Connect scopes"。
+- **见**：F-023、F-024。
+
+#### 3.9.5 §7.2.1 UserInfo CORS —— **符合**（见 3.9.4）
+
+#### 3.9.6 §12 refresh 时重发 id_token（核心 MUST 档，OIDC Core §12 列为 SHOULD）—— **未实现（Medium）**
+
+- **证据**：`TokenService.cc:430-436` refresh 响应只有 `access_token/token_type/expires_in/refresh_token`，无 `id_token` 分支。同样 `TokenEndpointController.cc:1145-1153` device_code 也不发 id_token。
+- **影响**：OIDC 客户端在 refresh 后丢失 id_token，需重新走授权码流程。
+- **见**：F-025。
+
+#### 3.9.7 §10.1 nonce 单次使用（核心 MUST 档）—— **未实现（Medium）**
+
+- **证据**：nonce 仅 echo 进 id_token（`TokenService.cc:314-317`），无任何存储/去重。
+- **依据**：OIDC Core §15.5.2 "nonce [...] MUST be [...] used only once [...] Clients MUST verify that the nonce [...] is equal to the nonce sent". 服务端虽不强制单次，但缺 replay 检测使 nonce 防护弱化。
+- **见**：F-026。
+
+#### 3.9.8 §15 pairwise sub —— **未实现（Low）**
+
+用内部 userId，非 pairwise。可选配置，缺即 Low。
+
+---
+
+### 3.10 OIDC RP-Initiated Logout / Session Management / Back-Channel Logout —— **未实现（扩展 SHOULD 档，Medium）**
+
+- **end_session_endpoint**：全代码库无（Grep `end_session/post_logout/RP-Initiated` 零命中），discovery 不广告。
+- **现有 logout**：`SessionController::logout`（`SessionController.cc:898-969`）是**非标 Bearer token 撤销端点**，取 `Authorization: Bearer`，调 `revokeAccessToken`，返回 JSON，不重定向，不处理 `id_token_hint`/`post_logout_redirect_uri`/`state`。
+- **Drogon session 不失效**：`logout` 不调 `req->session()->invalidate()`。
+- **Back-Channel Logout stub**：`sendBackchannelLogoutNotifications`（`SessionController.cc:66-69`）是 `LOG_DEBUG << "... stub"` 空实现。
+- **判定**：**未实现**（按用户要求的"扩展 SHOULD 分档"，Medium）。
+- **见**：F-027、F-028。
+
+---
+
+### 3.11 RFC 7519/7517/7515（JWT/JWK/JWS 支撑核验）—— **部分符合**
+
+#### 3.11.1 JWT §4.1 标准 claim —— **部分符合（Low）**
+
+id_token 含 iss/sub/aud/exp/iat/nonce，缺 `jti`（全库无）。jti 缺失意味着无 JWT 内置防重放。
+
+#### 3.11.2 JWK §4 公钥格式 —— **符合**
+
+`JwkManager::getJwks`（`:331-353`）发 `kty=RSA/use=sig/alg=RS256/kid/n/e`，`n/e` 由 `EVP_PKEY_get_bn_param` 取（`:305-314`），base64url。
+
+#### 3.11.3 私钥保护 —— **符合**
+
+仅取 n/e，无 d/p/q/dp/dq/qi。
+
+#### 3.11.4 kid 选择/轮转 —— **未实现（Low）**
+
+`JwkManager` init-once（`JwkManager.h:37-55`、`.cc:33-41`），单 kid（默认 `key-1`，dev `ephemeral-dev-key`），无多 key、无轮转、无按 token 选 kid。`signJwt` 永远用同一 kid。
+- **见**：F-029。
+
+#### 3.11.5 alg 白名单 / alg=none 防护 —— **符合（单向签发）**
+
+`signJwt`（`JwkManager.cc:231-293`）硬编 `alg=RS256`，不解析外部 alg。本项目不验签外部 JWT，故无 alg=none 注入面。
+
+---
+
+### 3.12 RFC 7591 / 7592 动态客户端注册 —— **部分符合**
+
+#### 3.12.1 RFC 7591 §3 动态注册 —— **部分符合（Medium）**
+
+- **形态**：`ClientRegistrationService.cc:37-184` 接受 `client_name/client_type/token_endpoint_auth_method/redirect_uris/grant_types`，返回 `client_id/client_secret/client_id_issued_at/client_secret_expires_at=0`。形态正确。
+- **gated by admin**：`AuthorizationFilter` 前置（`ClientRegistrationController.cc:24-30`），非 RFC 7591 §3 的开放注册模型。可接受的设计选择但偏离规范默认。
+- **client_secret 哈希 bug**：见 F-002，导致注册的客户端无法认证。
+
+#### 3.12.2 RFC 7592 客户端自管理 —— **未实现（Low）**
+
+无 `/oauth2/register/{client_id}` 路由，无 `registration_access_token`。客户端无法自管，仅 admin 通过 `/api/admin/clients/*`。
+- **见**：F-030。
+
+#### 3.12.3 token_endpoint_auth_method 持久化 —— **未实现（Medium）**
+
+`ClientRegistrationService.cc:57-58,181` 读取并回显，但**不入库**（`Oauth2Clients` 表无此列，`Oauth2Clients.h:52-64`）。token 端点永远 Basic→Post 回退，不按客户端声明方法。
+- **见**：F-017。
+
+---
+
+### 3.13 RFC 9068 JWT-format Access Tokens —— **不适用（未实现，按设计）**
+
+access token 为 opaque 随机串（`TokenCrypto.cc:9-24`，32 字节 base64url，仅哈希入库）。RFC 9068 不适用。**评级：未实现/不适用**，非缺陷。
+
+---
+
+### 3.14 RFC 9700 / OAuth 2.0 Security BCP —— **部分符合**
+
+| 条款 | 状态 | 说明 |
+|---|---|---|
+| §2.1.1 强制 PKCE | ❌ Medium | 默认 off（F-011） |
+| §2.2.1 redirect_uri 精确匹配 | ✅ | 已满足 |
+| §2.4 token 端点限流 | ❌ Medium | 无限流（F-018） |
+| §4.9 凭证常量时间比较 | ❌ High | Redis 非常量时间（F-004） |
+| §4.9.1 client_secret 加盐哈希 | ❌ Critical | 写入路径无盐（F-002） |
+| §4.10 id_token/auth_time 校验 | ❌ Medium | 未实现（F-022） |
+| §4.11.1 state CSRF | ✅ | state 强制（自定义策略） |
+| §4.12.1 redirect_uri open redirect | ✅ | 精确匹配防住（state 拼接未 urlEncode 见 F-020） |
+
+---
+
+### 3.15 横向安全与运维 —— 跨规范聚合
+
+| 主题 | 状态 | 见 |
+|---|---|---|
+| token 哈希一致性（UPPER-hex） | ✅ | — |
+| client_secret 写读哈希不一致 | ❌ Critical | F-002 |
+| Memory 后端明文存 client_secret | ❌ Medium | F-031 |
+| token 端点 / introspect / revoke 限流 | ❌ Medium | F-018 |
+| 日志脱敏（access/refresh 不进日志） | ✅ 大体 | 大部分变量是 hash；少量 LOG_INFO 打 hash 值（如 `PostgresTokenRepository.cc:378,383`）属可接受 |
+| CORS 全局白名单 | ✅ | `CorsSetup.cc` |
+| open redirect（state 拼接未 urlEncode） | ❌ Low | F-020 |
+
+---
+
+## 4. 发现清单（按编号）
+
+> 每条：规范依据 / 现象 / 根因 `file:line` / 风险 / 影响 / 整改建议。
+
+### F-001 [文档] OpenAPI grant_type 枚举缺 device_code 【Low】
+- **依据**：RFC 8628 §3.4 + OpenAPI 准确性。
+- **现象**：`openapi.yaml` 的 `/oauth2/token` grant_type enum 只列 `authorization_code,refresh_token,client_credentials`，缺 `urn:ietf:params:oauth:grant-type:device_code`（代码 `RuleSet.cc:255-261` 已支持）。
+- **整改**：补全 enum。
+- **阶段**：P2。
+
+### F-002 [Critical] client_secret 哈希写入与校验算法不一致，动态注册客户端无法认证
+- **依据**：RFC 6749 §10.6 "The client password MUST be hashed [...] using a salt"；OAuth 2.0 Security BCP §4.9.1。
+- **现象**：注册/管理路径写无盐大写 SHA-256，校验路径算有盐小写 SHA-256，两者永不匹配。
+- **根因**：
+  - 写入：`ClientRegistrationService.cc:143` `hashToken(clientSecret)`（无盐，`TokenCrypto.cc:26-37` UPPER-hex sha256(secret)）；`ClientManagementService.cc:128-129,367-368` 同样。reset 路径 `:380` 甚至不更新 salt。
+  - 校验：`PostgresClientRepository.cc:231` `getSha256(clientSecret + salt)` 再 `tolower`；`RedisClientRepository.cc:165-175` 同。
+- **影响**：所有经 `/oauth2/register` 或 `/api/admin/clients` 创建的机密客户端，在 token 端点永远 `invalid_client`。除非有未审的 seed/bootstrap 路径用有盐算法预置客户端（需 operator 确认），否则机密客户端流程整体不可用。
+- **整改建议**：
+  1. 统一为单一算法（推荐 PBKDF2/Argon2id；最低限度统一为有盐 SHA-256，与校验路径一致）。
+  2. 写入路径同时更新 salt。
+  3. 提供一次性数据迁移脚本：检测 `client_secret` 列无盐哈希模式 → 触发管理员强制 reset。
+- **阶段**：P0。
+
+### F-003 [High] refresh_token grant 跳过客户端认证
+- **依据**：RFC 6749 §3.2.1。
+- **现象**：见 3.1.6。
+- **根因**：`TokenEndpointController.cc:679-711` 不调 `validateClient`，仅 `TokenService.cc:387-391` 做字符串 client_id 比较。
+- **整改**：在 controller 入口对机密客户端加 `validateClient`（参考 client_credentials 分支 `:733-775`），公开客户端仅验 client_id 存在。
+- **阶段**：P0。
+
+### F-004 [High] Redis 后端 client_secret 非常量时间比较
+- **依据**：OAuth 2.0 Security BCP §4.9；RFC 6749 §10.6。
+- **现象**：`RedisClientRepository.cc:174-175` `calculatedHash == storedHash` 用 `std::string::operator==`，非常量时间。
+- **整改**：复用 `constantTimeMemcmp`（Postgres/Memory 已有实现，抽到 common）。
+- **阶段**：P0。
+
+### F-005 [High] Redis 后端 refresh_token 存储为空操作，轮换/级联吊销失效
+- **依据**：RFC 6749 §6。
+- **现象**：`RedisTokenRepository.cc:155-165` `saveRefreshToken`/`getRefreshToken` 空 return；`atomicRevokeRefreshToken`（`:192-213`）因 getRefreshToken 空 op 永远返回 nullopt；reuse-detection + revokeTokenFamily 不触发。
+- **影响**：Redis 部署下 refresh token 既不存储也不轮换，刷新请求永远 `invalid_grant`（或依赖某种 fallback；需运行时确认）。
+- **整改**：实现 Redis refresh token 存取 + family_id 索引；或文档明确"Redis 后端不支持 refresh_token grant"。
+- **阶段**：P0（若生产用 Redis）/ P1（若仅 Postgres 生产）。
+
+### F-006 [High] 资源端点 Bearer 401 不发 WWW-Authenticate challenge
+- **依据**：RFC 6750 §3。
+- **现象**：`OAuth2AuthFilter.cc`/`AuthorizationFilter.cc` 返回应用信封 `AUTH_TOKEN_INVALID`，不按 RFC 6750 §3 发 `WWW-Authenticate: Bearer realm, error=invalid_token, error_description`。
+- **整改**：在 filter 401 路径加 RFC 6750 §3 challenge 头。
+- **阶段**：P1。
+
+### F-007 [High] authorization 端点错误未按 §4.1.2.1 重定向
+- **依据**：RFC 6749 §4.1.2.1。
+- **现象**：见 3.1.4。仅 consent-deny 重定向，其余错误（invalid_scope、server_error、PKCE-required）直接 4xx，state 不回显。
+- **整改**：按 §4.1.2.1 区分（a）client_id 未知 / redirect_uri 无效 → 直接 4xx；（b）其余 → 302 `?error=&error_description=&state=` 重定向到已注册 redirect_uri。
+- **阶段**：P1。
+
+### F-008 [Medium] token 端点 validation gate 用应用信封而非 OAuth2 error 码
+- **依据**：RFC 6749 §5.2。
+- **现象**：`HttpResponder.cc:57-58,86` 失败返回 `VALIDATION_INVALID_INPUT` 信封 + 400，非 `error: "invalid_request"`。
+- **整改**：token 端点的 validation gate 走 `OAuth2ErrorHandler` 发标准 OAuth2 error 信封。
+- **阶段**：P1。
+
+### F-009 [Medium] authorization_code 兑换时空 redirect_uri 跳过 §4.1.3 比较
+- **依据**：RFC 6749 §4.1.3。
+- **现象**：见 3.1.5。`PostgresGrantRepository.cc:181-189` 与 `MemoryGrantRepository.cc:80-87` 用 `if (!redirectUri.empty() && ...)` 守卫。
+- **整改**：若签发时存了 redirect_uri，兑换时必须带且必须匹配（empty 应直接 `invalid_grant`）。
+- **阶段**：P1。
+
+### F-010 [High] 资源端点不按 scope 拒绝（insufficient_scope）
+- **依据**：RFC 6750 §3.1。
+- **现象**：见 3.2.4。
+- **整改**：为受保护端点定义所需 scope，filter 校验，缺则 `insufficient_scope` 403。
+- **阶段**：P1。
+
+### F-011 [Medium] PKCE 默认不强制
+- **依据**：RFC 9700 §2.1.1。
+- **现象**：见 3.5.4。
+- **整改**：默认 `require_pkce=true`（至少对所有 authorization_code 客户端）。
+- **阶段**：P1。
+
+### F-012 [Medium] device flow 永不返回 slow_down
+- **依据**：RFC 8628 §3.5。
+- **现象**：见 3.7.3。`ErrorCatalog.cc:232` 定义但无 emission。
+- **整改**：在 polling 分支按 `interval` 与最近 poll 时间比较，过快返回 `slow_down`。
+- **阶段**：P1。
+
+### F-013 [Medium] authorize 端不校验 code_challenge_method 集合
+- **依据**：RFC 7636 §4.3。
+- **现象**：见 3.5.1。
+- **整改**：authorize 入口校验 method ∈ \{plain, S256\}，否则 `invalid_request` 直接 4xx（属 client 错误，可直接返回）。
+- **阶段**：P1。
+
+### F-014 [Medium] 无 HTTPS 强制 / 无 loopback 例外
+- **依据**：RFC 6749 §3.1.2.1；RFC 8252 §7.3。
+- **现象**：见 3.1.1。
+- **整改**：redirect_uri 注册时强制 https（生产）；实现 RFC 8252 loopback 端口通配（`http://127.0.0.1:*` / `http://[::1]:*`）。
+- **阶段**：P1。
+
+### F-015 [High] device_authorization 端点不认证机密客户端
+- **依据**：RFC 8628 §3.1.1。
+- **现象**：见 3.7.1。`DeviceAuthController.cc:156` 空 secret 调用。
+- **整改**：device_authorization 端点按 client_type 分支（参考 token 端点 device_code 分支 `:1227-1276`）。
+- **阶段**：P1。
+
+### F-016 [High] issuer 与 iss claim 不一致 / refresh introspect iss 硬编码
+- **依据**：OIDC Discovery §3。
+- **现象**：见 3.8.2。`PostgresTokenRepository.cc:567` 硬编 `https://oauth.example.com`。
+- **整改**：refresh token 内省 iss 取配置 issuer；签发时统一写入 issuer 字段；discovery issuer 强制 https + 尾斜杠归一化。
+- **阶段**：P0（iss 一致性）/ P1（https 强制）。
+
+### F-017 [Medium] token_endpoint_auth_method 不持久化
+- **依据**：RFC 7591 §2 + RFC 6749 §3.2.1。
+- **现象**：见 3.12.3。
+- **整改**：加 DB 列；token 端点按客户端声明方法认证。
+- **阶段**：P1。
+
+### F-018 [Medium] token/introspect/revoke 端点无限流/防爆破
+- **依据**：RFC 9700 §2.4。
+- **现象**：见 3.14。
+- **整改**：加 per-client/IP 失败计数 + 指数退避（可复用 identity 的 account-lockout 机制）。
+- **阶段**：P1。
+
+### F-019 [Low] 成功响应缺 Cache-Control:no-store
+- **依据**：RFC 6749 §5.1；RFC 7009 §2.2.1。
+- **现象**：token 成功响应、revoke 成功响应不加 `Cache-Control: no-store`/`Pragma: no-cache`（仅错误响应加）。
+- **整改**：所有 token 类响应统一加。
+- **阶段**：P2。
+
+### F-020 [Low] authorize 成功重定向 state 未 urlEncode
+- **依据**：RFC 6749 §4.1.2 / §4.1.3（state 透传完整性）。
+- **现象**：`AuthorizationEndpointController.cc:468-470` `location += "&state=" + state;` 未 urlEncode（login/consent 中间跳转已 urlEncode）。`code` 同样未 urlEncode。
+- **整改**：state 与 code 统一 urlEncode。
+- **阶段**：P2。
+
+### F-021 [Medium] id_token 缺 auth_time / acr / amr / azp
+- **依据**：OIDC Core §2。
+- **现象**：见 3.9.1。
+- **整改**：耦合 F-022 一起做（auth_time 依赖 prompt/max_age）。
+- **阶段**：P1。
+
+### F-022 [High] OIDC prompt / max_age 未实现
+- **依据**：OIDC Core §3.1.2.1 / §3.1.3.7。
+- **现象**：见 3.9.2。
+- **整改**：authorize 端解析 `prompt`（none/login/consent/select_account）与 `max_age`；按值控制交互/重认证；签发 id_token 时按需写 auth_time/acr。
+- **阶段**：P1。
+
+### F-023 [Medium] UserInfo 不校验 openid scope
+- **依据**：OIDC Core §5.3。
+- **现象**：见 3.9.4。
+- **整改**：userinfo handler 校验 token scope 含 `openid`（client_credentials token 的 `sub=client:*` 应直接拒）。
+- **阶段**：P1。
+
+### F-024 [Low] claims_supported 含 email_verified 但 userinfo 不返回
+- **依据**：OIDC Discovery §3 accuracy。
+- **整改**：要么 userinfo 返回 email_verified（已知 login 时有此值），要么从 claims_supported 移除。
+- **阶段**：P2。
+
+### F-025 [Medium] refresh / device_code 不重发 id_token
+- **依据**：OIDC Core §12。
+- **现象**：见 3.9.6。
+- **整改**：refresh 时若原 scope 含 openid 且 jwkManager 可用，重签 id_token。
+- **阶段**：P1。
+
+### F-026 [Medium] nonce 无单次使用/防重放存储
+- **依据**：OIDC Core §15.5.2。
+- **整改**：nonce 落库 + 兑换时去重（可复用 grant/code 的过期清理机制）。
+- **阶段**：P1。
+
+### F-027 [Medium] RP-Initiated Logout 未实现（end_session_endpoint）
+- **依据**：OIDC RP-Initiated Logout 1.0。
+- **现象**：见 3.10。
+- **整改**：新增 `/oauth2/end_session` GET，处理 `id_token_hint`/`post_logout_redirect_uri`/`state`，discovery 广告 `end_session_endpoint`。
+- **阶段**：P1。
+
+### F-028 [Medium] logout 不失效 Drogon session + backchannel stub
+- **依据**：OIDC Session Management / Back-Channel Logout 1.0。
+- **现象**：`SessionController.cc:898-969` 不调 `session()->invalidate()`；`:66-69` backchannel 是 stub。
+- **整改**：logout 调 session invalidate；backchannel 实现或显式声明不支持。
+- **阶段**：P1。
+
+### F-029 [Low] JWKS 无密钥轮转
+- **依据**：运维最佳实践（RFC 7517 无强制轮转要求）。
+- **整改**：支持多 kid + current/previous；按 kid 选签发 key；JWKS 暴露全部公钥。
+- **阶段**：P2。
+
+### F-030 [Low] RFC 7592 客户端自管理未实现
+- **依据**：RFC 7592。
+- **整改**：按需实现 `registration_access_token` + `/oauth2/register/{client_id}` CRUD；或文档明确仅 admin 管理。
+- **阶段**：P2。
+
+### F-031 [Medium] Memory 后端明文存 client_secret
+- **依据**：RFC 6749 §10.6。
+- **现象**：`MemoryClientRepository.cc:67` 注释 "we store plain text"。
+- **整改**：Memory 后端也走哈希（仅用于测试场景则文档明确"测试用，不存敏感数据"）。
+- **阶段**：P2（若 Memory 仅测试）/ P1（若生产可选）。
+
+---
+
+## 5. 分阶段整改计划
+
+### P0 — 严重/高优先（认证与令牌安全，1-2 周内）
+
+| 编号 | 工作项 | 验收标准 | 估计复杂度 |
+|---|---|---|---|
+| F-002 | 统一 client_secret 哈希算法（推荐 Argon2id/PBKDF2；最低有盐 SHA-256）+ 写入路径更新 salt + 数据迁移 | 动态注册客户端可在 token 端点成功认证；存量客户端有 reset 通道 | 中（含迁移） |
+| F-003 | refresh_token grant 入口加 `validateClient` | 机密客户端无 secret 时 401 invalid_client | 低 |
+| F-004 | Redis validateClient 用 constantTimeMemcmp | 单元测试覆盖常量时间 | 低 |
+| F-005 | 决策 Redis 是否支持 refresh_token；若支持则实现 save/get/atomicRevoke | Redis 部署下 refresh 流程端到端通过；或文档明确不支持 | 中 / 决策 |
+| F-016（iss 部分） | refresh introspect iss 取配置 issuer；签发统一写 issuer | introspect 返回的 iss 与 discovery issuer 字节一致 | 低 |
+
+### P1 — 中优先（OIDC 完备性、协议合规加固，3-6 周）
+
+| 编号 | 工作项 | 验收标准 |
+|---|---|---|
+| F-006 | 资源端点 401 加 RFC 6750 §3 Bearer challenge | WWW-Authenticate: Bearer realm/error/error_description |
+| F-007 | authorize 错误按 §4.1.2.1 重定向 | redirectable 错误 302 带 error/state |
+| F-008 | token 端点 validation gate 走 OAuth2 error 信封 | 错误体含 `error: invalid_request` |
+| F-009 | exchange 时空 redirect_uri 强制校验 | 签发带 redirect_uri 时兑换必带且匹配 |
+| F-010 | 资源端点 scope 校验 + insufficient_scope | 按 scope 拒绝返回 403 insufficient_scope |
+| F-011 | PKCE 默认强制 | 默认 require_pkce=true |
+| F-012 | device flow slow_down | 过快轮询返回 slow_down |
+| F-013 | authorize 校验 code_challenge_method 集合 | 非 plain/S256 直接 4xx |
+| F-014 | HTTPS 强制 + loopback 例外 | 生产 redirect_uri 强制 https；支持 RFC 8252 loopback |
+| F-015 | device_authorization 认证机密客户端 | 机密客户端可发起 device flow |
+| F-017 | 持久化 token_endpoint_auth_method | 客户端按声明方法认证 |
+| F-018 | 端点限流 | 失败计数 + 退避 |
+| F-021+F-022 | 实现 OIDC prompt/max_age + auth_time/acr | prompt=none/max_age 互操作通过 |
+| F-023 | UserInfo 校验 openid scope | M2M token 取 userinfo 被拒 |
+| F-025 | refresh/device 重发 id_token | OIDC refresh 互操作通过 |
+| F-026 | nonce 防重放存储 | 重复 nonce 兑换被拒 |
+| F-027 | RP-Initiated Logout | /oauth2/end_session 端到端 |
+| F-028 | logout 失效 session + backchannel 决策 | session 真正失效 |
+
+### P2 — 低优先（一致性、文档、加固，按需）
+
+F-001（OpenAPI enum）/ F-019（Cache-Control）/ F-020（state urlEncode）/ F-024（email_verified 一致）/ F-029（JWKS 轮转）/ F-030（RFC 7592）/ F-031（Memory 明文）。
+
+---
+
+## 6. 已确认合规项（正向清单）
+
+为平衡视角，下列核心能力经核实**符合规范**，构成 fulla 的合规基座：
+
+1. 授权码生成：256-bit `RAND_bytes` + base64url + 仅哈希入库（`TokenCrypto.cc:9-24,26-37`）
+2. 授权码单次性：原子 CAS（`PostgresGrantRepository.cc:165-176`）
+3. 授权码 TTL：默认 600s（`OAuth2Plugin.cc:53`）
+4. refresh token 轮换 + 重用检测 + family 级联吊销（Postgres；`TokenService.cc:353-385`、`PostgresTokenRepository.cc:404-492`）
+5. PKCE S256 算法规范正确（`Pkce.cc:17-21`）
+6. redirect_uri 精确匹配（`Client.h:83-90`）
+7. state 强制 + 长度/字符校验（`AuthorizationEndpointController.cc:113-189`）
+8. client_secret 比较常量时间（Postgres/Memory）
+9. access/refresh token 哈希存储一致（UPPER-hex SHA-256）
+10. introspect/revoke 客户端凭证认证模型（commit 246db32 修正后，`TokenEndpointController.cc:279-345,420-523`）
+11. revoke 所有权校验 + 未知令牌返回 200（`TokenEndpointController.cc:489-544`）
+12. JWKS 仅暴露公钥 n/e（`JwkManager.cc:305-353`）
+13. id_token 仅对 openid scope 签发（`TokenService.cc:301-303`）
+14. id_token nonce 端到端透传（`TokenService.cc:314-317`）
+15. device_code 原子 consume 防竞态（`TokenEndpointController.cc:1065-1090`）
+16. CORS 全局白名单（无通配，`CorsSetup.cc:11-30`）
+
+---
+
+## 7. 未核验项声明
+
+以下项本次未深入核实，列出以备后续：
+
+- access token 签发时 `issuer` 字段写入 DB 的具体值与位置（F-016 的另一半）。
+- 是否存在 seed/bootstrap 路径用有盐算法预置客户端（影响 F-002 的实际爆炸半径）。
+- Redis 后端 `getAccessToken`/`saveAccessToken` 是否同样存在空操作（本次只确认了 refresh 的空操作）。
+- 测试代码（`tests/`）与 seed 脚本（`apps/server/seed/`）未纳入审计。
+- 运行时行为未验证（如 server_error 路径、并发竞态）。
+- WebAuthn / GitHub/Google/WeChat 社交登录的 OAuth dance（OIDC federation 范畴）未审。
+
+---
+
+## 8. 整改状态表（修复进度追踪）
+
+核验基线：`master`（审计所引代码逐条比对过）。处置结论分三类：**修复**（代码已改）、**文档化**（不改码，文档说明）、**伪问题关闭**。
+
+整改分支：`fix/oauth-oidc-compliance-batch-0-1`，三批次提交：
+- Batch 0+1 = `040639b`（P0 安全 + 协议正确性）
+- Batch 2 = `a7fd184`（OIDC 全量扩展）
+- Batch 3 = `c911ee9`（加固与清理）
+
+每批次均 `manage.ps1 build-backend` + `test-backend` 全绿（**456/456 CTest 通过**，含 Postgres 与 CI/memory 两套配置）。
+
+| Issue | 发现 | 结论 | 状态 |
+|---|---|---|---|
+| #21 | F-002 client_secret 哈希写/读算法不一致 | 修复：写入路径统一有盐小写 SHA-256（含 reset 轮换 salt） | ✅ Batch 0+1 (`040639b`) |
+| #22 | F-003 refresh_token grant 无客户端认证 | 修复：CONFIDENTIAL 需 secret（401 invalid_client），PUBLIC 仅验存在 | ✅ Batch 0+1 (`040639b`) |
+| #23 | F-004 Redis client_secret 比较非常量时间 | 修复：三后端统一 `constantTimeMemcmp`，删泄漏比较结果的 LOG_DEBUG | ✅ Batch 0+1 (`040639b`) |
+| #24 | F-005 Redis 后端 refresh 存储空操作 | 修复（弃用处置）：启动 LOG_ERROR + refresh grant 返回 `unsupported_grant_type`；postgres+redis 缓存架构另立 issue #42 | ✅ Batch 0+1 (`040639b`) |
+| #25 | F-016 issuer 不一致 | 修复：签发写入配置 issuer（含 client_credentials/device 分支）+ 删三后端硬编码 + introspect 兜底 + discovery 尾斜线归一化 + http issuer 告警；比报告额外发现：`saveAccessToken` 从未写 issuer 列 | ✅ Batch 0+1 (`040639b`) |
+| #26 | F-007 authorize 错误不重定向 | 修复：client_id 未知/redirect_uri 无效仍直接 4xx；其余按 §4.1.2.1 302 重定向并回显 state | ✅ Batch 0+1 (`040639b`) |
+| #27 | F-010 资源不强制 scope | 修复（最小 scope 校验：userinfo→openid、/api/me→profile、/api/admin→admin + 403 insufficient_scope）；完整资源-scope 模型另立 issue #43 | ✅ Batch 3 (`c911ee9`) |
+| #28 | F-006 Bearer 401 缺 WWW-Authenticate | 修复：资源端点 401 加 `WWW-Authenticate: Bearer error="invalid_token"` | ✅ Batch 0+1 (`040639b`) |
+| #29 | F-021+F-022 prompt/max_age/auth_time/acr | 修复（全量）：prompt/max_age 解析 + 三签发路径透传 auth_time/amr + id_token auth_time/acr/amr claims | ✅ Batch 2 (`a7fd184`) |
+| #30 | F-027+F-028 RP-Initiated Logout | 修复：新增 `/oauth2/end_session`（GET+POST）+ session clear；backchannel 文档化不实现 | ✅ Batch 2 (`a7fd184`) |
+| #31 | F-015 device_authorization 不认证机密客户端 | 修复：按 client_type 分支认证 | ✅ Batch 0+1 (`040639b`) |
+| #32 | F-025 refresh/device 不重发 id_token | 修复：refresh/device 在 openid scope 时重签 id_token | ✅ Batch 2 (`a7fd184`) |
+| #33 | F-011 PKCE 默认不强制 | 修复：默认值改 true + 4 个 config 显式 true | ✅ Batch 0+1 (`040639b`) |
+| #34 | F-012 device flow 无 slow_down | 修复：`last_polled_at` 列 + interval 递增 5s | ✅ Batch 0+1 (`040639b`) |
+| #35 | F-008+F-009+F-013 token 错误信封/redirect_uri/挑战方法校验 | 修复：token gate 发 OAuth2 invalid_request 信封；空 redirect_uri 不再绕过；authorize 校验 code_challenge_method ∈ \{plain,S256\} | ✅ Batch 0+1 (`040639b`) |
+| #36 | F-014 redirect_uri 无 https 强制/loopback 例外 | 修复：https 强制 + 仅 IP 字面量 loopback（127.0.0.1/[::1]）豁免 + `auth.allow_http_redirect_uri` 开关；seed/测试 localhost→127.0.0.1 | ✅ Batch 0+1 (`040639b`) |
+| #37 | F-017+F-023+F-026 | F-017 持久化 + 强制 token_endpoint_auth_method（NULL 保留回退）；F-023 userinfo 校验 openid scope + email_verified（F-024）；F-026（nonce 服务端防重放）**伪问题关闭**：OIDC §15.5.2 的 nonce 校验是客户端 MUST，服务端存储非规范强制，文档说明 | ✅ Batch 2 (`a7fd184`) |
+| #38 | F-018 端点无限流 | 修复：进程内滑动窗口限流（per IP+client_id，仅计失败，429 + Retry-After） | ✅ Batch 3 (`c911ee9`) |
+| #39 | P2 批量（F-001/F-019/F-020/F-024/F-029/F-030/F-031） | F-001/F-019/F-020 修复；F-024 随 F-023；F-029/F-030/F-031 文档化不改码 | ✅ Batch 3 (`c911ee9`) |
+
+决策记录（用户拍板）：F-002 选有盐 SHA-256；F-005 目标架构 postgres 存储 + redis 缓存，独立 Redis 模式废弃（issue #42）；F-010 最小 scope 校验 + 独立 issue #43；OIDC 扩展全量实现 prompt/max_age；schema 直接改源头 migrations（无生产数据，不做增量迁移）。
+
+**最终符合性**：审计报告中标记的 31 项发现全部处置完毕（28 项代码修复 + 3 项文档化 + F-026 伪问题关闭）。Issue #21-#39 已在 `fix/oauth-oidc-compliance-batch-0-1` 分支修复并验证，待合入后关闭（fine-grained PAT 无 close 权限，需手动关闭）；#40 为总跟踪，#42/#43 为两个架构 follow-up。
+
+---
+
+**报告版本**：v1.3（追加整改后深度复查） | **审查日期**：2026-08-07 | **整改完成日期**：2026-08-08 | **复查日期**：2026-08-08 | **审查者**：ZCode | **代码基线**：`test/coverage-push` @ 09ebf8d | **整改+复查基线**：`fix/oauth-oidc-compliance-batch-0-1` @ 4b4e282
+
+---
+
+## 9. 整改后深度复查（2026-08-08）
+
+> 按本计划 `oauth-oidc-compliance-audit-plan.md` §二「规范清单与逐项检查要点」的全部 14 个 RFC 规范、~90 个检查点，对整改后的代码（`fix/oauth-oidc-compliance-batch-0-1` @ 4b4e282）重新逐项核验。4 个并行核验 agent 覆盖 RFC 6749/6750、7662/7009/7636/8252、8628/8414/OIDC Discovery、OIDC Core/JWT-JWK/7591/9068/9700/横向安全，每项结论附 `file:line` 证据。
+
+### 9.1 复查结论概览
+
+**合规：88/90 检查点 ✅ COMPLIANT**（含 1 项 ➖ N/A：RFC 9068 JWT access token——access token 为 opaque 设计）。R-1/R-4/R-5 三项新发现已快速修复（见下表处置列），R-2/R-3 记录在案留待 follow-up。所有 F-001–F-031 整改项在当前代码中**均已落地、无回退**，关键修复点（F-002 写读哈希一致、F-003 refresh 客户端认证、F-011 PKCE 默认强制、F-013/§4.6 S256 正确算法、F-016 issuer 一致、F-017 auth_method 强制、F-018 限流、F-019 no-store、F-020 urlEncode、F-022 prompt/max_age/auth_time/acr/amr、F-023 userinfo openid、F-025 refresh id_token、F-027 end_session）经直接代码复核确认存在且端到端连通。
+
+**5 项待处置（均为新发现，非回退，无 1 项是整改前已报告的 F-xxx 漏修）**：
+
+| ID | 发现 | 风险 | 性质 | 处置 |
+|---|---|---|---|---|
+| **R-1** | `acr` claim 以 JSON **整数**签发（`TokenService.cc:367`、`OAuth2Plugin.cc:778` `Json::Int64`），但 OIDC Core §2 规定 `acr` 为**字符串**，且 discovery `acr_values_supported` 广告的是字符串 `"1"`/`"2"`——id_token 与 discovery 类型/值不匹配 | 中 | 新发现，整改引入 | ✅ **已修**：改为 `Json::String`（"1"/"2"），两处签发点 + 2 个单测断言同步 |
+| **R-2** | `/oauth2/register` 路由在所有 config 的 `rbac_rules` 均无对应条目，`AuthorizationFilter` 默认拒绝 → 动态注册端点**对所有用户（含 admin）返回 403**；实际客户端创建走 `/api/admin/clients`（匹配 `/api/admin/.*`）。注册能力存在但端点不可达 | 低（功能不可用，但无安全影响） | 预先存在（master 上即如此），非本批引入；属文档/配置与实现不一致 | 📌 **记录**：非合规硬伤，是端点可达性问题。建议二选一——在 `rbac_rules` 加 `"/oauth2/register": ["admin"]`，或文档明确该端点仅供 admin、实际用 `/api/admin/clients`。留待 follow-up。 |
+| **R-3** | `RedisGrantRepository::saveAuthCode`（`RedisGrantRepository.cc:48`）不持久化 `code_challenge`/`code_challenge_method`/`nonce`/`auth_time`/`amr`——Redis 部署下 PKCE 校验被静默跳过、id_token 丢失 nonce/auth_time/amr | 高（**仅 Redis 部署**；Postgres/Memory 正确） | 预先存在（Redis grant 存储历来不完整）；F-005 已声明独立 Redis 模式废弃，故实际爆炸半径=坚持用废弃 Redis 模式的人 | 📌 **记录**：由架构 follow-up issue #42 覆盖（目标架构 Postgres 存储 + Redis 仅作缓存，grant 走 Postgres）。本轮不修——独立 Redis 存储模式已废弃（启动 LOG_ERROR + refresh grant 返回 unsupported_grant_type）。 |
+| **R-4** | discovery `prompt_values_supported` 含 `select_account`（`DiscoveryController.cc:229`），但 authorize 端无对应分支（仅 none/login/consent 被处理，`AuthorizationEndpointController.cc:282-284`）——advertised-but-not-honored | 低 | 新发现，整改引入 | ✅ **已修**：从 discovery `prompt_values_supported` 与 OpenAPI prompt 参数描述移除 `select_account`（只广告实际支持的 none/login/consent） |
+| **R-5** | RFC 8414 `metadata()`（`DiscoveryController.cc:72-165`）缺 `subject_types_supported`（RFC 8414 §2 REQUIRED），且两份 discovery 文档均未广告 `registration_endpoint`（尽管 `/oauth2/register` 已实现） | 低 | 预先存在（metadata 路径）+ 一致性 | ✅ **已修**：metadata() 补 `subject_types_supported=["public"]`；metadata() 与 oidcDiscovery() 均补 `registration_endpoint` |
+
+### 9.2 低风险提示（非缺陷，记录在案）
+
+- **RFC 7662 §2.2** introspection 不返回 `username`/`jti`——两者均 OPTIONAL，合规。
+- **RFC 7009 §2.2.1** 跨客户端撤销返回 `unauthorized_client`（非静默 200）——偏向安全的可辩护解读，记录为设计决策。
+- **Memory 后端** client_secret 明文比较（F-031 已文档化为 dev/test 专用）。
+- **`AuthorizationFilter`** 仍接受 `?access_token=` query 传 token（RFC 6750 §2.3 已废弃但合规）；`OAuth2AuthFilter` 已收紧为仅 header。
+- **PKCE verifier 比较**（`Pkce.cc:35`）用 `==` 非常量时间——低危（verifier 高熵，时序攻击不实际）。
+- **`access_denied`** 在 ErrorCatalog 映射为 403（RFC 6749 §5.2 列在 400）——仅用于资源侧/撤销所有权拒绝，authorize 端的 access_denied 走 302 重定向，无安全影响。
+- **OAuth2Plugin 与 DiscoveryController 各自独立 fallback `http://localhost:5555`**——当前一致，但两处字面量可能漂移。
+
+### 9.3 处置结果
+
+- **R-1（acr 类型）** ✅ **已修**：`TokenService.cc` + `OAuth2Plugin.cc` 两处 `Json::Int64(...)` → 字符串 `"1"`/`"2"`；2 个单测断言（`TokenServiceTest`）同步为 `asString()`。
+- **R-4（select_account）** ✅ **已修**：从 `DiscoveryController.cc` 的 `prompt_values_supported` 与 `AuthorizationEndpointController.cc`/`openapi.yaml` 的 prompt 参数描述移除 `select_account`（只广告实际支持的 none/login/consent）。
+- **R-5（discovery 字段）** ✅ **已修**：`DiscoveryController.cc` 的 RFC 8414 `metadata()` 补 `subject_types_supported=["public"]`；`metadata()` 与 `oidcDiscovery()` 均补 `registration_endpoint`。
+- **R-2（register RBAC）** 📌 **记录在案**：非合规硬伤（端点可达性问题，预先存在）。建议 follow-up 二选一——`rbac_rules` 加 `"/oauth2/register": ["admin"]`，或文档明确实际用 `/api/admin/clients`。本轮不改码。
+- **R-3（Redis grant）** 📌 **记录在案**：由架构 follow-up issue #42 覆盖（目标 Postgres 存储 + Redis 仅缓存，grant 走 Postgres）。本轮不修——独立 Redis 存储模式已废弃。
+
+### 9.4 未回退确认
+
+逐项确认无整改前已报告的 F-xxx 出现回退：F-002 写读哈希一致（`ClientRegistrationService.cc:204-220` 写有盐小写 SHA-256 ↔ `PostgresClientRepository.cc:213-243` 读同算法常量时间比较）、F-003 refresh 认证（`TokenEndpointController.cc:1037-1134` 按 client_type 分支）、F-011 PKCE（代码与 4 个 config 默认 true）、F-013 method 校验（`AuthorizationEndpointController.cc:375-393`）、§4.6 S256 正确算法（`Pkce.cc:17-21` base64url(raw digest)）、F-016 issuer 一致（无 `oauth.example.com` 残留）、F-017 强制（`enforceClientAuthMethod`）、F-018 限流（`RateLimiter` 失败计数 429）、F-019 no-store（`applyNoStoreHeaders` 全成功响应）、F-020 urlEncode（4 处签发重定向）、F-022 prompt/max_age/auth_time/amr（`AuthorizationEndpointController.cc` + `SessionController.cc:484-489` + `MfaController.cc:540-550`）、F-023 userinfo openid（`TokenEndpointController.cc:1879-1898`）、F-025 refresh/device id_token、F-027 end_session（`SessionController.cc:1105-1227` + session clear）——均存在且端到端连通。
+
+**整体结论**：整改有效，14 个 RFC 规范的 ~90 检查点中 88 项合规、1 项不适用、R-1/R-4/R-5 三项新发现已修复、R-2/R-3 两项记录在案（R-2 留待 follow-up，R-3 由 issue #42 覆盖）。无整改回退，无新引入的安全回归。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/rename-impact-fulla.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/rename-impact-fulla.md
@@ -1,0 +1,250 @@
+---
+title: 档案 · authforge→fulla 改名影响分析（2026-08-25 快照）
+date: 2026-08-25
+status: 已执行（PR #93/#94/#95 落地；v1.0.0 序列重置首发）
+sidebar_label: 档案 · 改名影响分析
+---
+
+> 本文档是改名决策的历史档案（入库版，本机细节已泛化）。其中的执行计划已全部
+> 完成：仓库已改名 voidvec/fulla、版本序列重置为 v1.0.0、PyPI fulla-oauth2 已
+> 发布。当前权威规则见 [documentation-governance.md](../documentation-governance.md)。
+
+# authforge → fulla 改名影响范围分析
+
+> 分析日期：2026-08-25（第一轮 + 同日第二轮补充审查，见 §2bis）｜ 方法：`git grep` 全仓实测 + 外部 registry/API 实查
+> 前置文档：rename-candidates.md（本地维护副本）（命名调研，fulla 排名第 9）
+>
+> **版本策略（2026-08-25 已定）**：改名视为**新产品身份**，版本序列**重置为 v1.0.0**（而非 v2.0.0）。依据：SemVer 约束的是包身份而非仓库——`fulla-oauth2`/`fulla-*` 镜像/`fulla` CMake 包均为新身份，1.0.0 起步是唯一自然选择；项目零外部用户，v2.0.0 的"破坏性升级"信号无处安放，反而让新项目首发 2.0 显得来历不明。先例：OpenSearch fork 自 ES 7.10 仍以 1.0.0 首发。直接 1.0.0（不用 0.x）是因为代码库已有 353 ctest + 完整 CI 矩阵 + benchmark 体系，0.x 会低估成熟度。红线（不可随之重置）见 §6 末尾。
+
+## 0. 结论摘要
+
+改名是**大规模但低风险**的工程：全仓 1658 个文件、约 1.1 万处 `authforge` 出现，其中约 **90% 是纯机械替换**（源码标识符、脚本、文档、CI），真正需要**决策和迁移策略**的只有 8 个层面：
+
+| # | 非机械层面 | 性质 |
+|---|---|---|
+| 1 | Redis 键前缀 `authforge:cache:*` + Prometheus 指标 `authforge_cache_*` | 运行时数据面：前缀变更=升级时缓存整体失效；指标变更=监控面板/告警断点 |
+| 2 | PyPI 已发布包 `authforge-oauth2`（1.4.x 在线）+ GHCR 镜像 `voidvec/authforge-*` | 已发布工件：旧名永久存在，需 deprecation + 新名并行 |
+| 3 | api-diff 门禁基线（`tools/api-diff/api-baseline.txt`，820 处） | CI 门禁：改名=全局 API 破坏，基线必须重生成并 --force 批准 |
+| 4 | C++ 公共 API 面（`#include <authforge/...>` 路径 + `namespace authforge`） | 语义化版本：版本序列重置为 **v1.0.0**（新产品身份，见文首决策） |
+| 5 | Go module path `github.com/voidvec/authforge/clients/go` | module 路径=URL：旧路径不可长期依赖 |
+| 6 | 本机目录改名 `D:\...\authforge` | 工作区身份/构建缓存/多工具路径全部失效 |
+| 7 | `OAUTH2_*` 环境变量前缀（20+ 变量、1260 处、22 个代码文件读取） | 第二套命名体系，规范化决策见 §2bis B |
+| 8 | 前端品牌面（文案 + **e2e 断言** + 页面标题 + package.json 名） | UI 品牌替换与测试断言必须同 PR，漏改直接挂 e2e |
+
+**三条好消息**（实测排除的担忧）：
+
+- **数据库零影响**：DB 名/用户是 `oauth2_db`/`oauth2_user`（deploy/docker/docker-compose.debug.yml:7-9），不含项目名；SQL 迁移/种子文件**零命中**；
+- **协议面零影响**：cookie 名、issuer、User-Agent 中**无任何 authforge 字样**——JWT/session/OIDC 协议行为完全不变，存量令牌不受影响；
+- **运行时配置零耦合**：`apps/server/config/*.json`（5 份）中 0 处 authforge，filters 段为空数组——过滤器名（`"authforge::drogon::filters::..."` 共 56 处字符串字面量）只在代码内自洽，随命名空间一并机械替换即可。
+
+---
+
+## 1. 实测总量（2026-08-25，git 跟踪文件）
+
+- **1658 个文件**含 `authforge`（不区分大小写），合计约 **11,000+ 处**；
+- 目录分布：benchmarks 821（其中 ~770 为**历史测量结果数据**，见 §8）、libs 328、.qoder 镜像 wiki 201（可再生）、tests 108、docs 52、apps 21、clients 18、deploy 17、其余为脚本/CI/配置/README；
+- 标识符变体 TOP：`authforge`(9826)、`authforge-sdk`(279)、`authforge-server`(161)、`authforge-oauth2`(64)、`authforge-tests`(53)、`authforge-drogon`(43)、`authforgepackage`(41)、`authforge_package`(38) 等。
+
+## 2. 分层影响清单
+
+### L1 品牌与身份资产（改名决策本体）
+
+| 资产 | 现状 | 改为 fulla 的影响 |
+|---|---|---|
+| GitHub 仓库 | `voidvec/authforge` | Settings 改名后 web/git 链接 301 重定向（issues/PRs/stars/tags 全保留）；**重定向在别人抢注旧名时失效**——改名后旧名空置即有此风险，可接受 |
+| GitHub org | `voidvec`（不含项目名） | **无影响**。注意：GitHub 用户名/org `fulla` **已被占用**（早前实测 404 检查 github=200），若想要 fulla 同名 org 需变体（`fulla-iam`、`getfulla` 等）或沿用 voidvec |
+| 域名 | — | `fulla.dev` ✅ 已注册（2026-08-26）；`fulla.com` ❌ 已被占 |
+| PyPI | `authforge-oauth2` 在线（实测 HTTP 200） | 新包 `fulla-oauth2`（裸名 `fulla` 在 PyPI 也空，可考虑直接占）；旧包可继续存在但应在新版描述中标注 deprecated |
+| npm | 无已发布包 | 前端 `oauth2-admin`/`oauth2-frontend` 均非发布包，无影响。注意裸名 `fulla` 在 npm 被 2019 年死包占用——未来若发 JS SDK 用 `fulla-sdk` |
+| Go module | `github.com/voidvec/authforge/clients/go` | 必须改为 `github.com/voidvec/fulla/clients/go`；旧路径靠 GitHub 301 短期可解析，**不可长期依赖**，旧版应打 deprecated 注释 |
+| Docker 镜像 | `ghcr.io/voidvec/authforge-{backend,frontend,admin}` | GHCR 包名不随仓库改名自动迁移：新构建发布为 `fulla-*`，旧包留在原地；compose 拉取方需改引用 |
+
+### L2 C++ 源码标识符（机械替换的主体，但=公共 API 破坏）
+
+- **命名空间**：`namespace authforge` 覆盖 **350 个文件**（libs/ + apps/ + tests/）；
+- **公共头文件路径**：8 个目录 `libs/{common,drogon,identity,oauth2,storage-memory,storage-postgres,storage-redis}/include/authforge/`（含 testing）→ 所有 `#include <authforge/...>` 变更，SDK 消费方全破；
+- **CMake**：`project(authforge ...)`（CMakeLists.txt:3）、目标 `authforge::*`（如 `authforge::identity`，CMakeLists.txt:57）、导出包 `cmake/AuthForgePackage.cmake` + `AuthForgePackageConfig.cmake.in`、安装布局 `lib/cmake/authforge-*/`（release.yml:8 注释）；
+- **公共 CMake 选项**（下游用户可见）：`AUTHFORGE_WERROR`、`AUTHFORGE_ENABLE_LTO`、`AUTHFORGE_CMAKE_PRESET`、`AUTHFORGE_VERSION` 等；
+- **字符串字面量**：Drogon 过滤器注册名 56 处（`"authforge::drogon::filters::AuthorizationFilter"`×39、`OAuth2AuthFilter`×17 等）——与 config.json 零耦合（实测 filters 段为空），代码内自洽；
+- **ORM 模型路径**：`paths.env:68` `MODELS_INC_REL_DIR=include/authforge/storage/postgres/models`——orm-gen 流程与生成的 include 路径联动；
+- **conanfile.py**：`AuthForgeConan` 类名与包引用。
+
+### L3 构建与二进制名
+
+- `paths.env:46` `SERVER_BINARY_NAME=authforge-server`、测试二进制 `authforge-tests`（CI 多处默认值）+ 各库测试目标 `authforge-common-test`、`authforge-identity-test` 等（add_executable 实测 6+）；
+- CMakePresets.json：LTO preset 描述与 `AUTHFORGE_ENABLE_LTO` 缓存变量；
+- 所有构建缓存因路径/目标名变化**全部失效，需清空重建**。
+
+### L4 CI / 门禁
+
+- `ci.yml`：测试 exe 名（authforge-tests.exe）、`AUTHFORGE_WERROR`、SDK 头 SemVer 守卫（ci.yml:53，注释明言守卫 `libs/*/include/authforge`）——改名触发该守卫，以 v1.0.0 新版本序列放行；
+- `_build-test.yml`：docker 容器名 `authforge-postgres`/`authforge-redis`（仅 CI 内部，无持久化影响）；
+- **api-diff 门禁**：`tools/api-diff/api-baseline.txt` 含 820 处 authforge——基线是导出 API 符号快照，改名后 diff 会全量飘红；处理=重新生成基线 + `--force` 批准（先例：backchannel logout PR 已有 drift 批准流程）；
+- `release.yml`：安装布局 `lib/cmake/authforge-*/`、可能的 GHCR 发布名；
+- `arch_guard.py`、`api_diff.py` 工具自身的路径规则。
+
+### L5 运行时数据面（升级瞬间的影响）
+
+| 项 | 现值 | 影响 |
+|---|---|---|
+| Redis 键前缀 | `authforge:cache:token:access:` / `token:revoked:` / `token:introspect:` / `client:` / `user:*` 等 | 前缀改 `fulla:` 后旧键全部孤儿化=**一次性全量缓存失效**，升级窗口内回源 DB 有小风暴（QPS 高时注意）；旧键带 TTL 自然过期，无需清理脚本 |
+| Prometheus 指标 | `authforge_cache_total`、`authforge_cache_invalidation_failures_total` | 指标名变更= Grafana 面板/告警规则同步改，否则监控盲窗 |
+| 数据库 | `oauth2_db` / `oauth2_user` | **零影响** |
+| cookie / issuer / JWT / UA | 无 authforge 字样 | **零影响**，存量令牌与会话完全兼容 |
+
+### L6 部署与运维
+
+- `deploy/docker/docker-compose.prod.yml`：三镜像引用 + `AUTHFORGE_VERSION` 环境变量名（5 处）；
+- deploy/ 共 17 个文件（compose ×3、k8s manifests 等）；
+- k8s 部署中的镜像名/资源名（.qoder wiki 的 Kubernetes 部署页有 79 处，可作清单参考）。
+
+### L7 客户端 SDK（已发布工件）
+
+- **Python**：`clients/python/pyproject.toml` `name = "authforge-oauth2"`（PyPI 实测在线）→ 新包 `fulla-oauth2`；旧包发一个带 deprecation 说明的封版或仅改 README；
+- **Go**：module path 变更（见 L1）；Go proxy 缓存旧路径版本，消费方 `go get` 新路径即可，旧模块建议加 `// Deprecated:` 注释；
+- **前端**：品牌文案/标题/e2e 断言/package.json 名的完整清单与陷阱见 §2bis A（8 文件 11 处）；
+
+### L8 文档、镜像目录与历史数据
+
+- docs/ 52 个文件 + README×3 + AGENTS.md/CLAUDE.md/CONTRIBUTING/SECURITY：机械替换；
+- `.qoder/` 201 个文件是**可再生的镜像 wiki**（含路径含 `(authforge__common)` 的文件名）：整体 sed 或由工具重生成；
+- `.codebuddy/`、`.claude/`、`.kiro/`、`.zcode/` 中的规则镜像同步；
+- `benchmarks/` 821 个命中文件中约 **770 个是历史测量结果**（benchmarks/results/ 359、baseline、各 sweep）——**不应改写**：它们是"authforge@某 commit"的测量记录；仅 `benchmarks/authforge/` 工具目录（~30 文件）需要 `git mv` 为 `benchmarks/fulla/` + .gitignore:33 路径同步；
+- `CHANGELOG.md` 历史条目**不改写**（历史事实）；新条目以新名书写。
+
+### L9 本机与工作区（维护者机器特有，细节不入库档）
+
+- 仓库目录改名后：
+  - AI 工具工作区身份 key 随目录名变化，需迁移或重建索引；
+  - 辅助工具的本地扫描历史/coverage 路径失效；
+  - 辅助克隆（基准环境）的路径同步；
+  - 本机 native PostgreSQL 的 DB 名不变（oauth2_*），无数据迁移。
+
+### L10 不可改 / 不应改（负面清单）
+
+1. git 历史与 tag（v1.x.y）——永久保留；
+2. CHANGELOG 历史条目、benchmarks/results 历史数据——测量事实；
+3. PyPI 旧版本、GHCR 旧镜像——只能 deprecate 不能消除；
+4. `docs/branding/rename-candidates.md` 调研报告本身（authforge 是调研对象）。
+
+## 2bis 第二轮补充审查（2026-08-25，五个专项）
+
+### A. 前端品牌面（L7 细化，实测 8 文件 11 处）
+
+- **品牌文案**：`AppLogo.vue`（admin+user）、`LoginPage.vue:37` h1 "AuthForge Admin"、`:94` 页脚 "AuthForge Identity Platform · Enterprise OAuth2/OIDC Server"、user 侧 `AppLayout.vue:130`/`AuthLayout.vue:73` 同款页脚、`design-tokens.css` 注释；
+- **e2e 断言联动（陷阱）**：`frontends/admin/tests/e2e/auth.spec.ts:16` `toContainText('AuthForge Admin')` —— 品牌文案改动必须同步此断言，否则 16 条 admin e2e 直接红；
+- **页面标题**：admin `index.html` `<title>oauth2admin</title>`、user `<title>OAuth2 App</title>` 及 `frontends/user/.env` `VITE_APP_NAME=OAuth2 App` → 统一 Fulla 系（"Fulla Admin"/"Fulla"）；
+- **package.json 名**：`oauth2-admin`/`oauth2-frontend` → `fulla-admin`/`fulla-user`（顺带与目录名 user 对齐；均为非发布包，无 registry 迁移成本）；
+- user 有 `.env`/`.env.example`（含 VITE_GITHUB_CLIENT_ID 等与改名无关项，随迁检查），admin 无 .env；admin 有 favicon.svg，**user 无 favicon**——顺手补齐（品牌 logo 机会）。
+
+### B. 基础设施与 DB 命名规范化（借改名窗口从头开始）
+
+无生产环境，方法 = **改配置 + db-reset 重建**，不写 `ALTER DATABASE RENAME` 迁移 SQL（迁移编号红线不变）。对照表：
+
+| 现值 | 建议新值 | 出现点 |
+|---|---|---|
+| `oauth2_db` / `oauth2_db_prod` | `fulla_db` / `fulla_db_prod` | 5 份 config 的 dbname、compose×3、`_build-test.yml:217` |
+| `oauth2_user` | `fulla_user` | 同上 |
+| `container_name: oauth2-{admin,frontend,backend,postgres,redis,prometheus}` | `fulla-*` | `deploy/docker/docker-compose.yml:7-115` |
+| `OAUTH2_*` 环境变量（20+ 个、1260 处、22 个代码文件读取） | `FULLA_*` | env_common.sh、compose、CI、bench 脚本（注意只改**全大写下划线形态**，见 §3 新增规则） |
+| compose 服务键名（admin/frontend/backend/postgres/redis/prometheus） | **保持** | `config.prod.json` 的 db host `"postgres"`/redis host `"redis"` 引用服务键名 |
+| 卷名 pgdata/redisdata/promdata | **保持** | compose project 前缀已隔离 |
+| redis 密码两套（主 compose `redis_secret_pass` vs debug `123456`） | 顺手统一 | compose×2 |
+| `POSTGRES_PASSWORD=123456` | dev 默认可留；prod 已有 `${POSTGRES_PASSWORD}` 注入机制 | — |
+
+`OAUTH2_`→`FULLA_` 的理由：这批变量中 `OAUTH2_PROJECT_VERSION`/`OAUTH2_ENV`/`OAUTH2_SERVER_DIR` 本就是**项目级而非协议级**，前缀实际起品牌作用；一个品牌一个前缀，避免 fulla 时代继续背着 oauth2 前缀的二次不一致。代价：替换面 +1260 处，但模式单一（纯前缀替换）。
+
+### C. README 与仓库门面
+
+- README.md / README.zh-CN.md 当前定位 "Full-Stack OAuth2/OIDC Authorization Server" —— **借机重写**为终极定位（"高性能 C++ 开源 IAM 核心 + 商业增强模块"），更新模块划分图（libs/* SDK 分层、apps/server、frontends、clients）、Quick Start；benchmark 章节与 "5/5 scenarios lead" 徽章内容保留（指向 benchmarks/competitors）；
+- **owner 不一致（既有问题，改名时一并修）**：仓库内 `github.com/lucaswang420/authforge` 引用 **36 处**（README 徽章等）vs 实际 remote/go module/GHCR 的 `voidvec` —— 统一为 voidvec（`git remote -v` 实测 origin）；
+- **GitHub 仓库元数据**：description 含 "the auth forge for your apps" 双关语需重写；topics 存在拼写错误 `rabc`→`rbac`，可补充 iam/authorization-server 等；homepageUrl 当前为空 → 注册 fulla.dev 后填入。
+
+### D. 五环境配置项审查（config.\{json,dev,ci,prod,bench\}）
+
+- config.json / dev / bench 三份实质相同（dbname oauth2_db、host 127.0.0.1、port 5555）—— 改名落地后可另行决策是否合并为 overlay，减少三份漂移面（非改名必需）；
+- config.prod.json：db host `"postgres"`、redis host `"redis"`（compose 服务键名）—— 服务键名不改则此处只改 dbname；
+- config.ci.json：无 dbclient 段，DB 连接由 CI 以 `OAUTH2_DB_*` env 注入 → **前缀改名的联动点**；
+- 五份 listener 端口统一 5555，一致性良好，无需动。
+
+## 3. 大小写映射表（机械替换的替换规则）
+
+| 旧 | 新 | 例 |
+|---|---|---|
+| `authforge` | `fulla` | 命名空间、路径、二进制名 |
+| `Authforge` | `Fulla` | `AuthforgePackage` → `FullaPackage` |
+| `AuthForge` | `Fulla` | `AuthForgePackage.cmake` → `FullaPackage.cmake`、`AuthForgeConan` → `FullaConan` |
+| `AUTHFORGE` | `FULLA` | `AUTHFORGE_WERROR` → `FULLA_WERROR` |
+| `OAUTH2_`（全大写下划线前缀） | `FULLA_` | `OAUTH2_DB_HOST` → `FULLA_DB_HOST` 等 20+ 变量（§2bis B） |
+| `oauth2_db` / `oauth2_user` / 容器名 `oauth2-*` | `fulla_db` / `fulla_user` / `fulla-*` | 见 §2bis B 对照表 |
+| `authforge-oauth2`（PyPI） | `fulla-oauth2` | — |
+| `authforge::` | `fulla::` | 过滤器注册字符串同步 |
+
+> `fulla` 是真词（可为子串，如英语 FullAuto），反向替换无风险；但正向替换时注意 `authforgepackage`/`authforge_package` 这类**无分隔符拼接变体**（41+38 处）必须列入替换模式，不能只替裸词。
+>
+> **关键区分**：只改 `OAUTH2_`（全大写下划线，环境变量前缀）；**不改** `OAuth2` 驼峰形态——`OAuth2Plugin` 插件类名、`OAuth2AuthFilter`、openapi 里的协议词、"Enterprise OAuth2/OIDC Server" 副标题里的 OAuth2 都是**功能/协议名**，不是项目名，保留。
+>
+> **子串边界教训（Phase 2 实测踩坑，已修复）**：`oauth2_user` 是表名 `oauth2_user_consents` 与 operationId `oauth2_userinfo` 的**子串**——朴素 sed 会把这两类 token 也改掉（32+25 处，含 V006 迁移、model.json、模型 .cc 的 tableName、openapi、Python SDK 函数名），症状是 ORM 重生成后模型类名错乱（FullaUserConsents）与运行时 SQL 表名失配。修复原则：DB 表名、索引名、operationId、URL 路径一律不改；替换后必须按 token 直方图（`grep -hoE 'fulla_[a-z_]+' | sort | uniq -c`）逐类复核边界。
+
+## 4. 兼容性矩阵（谁破谁不破）
+
+| 消费方/资产 | 是否破坏 | 缓解 |
+|---|---|---|
+| C++ SDK 消费方（include 路径+命名空间+CMake 包） | ❌ 破坏（当前仅内部消费） | fulla v1.0.0 新序列 + 迁移说明（一段 sed 即可） |
+| Python SDK 用户 | ❌ 包名变更 | 新包发布 + 旧包 README 标 deprecated |
+| Go SDK 用户 | ❌ module 路径变更 | 新路径 + 旧版 Deprecated 注释 |
+| Docker 部署方 | ❌ 镜像名变更 | 新镜像 fulla-* + 文档公告 |
+| 存量 JWT/session/cookie | ✅ 兼容 | 协议面无项目名（实测） |
+| 存量数据库 | ✅ 兼容 | DB 名无项目名（实测） |
+| Redis 缓存 | ⚠️ 一次性失效 | 升级窗口回源风暴，TTL 自然清理 |
+| Grafana/告警 | ⚠️ 指标断点 | 面板同步改名 |
+
+## 5. 建议执行顺序（13 步）
+
+1. **前置外部资产**：域名与包名等外部资产于改名日前置办理（具体清单见本地维护副本）；
+2. 开改名分支，写替换脚本（按 §3 映射表，含拼接变体），先 `git mv` 八个 `include/authforge/` 目录与 `benchmarks/authforge/`；
+3. 跑替换（排除 benchmarks/results、CHANGELOG 历史区、docs/branding/）；替换模式 = §3 映射表全表，**含 `OAUTH2_`→`FULLA_` 前缀替换与 §2bis B 的 DB/容器名规范化**（只替全大写 `OAUTH2_`，不动驼峰 `OAuth2` 类名）；
+4. 重生成 ORM 模型（orm-gen，路径联动）与 **api-diff 基线**，`--force` 批准记录在 PR 描述；
+5. 清空全部构建目录，全量构建 + `full_test` 8 步后端流水线 + 前端（admin 16 e2e + user 8 e2e）；
+6. CI 三件套（ci/release/_build-test/_sdk-smoke）中的 exe 名/容器名/环境变量同步；
+7. deploy/ 三份 compose + k8s manifests：镜像名 → `ghcr.io/voidvec/fulla-*`，`AUTHFORGE_VERSION` → `FULLA_VERSION`；同时落 §2bis B 的基础设施规范化（DB 名/用户/container_name/redis 密码统一；compose 服务键名与卷名不动）；
+8. 清除旧版本序列：删除五个旧 tag（v1.0.0–v1.4.1）及对应 GitHub Releases（`git tag -d` + `git push --delete`，Releases 需在 GitHub 侧显式删除）——git 提交历史与 CHANGELOG.md 历史区**原样保留**，CHANGELOG 顶部加更名分界说明；随后版本定为 **v1.0.0** 走发版六处版本同步流程（openapi.yaml info.title、pyproject 等）+ openapi tags/SDK drift 检查（PR #85 教训：openapi tags 丢失会挂 SDK 门）；
+9. PyPI 发布 `fulla-oauth2` 1:1 首版；旧包 README 加 deprecated 指引；
+10. GitHub 仓库改名（放最后，重定向即刻生效）；GHCR 新镜像名随 release.yml 首次发布；
+11. 前端品牌与仓库门面（§2bis A/C）：AppLogo/LoginPage 文案、index.html 标题、`VITE_APP_NAME`、package.json 名、**auth.spec.ts e2e 断言同步**、user 侧 favicon 补齐；README 双语重写（新定位 + 模块划分 + owner 统一为 voidvec）；GitHub 元数据更新（description、topics 含 `rabc`→`rbac` 修正、homepage=fulla.dev）；
+12. 维护者本机工作区改名与各工具本地索引迁移；
+13. 旧工件收尾：Grafana 面板、告警规则、外部文档/榜单（若有）公告更名。
+
+## 6. 风险清单（TOP 8）
+
+1. **api-diff 基线重生成**是唯一"改错了会放走真回归"的环节——基线重生成前后各跑一次全量测试；
+2. **过滤器注册字符串漏改**（56 处字面量藏在 .cc 深处）会导致运行时过滤器失配启动失败——靠全量 e2e 兜底；
+3. **Redis 前缀变更的回源风暴**——高 QPS 生产环境选择低峰升级；
+4. **拼接变体漏替换**（authforgepackage 等 80+ 处无分隔符形态）——替换脚本必须含这些模式并 grep 验证归零；
+5. **npm/PyPI/GitHub 的 fulla 裸名占用不对称**（PyPI 空、npm 死包、GitHub org 被占）——包名策略先行统一再动手，避免发一半改主意；
+6. **前端 e2e 品牌断言**（auth.spec.ts:16 `toContainText('AuthForge Admin')`）与文案不同步会挂 admin e2e —— 文案与断言必须同 PR；
+7. **owner 不一致**（lucaswang420×36 处 vs voidvec）——统一方向错了会让 README 徽章/克隆链接全断，以 `git remote -v` 的 voidvec 为准；
+8. **`OAUTH2_` 替换误伤**：sed 模式若写成宽松的 `OAUTH2` 会把 `OAuth2Plugin`/协议词一并破坏 —— 前缀替换必须锚定全大写下划线形态（§3 关键区分）。
+
+### 红线（版本重置 ≠ 这些也重置）
+
+1. **DB migration 编号**：schema_migrations 序号是 schema 演进史，与产品版本无关——重置它会让所有已初始化的 dev/测试库校验失败，是整个改名过程中**唯一可能真正搞坏数据**的操作；
+2. **git 提交历史**：不 rebase、不 squash——PR #47–#85 的评审与决策历史是工程资产，只动 tag 指针；
+3. **CHANGELOG 历史区与 benchmarks/results 历史数据**：authforge 时代的发布与测量事实，原样保留，仅新条目用新名。
+
+## 7. 实施计划（PR 切分与验证门）
+
+> 配套审计：[repo-professionalization-audit.md](repo-professionalization-audit.md)（Phase 1 的逐文件依据）
+
+| Phase | 分支/PR | 内容 | 验证门 | 执行者 |
+|---|---|---|---|---|
+| **P0** 资产占位 | —（无代码） | 域名与包名等外部资产前置办理 | 资产到手 | **用户手动** |
+| **P1** 专业仓库清理 | `chore/professional-repo-cleanup` | 审计清单执行：untrack `.qoder/.codebuddy/.zcode/.kiro`（kiro specs 先迁 docs/history）、删过期 MEMORY.md、.gitignore 增补、AGENTS.md 角色表、绝对路径泛化 | 纯文件操作；`git status` 干净 + CMake configure 冒烟 | 代理可执行 |
+| **P2** 改名机械替换 | `feat/rename-fulla`（基于 P1） | §3 映射全表替换（含 `OAUTH2_`→`FULLA_`、§2bis B 基础设施规范化）+ 8×`include/authforge` 与 `benchmarks/authforge` 的 git mv + config 五份 | **Release 构建 + 353 ctest 全绿** + 前端 tsc/build | 代理可执行 |
+| **P3** 门禁与基线 | 并入 P2 或紧随 | api-baseline 重生成 + `--force` 批准记录；arch-guard；前端 e2e 16+8（含 auth.spec.ts 断言联动） | CI 全绿 + 本地全量前端测试 | 代理可执行 |
+| **P4** 定版与门面 | `release/v1.0.0` | 删旧 tag v1.0.0–v1.4.1 + Releases；v1.0.0 六处版本同步 + openapi tags/SDK drift 检查；README 双语重写；前端品牌文案；GitHub 元数据（description/topics/rbac/homepage） | 发版六点本地预检清单全过 | 代理可执行（tag 删除需用户确认） |
+| **P5** 外部与本机收尾 | —（无 PR） | GitHub 仓库改名；GHCR 新镜像首推；PyPI 发布；本机目录改名 + ZCode 工作区迁移 + WSL 克隆同步；Grafana/告警同步 | Release workflow 全绿 | **用户手动**（远程操作+凭据） |
+
+**依赖关系**：P0 与 P1 并行；P2→P3→P4 严格串行；P5 最后。P1 必须先于 P2 合入（否则改名 diff 混入 347 个出库文件的噪音，评审不可读）。
+
+**回滚**：P1–P4 均为可 revert 的普通 PR；P5 的 GitHub 仓库改名可再改回（重定向链保持）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/repo-professionalization-audit.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/repo-professionalization-audit.md
@@ -1,0 +1,61 @@
+---
+title: 档案 · 专业仓库改造审计（2026-08-25）
+date: 2026-08-25
+status: 已执行（chore/professional-repo-cleanup 落地）
+sidebar_label: 档案 · 仓库改造审计
+---
+
+# 专业仓库改造审计 — 入库范围清理清单
+
+> 审计日期：2026-08-25 ｜ 方法：`git ls-files` 全量盘点 + 体积/敏感内容/生成物交叉筛查
+> 背景：仓库转入专业化运营（配合 authforge→fulla 更名，见 [rename-impact-fulla.md](rename-impact-fulla.md) §7 Phase 1）
+
+## 一、必须从远程去除的文件（untrack + gitignore，磁盘保留）
+
+| # | 目录/文件 | 规模 | 性质 | 处置 |
+|---|---|---|---|---|
+| 1 | `.qoder/` | 257 文件 / ~150KB（含 1.1MB repowiki 元数据） | Qoder AI 工具工作区：repowiki 为**生成的仓库 wiki**（201 页，改名时还会产生 800+ 处替换噪音） | `git rm -r --cached` + ignore |
+| 2 | `.codebuddy/` | 45 文件 | `.claude/rules/`+skills 的**镜像副本**（内容一致，纯冗余、有漂移风险） | 同上 |
+| 3 | `.zcode/` | 21 文件 | ZCode 工具专属：skills 镜像 + 2 个旧 plans（`plans/` 已在 .gitignore，这 2 个是规则生效前的漏网） | 同上 |
+| 4 | `.kiro/` | 23 文件 | Kiro 工具专属 specs —— 但其中 **6 个 spec 的 design/requirements/tasks 是有价值的工程设计文档**，先迁移再去除 | **先迁 `docs/history/design/kiro-specs/`**（`.config.kiro` 工具状态文件不迁），再 untrack + ignore |
+| 5 | `.claude/MEMORY.md` | 1 文件 | 2025-04 断代的**过期个人自动化记忆**（自称"OAuth2 插件示例项目"，与现状严重失配） | 直接 `git rm`（删除） |
+
+**合计**：约 347 个文件出库。所有工具目录磁盘副本保留（本地工具流不受影响），仅退出版本库。
+
+**去除理由归纳**：专业仓库入库标准 = 对所有贡献者有复现/协作价值的产物。AI 工具的个人工作区、可再生成物、多副本镜像均不符合；`.claude/`（规则权威源）作为唯一例外保留，见下。
+
+## 二、保留清单（审查过但有明确专业理由，防御性记录）
+
+| 项 | 规模 | 保留理由 |
+|---|---|---|
+| `.claude/`（除 MEMORY.md） | 37 文件（rules 4 / skills 19 / agents 7 / commands 6 / settings） | AGENTS.md 声明的**规则权威源**，等价于贡献者工作流文档；settings.json 权限/钩子配置合理 |
+| `.vscode/` | 5 文件 | 共享 IDE 配置（launch/tasks/c_cpp + `settings.local.json.example` 模板）；`*.local.json` 已 ignore |
+| `benchmarks/results/` | 885 文件 / 仅 756KB | README 明示"从提交的 JSON 再生对比报告"的**可复现性设计**，非垃圾数据 |
+| `docs/backend/api/swagger-ui/` vendored bundle | ~3.9MB | 离线可用的 API 文档（标准 vendoring 做法） |
+| `tools/api-diff/api-baseline.txt` | 300KB | CI API 门禁基线（改名时按计划重生成） |
+| `clients/go/generated/`、`frontends/*/package-lock.json`、`conan.lock` | — | 生成 SDK 是交付物本体；锁文件是专业仓库标配 |
+
+## 三、需要调整（不出库，但要改）
+
+1. **`.gitignore` 增补**：`.qoder/`、`.codebuddy/`、`.zcode/`、`.kiro/`、`.workbuddy/`（`.workbuddy/` 当前未忽略，git status 长期裸奔）；
+2. **`AGENTS.md`「各 AI 工具目录的角色」表**：从"多工具镜像同步"改为"`.claude/` 唯一权威 + 其余工具目录本地化"；
+3. **机器绝对路径泛化（共 3 处，已执行）**：`.claude/skills/full-backend-test/SKILL.md:20` 的 `cd /d/work/...` → `cd "$(git rev-parse --show-toplevel)"`；`docs/history/design/http-integration-test-coverage-plan.md:10` 的本地 Drogon 检出路径 → 通用描述；`docs/history/design/superpowers/specs/2026-04-14-multiplatform-ci-design.md:519` 的 `file:///D:/...` 本地链接 → 纯文本引用（初扫误报的 `docs/ops/deployment-windows-docker-desktop.md` 复核后无个人路径，未改）；
+4. （随改名 PR 处理，不在本清单执行）README owner 统一、GitHub topics `rabc` 拼写等见 rename-impact §2bis C。
+
+## 四、审计确认无问题项
+
+- **零密钥/证书/凭据入库**：无 `*.pem/*.key/*.crt` 跟踪；`PRIVATE KEY` 零命中；`frontends/user/.env`（含 GitHub client id 等）已被 .gitignore 正确拦截；
+- **零构建产物/IDE 垃圾**：dist/build/node_modules/coverage 均未跟踪；
+- **`.claude/settings.local.json` 未入库**（仅 `.vscode` 有 `.example` 模板，处理正确）；
+- 现有 `.gitignore` 本身已相当完善（本审计仅增补上述 5 条）。
+
+## 五、执行记录（Phase 1 实际命令）
+
+```bash
+git switch -c chore/professional-repo-cleanup          # 基于 origin/master (e973a4f8)
+git mv .kiro/specs/<6 个 spec 目录> docs/history/design/kiro-specs/   # 迁移设计文档
+git rm docs/history/design/kiro-specs/*/.config.kiro   # 工具状态文件不迁
+git rm -r --cached .qoder .codebuddy .zcode            # 出库（磁盘保留）
+git rm .claude/MEMORY.md                               # 过期记忆删除
+# + .gitignore 增补、AGENTS.md 角色表更新、绝对路径泛化
+```

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/architecture/architecture-overview.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/architecture/architecture-overview.md
@@ -1,0 +1,107 @@
+# 架构总览
+
+本文从技术栈、模块布局、请求流转与部署形态四个视角，概括 fulla 的整体架构。
+
+## 1. 技术栈
+
+| 层 | 技术 | 用途 |
+|---|---|---|
+| Web 框架 | Drogon | 高性能异步 C++ HTTP 服务 |
+| 主数据库 | PostgreSQL 17 | 用户、角色、客户端、授权码与令牌的持久化（2026-08-18 起为部署默认；服务端也可运行在 15 上——升级路径见 [PG 大版本升级](../operate/postgresql-major-upgrade.md)） |
+| 缓存 / KV | Redis | Postgres 前置的可选 L2 缓存（client 与 access-token 读路径）；独立 Redis 存储已弃用（限流为进程内实现，不依赖 Redis） |
+| 前端 | Vue 3 + Vite | OAuth2 授权码流程的 SPA 客户端 |
+| 部署 | Docker Compose | 本地与类生产全栈部署 |
+| 可观测 | Prometheus | 经 Drogon PromExporter 采集指标 |
+
+## 2. 模块布局
+
+为保证真正的可插拔，项目重构为「核心插件库 + 演示服务器」两层：
+
+```text
+HTTP 请求
+  |
+  |-- fulla-server（apps/server —— 演示服务器二进制）
+  |   `-- AuthService：本地应用认证（libs/drogon/src/AuthService.cc）
+  |
+  `-- fulla::drogon（libs/drogon —— 独立 SDK 包，target fulla::drogon）
+      |-- 插件核心
+      |   `-- OAuth2Plugin：初始化与生命周期管理
+      |
+      |-- 协议控制器与过滤器（自动注册）
+      |   |-- AuthorizationEndpointController / TokenEndpointController / DiscoveryController：
+      |   |     处理 /oauth2/authorize、/oauth2/token、/.well-known/*、/userinfo
+      |   `-- 过滤器：AuthorizationFilter、OAuth2AuthFilter
+      |
+      |-- 服务层（核心业务逻辑，libs/oauth2）
+      |   |-- TokenService：PKCE、授权码/令牌的生成与交换
+      |   |-- ClientService：客户端凭据与 redirect URI 校验
+      |   `-- IdentityService：RBAC、subject 映射与用户同意
+      |
+      `-- 存储层（按仓储定义端口，按后端装配 Bundle）
+          |-- I{Client,Grant,Token,Consent,UserInfo}Repository：存储端口（libs/oauth2）
+          |-- MemoryRepositoryBundle：进程内测试存储（libs/storage-memory）
+          |-- PostgresRepositoryBundle：持久化存储（libs/storage-postgres）
+          `-- RedisRepositoryBundle：Redis 存储（libs/storage-redis）
+```
+
+## 3. 授权码流程
+
+```mermaid
+sequenceDiagram
+    participant SPA as Vue SPA
+    participant App as fulla-server (App)
+    participant Core as OAuth2Plugin (Core)
+    participant Store as Storage
+
+    SPA->>Core: GET /oauth2/authorize
+    Core->>Store: validate client
+    Core-->>SPA: 302 → App /login
+    SPA->>App: POST /api/login
+    App->>Store: AuthService::validateUser
+    App-->>SPA: 302 /callback?code=...
+    SPA->>Core: POST /oauth2/token
+    Core->>Store: consume auth code
+    Core->>Store: save access token
+    Core-->>SPA: access_token JSON
+    SPA->>Core: GET /oauth2/userinfo
+    Core->>Store: validate token
+    Core-->>SPA: userinfo JSON
+```
+
+## 4. 存储策略
+
+`OAuth2Plugin` 依据 `config.json` 中的 `storage_type` 选择后端。
+
+| storage_type | 实现 | 典型用途 |
+|---|---|---|
+| memory | `MemoryRepositoryBundle` | 单元测试与本地快速演示 |
+| redis | `RedisRepositoryBundle` | **已弃用**——启动时打 ERROR 日志，并以 `unsupported_grant_type` 拒绝 `refresh_token` 授权；不要使用。Redis 现在仅作为 Postgres 前置的可选缓存层（见[配置指南 §3](../operate/configuration-guide.md)） |
+| postgres | `PostgresRepositoryBundle` | 生产持久化存储 |
+
+> 每个 `*RepositoryBundle` 同时装配同一后端下的 client / grant / token / consent / userinfo 五个仓储实现（见各 `libs/storage-*/include` 下的头文件）。
+
+## 5. 前后端集成
+
+前端从登录页发起 OAuth2 授权码流程：将 CSRF `state` 存于 localStorage，
+处理 `/callback`、用授权码换取令牌，随后调用 `/oauth2/userinfo`。
+
+第三方社交登录时，前端接收外部授权码后提交给后端端点：
+
+- `/api/google/login`
+- `/api/wechat/login`
+
+与 provider 的令牌交换在服务端完成，provider 密钥不暴露给浏览器。
+
+## 6. 部署形态
+
+Docker Compose 默认启动：
+
+- `fulla-frontend`：端口 `8080`
+- `fulla-admin`（管理后台）：端口 `8081`
+- `fulla-backend`：端口 `5555`
+- PostgreSQL：宿主端口 `5433`
+- Redis：宿主端口 `6380`
+- Prometheus：端口 `9090`
+
+生产环境建议在反向代理终结 TLS，再将 API 请求代理到 Drogon 后端
+（完整步骤见[生产部署](../operate/deployment.md)）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/architecture/data-persistence.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/architecture/data-persistence.md
@@ -1,0 +1,233 @@
+# OAuth2 数据持久化文档 (Data Persistence)
+
+本文档详细描述了 OAuth2 插件的持久化层设计、数据库 Schema、Redis 键值结构以及安全加固方案。
+
+## 1. 设计目标
+
+- **存储解耦**：通过仓储接口（`libs/oauth2/include/fulla/oauth2/repository/` 下的 `IClientRepository`、`IGrantRepository`、`ITokenRepository` 等）抽象，支持内存、PostgreSQL、Redis 等多种存储后端，各后端以 `*RepositoryBundle` 装配实现。
+- **数据持久化**：确保 Client 信息、Token、Auth Code 等关键数据不丢失。
+- **安全加固**：Client Secret 绝不明文存储，强制使用 SHA256 加盐哈希。
+- **异步高性能**：底层操作全部采用 `execSqlAsync` 和 `execCommandAsync`，基于回调机制，充分利用 Drogon 的非阻塞 I/O 能力。
+
+---
+
+## 2. PostgreSQL 存储方案
+
+适用于生产环境，提供严格的全部关系型数据一致性。
+
+### 2.1 Database Schema
+
+由迁移脚本 `apps/server/migrations/V002__oauth2_core.sql` 创建（幂等，`IF NOT EXISTS`；后续迁移会追加 scopes、device codes、lockout 等列）。核心表结构如下：
+
+#### 客户端表 (`oauth2_clients`)
+
+存储接入的客户端应用信息。
+
+```sql
+CREATE TABLE IF NOT EXISTS oauth2_clients (
+    client_id       VARCHAR(50) PRIMARY KEY,
+    client_type     VARCHAR(20) NOT NULL DEFAULT 'CONFIDENTIAL',
+    client_secret   VARCHAR(100) NOT NULL, -- 存储 SHA256(secret + salt) 的 Hex 字符串
+    salt            VARCHAR(50) NOT NULL,  -- 随机盐值
+    name            VARCHAR(100),
+    redirect_uris   TEXT,                  -- 逗号分隔或 JSON 数组
+    allowed_grant_types TEXT               -- 允许的 grant_type 列表
+);
+```
+
+#### 授权码表 (`oauth2_codes`)
+
+短期有效的授权凭证。
+
+```sql
+CREATE TABLE IF NOT EXISTS oauth2_codes (
+    code            VARCHAR(100) PRIMARY KEY,
+    client_id       VARCHAR(50) NOT NULL REFERENCES oauth2_clients(client_id),
+    user_id         VARCHAR(50),
+    scope           TEXT,
+    redirect_uri    TEXT,
+    code_challenge  VARCHAR(128),          -- PKCE 支持
+    code_challenge_method VARCHAR(10),      -- S256 / plain
+    expires_at      BIGINT NOT NULL,       -- Unix Timestamp
+    used            BOOLEAN DEFAULT FALSE  -- 防重放攻击
+);
+```
+
+#### 访问令牌表 (`oauth2_access_tokens`)
+
+```sql
+CREATE TABLE IF NOT EXISTS oauth2_access_tokens (
+    token           VARCHAR(100) PRIMARY KEY, -- 存 SHA-256(token) 哈希（64 hex），非明文（ADR-0004）
+    client_id       VARCHAR(50) NOT NULL REFERENCES oauth2_clients(client_id),
+    user_id         VARCHAR(50),
+    scope           TEXT,
+    expires_at      BIGINT NOT NULL,
+    revoked         BOOLEAN DEFAULT FALSE,
+    issued_at       BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::BIGINT,
+    issuer          VARCHAR(255) NOT NULL DEFAULT '',
+    audience        VARCHAR(255),
+    not_before      BIGINT DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::BIGINT,
+    introspect_count INTEGER DEFAULT 0,
+    revoked_at      BIGINT,
+    revoked_by      VARCHAR(50)
+);
+```
+
+#### 刷新令牌表 (`oauth2_refresh_tokens`)
+
+```sql
+CREATE TABLE IF NOT EXISTS oauth2_refresh_tokens (
+    token           VARCHAR(100) PRIMARY KEY,   -- 存 SHA-256(token) 哈希，非明文（ADR-0004）
+    access_token    VARCHAR(100) NOT NULL, -- 关联的访问令牌哈希（无外键约束，按值引用）
+    client_id       VARCHAR(50) NOT NULL REFERENCES oauth2_clients(client_id),
+    user_id         VARCHAR(50),
+    scope           TEXT,
+    expires_at      BIGINT NOT NULL,
+    revoked         BOOLEAN DEFAULT FALSE,
+    revoked_at      BIGINT,
+    revoked_by      VARCHAR(50)
+);
+```
+
+---
+
+## 3. Redis 存储方案（已弃用）
+
+> **⚠️ 独立 Redis 存储已弃用（F-005）**：该模式启动时打 ERROR 日志，并以
+> `unsupported_grant_type` 拒绝 `refresh_token` 授权；历史上 refresh token
+> 从未在该模式持久化。新部署一律用 `postgres` + 可选 Redis 缓存层（§缓存
+> 一致性）。以下键空间仅作存量部署参考。
+
+### 3.1 Key Pattern 设计
+
+所有 Key 均以 `oauth2:` 前缀开头（缓存层另有独立的 `fulla:cache:` 前缀，
+事务协调键族 `oauth2:transaction:*` 未列入下表）。
+
+| 实体 | Key 格式 | 类型 | TTL | 说明 |
+|------|-------------|------|-----|------|
+| **Client** | `oauth2:client:{client_id}` | Hash | 无 | 字段: `secret` (Hash), `salt`, `redirect_uris` (JSON), `allowed_scopes` (JSON) |
+| **Auth Code** | `oauth2:code:{code}` | String | 10分钟 | Value: JSON 序列化对象 |
+| **Access Token** | `oauth2:token:{token}` | String | 1小时 | Value: JSON 序列化对象 |
+| **Refresh Token**| `oauth2:refresh:{token}` | String | 30天 | Value: JSON 序列化对象 |
+
+### 3.2 示例数据
+
+**Client (Hash Structure)**:
+
+```bash
+HSET oauth2:client:vue-client secret "42a121b66fb9f1d4f73125788f42eb6799110c6aeae5a9a12a2fed5307a0088d" salt "random_salt" redirect_uris "[\"http://localhost:5173/callback\"]"
+```
+
+**Auth Code (String Value)**:
+
+```json
+{
+  "client_id": "vue-client",
+  "user_id": "admin",
+  "scope": "openid",
+  "redirect_uri": "http://localhost:5173/callback",
+  "expires_at": 1735689000,
+  "used": false
+}
+```
+
+---
+
+## 4. 安全加固 (Security Hardening)
+
+为了防止数据库泄露导致 Client Secret 暴露，本系统实施了强制哈希策略。
+
+### 4.1 算法与流程
+
+1. **存储时**：
+    - 生成随机 `salt`（可选，但在 Postgres Schema 中建议预留）。
+    - 计算 `Hash = SHA256(raw_secret + salt)`。
+    - 数据库存储 `Hash` (Hex String) 和 `salt`。
+
+2. **验证时**：
+    - 用户提交 `input_secret`。
+    - 系统读取库中的 `stored_hash` 和 `salt`。
+    - 计算 `CheckHash = SHA256(input_secret + salt)`。
+    - 比对 `CheckHash` 与 `stored_hash` (忽略大小写)。
+
+### 4.2 代码实现
+
+位于 `RedisClientRepository::validateClient` 和 `PostgresClientRepository::validateClient` 中。
+
+```cpp
+// 核心逻辑示例
+std::string input = clientSecret + client->salt;
+std::string calculatedHash = drogon::utils::getSha256(input.data(), input.length());
+return lower(calculatedHash) == lower(storedHash);
+```
+
+---
+
+## 5. 数据生命周期管理 (Data Lifecycle)
+
+为了防止数据库无限增长，系统实现了自动化的过期数据清理机制。
+
+### 5.1 策略概览
+
+| 存储后端 | 清理策略 | 实现机制 | 频率 |
+|----------|----------|----------|------|
+| **Redis** | **TTL 自动清理** | 依赖 Redis 原生 `SETEX`/`EXPIRE` 机制，无需应用层干预。 | 实时 |
+| **PostgreSQL**| **定期删除** | 由 `OAuth2CleanupService` 调用 `IGrantRepository` / `ITokenRepository` 的清理方法删除过期 Auth Code、Access/Refresh Token。 | 默认每 1 小时 |
+| **Memory** | **定期扫描** | 同上，由 `OAuth2CleanupService` 触发各仓储的过期清理。 | 默认每 1 小时 |
+
+### 5.2 调度器实现
+
+清理由独立的 `OAuth2CleanupService`（`libs/drogon/src/plugin/OAuth2CleanupService.cc`）承担，在 `OAuth2Plugin::initAndStart` 中创建并启动，间隔由插件配置项 `cleanup_interval_seconds` 控制（默认 `3600`，见 `config.json`）：
+
+```cpp
+cleanupService_ = std::make_shared<OAuth2CleanupService>(grantRepo_, tokenRepo_);
+double cleanupInterval = config.get("cleanup_interval_seconds", 3600.0).asDouble();
+cleanupService_->start(cleanupInterval);
+```
+
+服务内部用 `drogon::app().getLoop()->runEvery(interval, ...)` 周期触发，并通过 `weak_from_this()` 防止在销毁后回调。
+
+### 5.3 接口定义
+
+清理不再集中于单一的 `IOAuth2Storage::deleteExpiredData`；而是按仓储拆分，由 `IGrantRepository`（Auth Code）与 `ITokenRepository`（Access/Refresh Token）各自提供过期删除方法，由 `OAuth2CleanupService` 编排调用。
+
+## 6. 存储后端选型与 Memory 后端警告 (F-031)
+
+> **⚠️ Memory 存储后端仅供测试 / 开发使用，生产环境禁用。**
+
+`storage_type="memory"`（见 `config.ci.json`）将所有 client / token / code /
+consent 数据保存在进程内存中，**密钥（client_secret）以明文存储**（不经
+SHA-256 加盐哈希），且：
+
+- 进程重启即丢失全部数据（无持久化）；
+- 无多用户 / 多实例共享（每个进程一份独立状态）；
+- 无事务、无原子 CAS 保证（测试桩实现）；
+- Memory identity 仓库永远从 `findByUsername` 返回 `nullopt`，因此 admin
+  登录链路在该模式下不可用（`loginAsAdmin()` 返回 `nullopt`，依赖它的集成
+  测试会干净跳过）。
+
+**生产部署必须使用 `storage_type="postgres"`**（Postgres 是唯一受支持的生产
+存储后端；独立 Redis 存储模式已弃用，见 F-005 / [配置指南 §3](../operate/configuration-guide.md)）。
+Memory 后端存在的唯一目的是让 Windows / macOS CI 环境在无 Postgres 时仍能
+跑通不依赖 DB 的测试用例（contract 测试、纯单测、协议错误信封测试等）。
+
+## 数据一致性专题
+
+### 授权码单次使用（防双花）
+
+`consumeAuthCode` 在存储层保证原子性：PostgreSQL 用 `UPDATE ... WHERE consumed = false ... RETURNING`
+（raw SQL 豁免条款）；Redis 后端用 Lua 脚本；Memory 后端用互斥锁。契约由
+`tests/contract/GrantRepositoryContractTest.cc` 的三实现同测覆盖。
+
+### 缓存一致性：延迟双删
+
+Redis L2 缓存（键前缀 `fulla:cache:`）的写路径失效采用**延迟双删**：立即 DEL + 事件循环上
+延迟二次 DEL（默认 200ms，`cache.invalidation_double_delete_delay_ms` 可配，钳位 [50,2000]），
+以覆盖"读线程在 DEL 前刚回填旧值"的竞态窗口（issue #79）。二次 DEL 失败可观测：
+`fulla_cache_invalidation_failures_total{kind}` 计数器（issue #80）。读路径为 cache-aside，
+未命中回源 PostgreSQL 后回填（TTL 兜底最终一致）。
+
+### refresh token 家族与级联撤销
+
+refresh token 存储家族标识（V008），检测到重放即撤销整个家族；撤销可按 token / client / user
+三个粒度发起（管理 API 与 `/oauth2/revoke`）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/architecture/security-architecture.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/architecture/security-architecture.md
@@ -1,0 +1,157 @@
+# OAuth2 安全架构设计 (Security Architecture)
+
+本文档详细描述了本系统的安全威胁模型及相应的防御机制，涵盖 Token 生命周期管理、加密存储及防攻击策略。
+
+## 1. 威胁模型与防御 (Threat Model)
+
+| 威胁类型 | 描述 | 防御机制 | 对应文档 |
+|----------|------|----------|----------|
+| **Replay Attack** (重放攻击) | 攻击者截获 Auth Code 并在合法客户端之前或之后尝试兑换。 | **Atomic Consume** (原子消费) + **One-Time Use Enforcement**。 | [Data Consistency](data-persistence) |
+| **Credential Leakage** (凭据泄露) | 数据库被拖库导致 Client Secret 泄露。 | **SHA256 Salted Hash**。数据库仅存 Hash 值，绝不存明文。 | [Data Persistence](data-persistence) |
+| **Token Theft** (令牌窃取) | Access Token 被截获。 | **Short-lived Token** (1小时) + **Refresh Token Rotation** (轮转机制)。 | 本文档 |
+| **CSRF** | 攻击者诱导用户进行非预期的授权。 | 强制校验 **state** 参数 (推荐客户端实现)。 | [API Reference](../domains/api-reference.md) |
+
+## 2. Token 生命周期管理
+
+### 2.1 Access Token
+
+- **有效期**: 1小时。
+- **用途**: 访问受保护资源（如 `/userinfo`）。
+- **验证**: 无状态（JWT）或有状态（DB 查询）。本项目采用 **有状态** 验证，支持即时撤销。
+
+### 2.2 Refresh Token
+
+- **有效期**: 30天。
+- **用途**: 在 Access Token 过期后换取新 Token。
+- **安全机制: 轮转 (Rotation)**
+  - 每次刷新时，不仅颁发新的 Access Token，也会 **颁发新的 Refresh Token**。
+  - 旧的 Refresh Token 立即失效。
+  - **检测机制**: 如果检测到旧 Refresh Token 被再次使用，系统可视为 Token 泄露，并级联撤销该 `token_family` 下的所有关联 Token（已实现，见 §7.2）。
+
+## 3. 密钥管理 (Secrets Management)
+
+### 3.1 Client Secrets
+
+- **存储**: `sha256(secret + salt)`
+- **传输**: 仅在 POST body 中通过 HTTPS 传输。
+
+### 3.2 配置文件
+
+- 敏感信息（如 DB 密码、Redis 密码）建议通过 **环境变量** 注入，而非硬编码在 `config.json` 中。
+- 生产环境部署时，应确保配置文件权限严格限制。
+
+## 4. 最佳实践建议
+
+- **HTTPS**: 生产环境 **必须** 启用 HTTPS/TLS，否则 OAuth2 毫无安全性可言。
+- **PKCE**: 对于移动端/SPA 客户端，建议开启 PKCE (Proof Key for Code Exchange) 模式（本后端已实现并对 PUBLIC 客户端默认强制启用，支持 `plain` 与 `S256`）。
+- **IP 白名单**: 对于高权限 Client，建议限制 Token 兑换的源 IP。
+
+## 5. Token 存储安全 (Token Storage)
+
+所有 Token（Access Token、Refresh Token）在数据库中 **仅存储 SHA-256 哈希值**，绝不存储明文。
+
+- **存储格式**: `SHA-256(token_value)`
+- **验证流程**: 客户端提交 Token → 服务端计算哈希 → 与数据库哈希比对
+- **优势**: 即使数据库泄露，攻击者无法还原出有效 Token
+
+## 6. 密码哈希策略 (Password Hashing)
+
+### 6.1 当前标准 (OWASP 2023)
+
+- **算法**: PBKDF2-SHA256
+- **迭代次数**: 310,000 次（符合 OWASP 2023 推荐）
+- **Salt**: 每用户独立随机 Salt（16 字节）
+- **输出**: 32 字节密钥
+
+### 6.2 遗留密码迁移
+
+系统支持从旧版 SHA-256 单次哈希渐进式迁移到 PBKDF2：
+
+1. 用户登录时，系统检测密码哈希格式
+2. 若为旧格式（SHA-256），验证通过后自动升级为 PBKDF2
+3. 迁移对用户透明，无需重置密码
+
+## 7. Refresh Token 轮转与家族追踪 (Refresh Token Rotation)
+
+### 7.1 家族追踪机制 (Family-Based Tracking)
+
+每个 Refresh Token 链共享一个 `token_family` 标识符：
+
+- 首次颁发 RT 时生成唯一 `token_family` ID
+- 后续轮转的 RT 继承同一 `token_family`
+- 系统可追踪整个 Token 链的生命周期
+
+### 7.2 重用检测与级联撤销
+
+当检测到已撤销的 Refresh Token 被再次使用时：
+
+1. **检测**: 收到的 RT 在数据库中标记为已撤销
+2. **判定**: 视为 Token 泄露（攻击者持有旧 RT）
+3. **响应**: 级联撤销该 `token_family` 下的 **所有** Token
+4. **结果**: 合法用户和攻击者均需重新认证
+
+### 7.3 时序图
+
+```mermaid
+sequenceDiagram
+    participant U as 用户
+    participant S as 服务器
+    participant A as 攻击者
+    U->>S: 使用 RT-1 刷新
+    S-->>U: 撤销 RT-1，颁发 RT-2（同 family）
+    A->>S: 使用 RT-1 刷新（重用!）
+    S->>S: 检测到 RT-1 已撤销
+    S->>S: 级联撤销 family 下所有 Token
+    U--xA: 下次请求失败，需重新登录
+```
+
+## 8. Subject 隐私保护 (Subject Privacy)
+
+### 8.1 UUID public_sub
+
+- **外部标识**: 使用 UUID v4 作为 `public_sub`（公开主体标识符）
+- **内部标识**: 数据库自增 ID 仅用于内部关联
+- **防枚举**: UUID 不可预测，攻击者无法通过递增 ID 枚举用户
+- **OIDC 兼容**: `id_token` 中的 `sub` claim 使用 `public_sub`
+
+### 8.2 对比
+
+| 方案 | 可枚举 | 信息泄露 | OIDC 兼容 |
+|------|--------|----------|-----------|
+| 自增 ID | ✗ 可预测 | 泄露用户数量 | ✓ |
+| UUID public_sub | ✓ 不可预测 | 无信息泄露 | ✓ |
+
+## HTTP 安全响应头
+
+全局中间件为所有响应附加：`X-Content-Type-Options: nosniff`、`X-Frame-Options: DENY`、
+`Referrer-Policy: strict-origin-when-cross-origin`、`Content-Security-Policy`（API 域收敛策略）。
+
+## 全局限流：Hodor（仅生产配置启用）
+
+全局侧限流由 Drogon 官方 **Hodor** 插件承担（令牌桶 + 进程内 CacheMap，IP/用户/全局三级），
+**只在 `config.prod.json` 挂载**（开发配置不含该插件）。当前生产阈值（以 `config.prod.json`
+为准，此处为快照）：`/oauth2/login` IP 容量 3 / 用户容量 2；`/oauth2/token` 5/min；其余端点
+全局 5000、每 IP 30。拒绝响应经错误信封 `VALIDATION_RATE_LIMITED`（429）返回。
+
+> 注意与 F-018 的关系：这是**全局侧**限流（任意请求，防扫）；`configuration-guide` §8 的
+> 进程内失败计数限流是**认证侧**防爆破（login/token 失败计数），两者并存、作用面不同。
+
+## 安全运维清单
+
+**例行验证**：密钥不入库（`git grep` 抽查 + Secret Hygiene CI 门）；`.env*` 均被 ignore；
+前端生产构建无内嵌凭据。
+
+**密钥轮换**：JWKS 当前为单 kid 静态密钥（F-029 为后续运维任务，轮换流程未自动化）；
+DB/SMTP/社交凭据轮换 = 改 env + 滚动重启。
+
+**事件响应**：泄漏怀疑 → 立即轮换受影响凭据 → 如涉历史提交，用 `git filter-repo`
+（勿用已弃用的 filter-branch）重写并强推 → 通报。
+
+**pre-commit 钩子模板**（可选）：
+
+```bash
+#!/bin/sh
+if git diff --cached | grep -qiE '(api[_-]?key|secret|password)\s*[:=]'; then
+  echo "possible credential in commit"; exit 1
+fi
+```

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/benchmark/competitor-benchmark-design.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/benchmark/competitor-benchmark-design.md
@@ -1,0 +1,402 @@
+# Fulla 竞品性能基准对比设计
+
+> **版本**: v1.1（2026-08-15 评审修订：新增 M0 前置参数化、S5 池规模修正、GC 抖动场景钉死、Fulla 同 session 重跑、Zitadel JWT-profile 认证说明、warmup 口径对齐入仓数据）
+> **日期**: 2026-08-15
+> **文档性质**: 技术设计（Phase 0.5 落地蓝图，**非代码**——实施见 §七 milestone）
+> **上游规划**: [演进方案 §三 Phase 0]（productization-evolution-plan：本地维护档案） P0「自托管竞品对比基准」
+> **前置依赖**: 基准设施设计（内部档案，已随 productization-evolution 目录转为本地维护） M1–M4 已交付（S1–S6 自测数据已入仓 `benchmarks/results/`）
+> **验证对象**: 调研报告 §3.1（内部档案，已转本地维护） 竞品列（Keycloak/Ory）的量级参考数字
+
+---
+
+## 零、TL;DR
+
+- **做什么**：在**同一台机器、同一套 wrk 阶梯、同一个 PostgreSQL 后端**下压 Keycloak / Ory Hydra / Zitadel，与 Fulla 已入仓的自测数据（`benchmarks/results/SUMMARY.md`）产出同口径对比表。
+- **比什么**：S1 discovery / S2 client_credentials / S3 introspect / S5 refresh_token / S6 userinfo 五个单步场景 + 冷启动 + 稳态 RSS + **GC 抖动长跑**（5 分钟 P99 时间序列——Fulla 无 GC 的核心差异化证据）。
+- **不比什么**：S4 auth_code（各产品登录/consent 流程不可 wrk 统一驱动）；Auth0（SaaS，无法自托管）；竞品的极限调优配置（一律用官方推荐生产配置）。
+- **核心原则**：公平性优先于数字好看。竞品社区会质疑，方法论必须无懈可击——同硬件、同并发阶梯、同后端、各产品官方推荐配置、脚本全部入仓可复现。
+- **验收**：四家同口径对比表（QPS / P99 / 稳态 RSS / 冷启动 / GC 抖动）落盘 `benchmarks/competitors/results/COMPARISON.md`；第三方按 README 一键复现。
+
+---
+
+## 一、目标与非目标
+
+### 1.1 目标
+
+| # | 目标 | 衡量 |
+|---|------|------|
+| G1 | **同环境竞品对比数据**：把调研报告 §3.1 的竞品列（"来自各产品社区公开基准，非同环境对比"）替换为同环境实测 | §六验收 ✅ COMPARISON.md |
+| G2 | **验证差异化叙事**：C++ 无 GC / 低内存 / 低尾延迟的卖点是否有同环境数据支撑 | GC 抖动长跑 + 稳态 RSS 对比 |
+| G3 | **可复现**：第三方按 `benchmarks/competitors/README.md` 在同规格机器跑出误差 &lt;15% 的数据 | 复现门槛（沿用自测设施 AC1） |
+| G4 | **诚实修订**：若某维度 Fulla 不领先，据实修订调研报告 §3.1/§3.2 的卖点排序 | 报告更新 |
+
+### 1.2 非目标
+
+| # | 非目标 | 为什么 / 归属 |
+|---|--------|--------------|
+| N1 | Auth0 / Okta 等托管竞品 | SaaS 无法自托管、无法控制环境；其公开数字不可复现。仅保留在调研报告的量级参考里 |
+| N2 | S4 auth_code 场景对比 | 各产品的登录页/重定向/consent 交互流完全不同，wrk 无法统一驱动（详见 §四 D4） |
+| N3 | 竞品极限调优 | 一律官方推荐生产配置。极限调优对比是军备竞赛，无公信力；官方文档链接随结果附上 |
+| N4 | 功能/协议覆盖度对比 | 属产品能力审计（iam-architecture-audit.md），与性能无关 |
+| N5 | Fulla 阶梯数据重跑 | 同 session 仍会重跑（见 §5.1 v1.1 修正：gcjitter/RSS/冷启动必采 + R7 消漂移）；"复用"仅指沿用同一 runner/口径，2026-08-12 入仓数据降级为历史基线 |
+
+---
+
+## 二、背景：为什么现在做
+
+### 2.1 Phase 0 已完成自测，对比是最后缺口
+
+Phase 0（benchmark M1–M4）已于 2026-08-12 交付：S1–S6 六场景、40 个 JSON、承重验证报告（`benchmarks/results/SUMMARY.md`）。Fulla 自身数字已可信。
+
+调研报告 §3.1 的竞品列（Keycloak ~10–20k QPS、Ory ~30–50k QPS）标注为"社区公开基准，非同环境对比，仅作量级参考"。**没有同环境对比数据，"比 Keycloak 快 N 倍"就不能出现在任何对外物里。**
+
+### 2.2 Fulla 自测基线（对比基准，2026-08-12 实测）
+
+| 场景 | 稳态 QPS | 稳态 P99 | 错误率 |
+|------|---------|---------|--------|
+| S1 discovery | 86,332 | —（低并发 &lt;1ms） | 0.006% |
+| S2 client_credentials | 8,915 | 8ms | 0.000% |
+| S3 introspect | 17,132 | 12ms | 0.000% |
+| S5 refresh_token | 1,982 | 26ms | 0.000% |
+| S6 userinfo | 16,674 | 12ms | 0.000% |
+
+环境：WSL2 8 vCPU / 16GB / PG 连接池 25 / Redis 20 / wrk 4.1.0 / 阶梯 2→128。
+详见 `benchmarks/results/SUMMARY.md`。
+
+### 2.3 现有可复用资产
+
+| 资产 | 复用方式 |
+|------|---------|
+| `run-scenario.sh` 阶梯 runner（warmup→measure→JSON） | 竞品场景直接传不同的 `.lua`；runner 加**可选**参数（`READY_PATH`/`RESULTS_DIR`/`WRK_LIB_DIR`/`--reissue` 钩子，见 M0.1），单一实现不复制第二份 |
+| `parse-wrk.py`（wrk 文本→schema v1 JSON） | 场景无关，仅加 `--product/--product-version` 透传参数（M0.2） |
+| `observe/docker-stats.sh` + `scrape-metrics.sh` | docker-stats 加 `CONTAINER_GLOB` 参数（M0.3）采竞品容器 RSS/CPU；scrape-metrics 仅 Fulla 可用（竞品无 `/metrics` 端点，观察项拆分） |
+| `measure-cold-start.sh` 模式 | 每家竞品一个等价的冷启动计时脚本 |
+| `lib/gen-tokens.py` 思路 | 竞品 token 池生成（各家 introspect 的 token 须由其自身签发，见 D5） |
+| docker-compose 底座（PG15） | 竞品 compose 复用同一 PG 版本与连接池配置 |
+
+---
+
+## 三、关键约束与设计决策
+
+### D1 — 公平性三同原则（同硬件 / 同工具 / 同后端）
+
+**这是整个方案的可信度基础。**
+
+| 维度 | 统一值 | 说明 |
+|------|--------|------|
+| 硬件 | 同一台机器（Phase 0 用的 WSL2 8 vCPU/16GB，或后续专用裸机） | 四家依次跑，中间 `docker compose down -v` 清场 |
+| OS/内核 | 同一 WSL2 Ubuntu | — |
+| 压测工具 | wrk 4.1.0，同一份阶梯参数（2→4→8→16→32→64→128）、warmup 5s / measure 10s（与入仓自测数据口径一致；Keycloak warmup 60s，见 D2 豁免） | 复用 `run-scenario.sh`，不写第二套 runner |
+| 后端存储 | PostgreSQL 15（同一 image tag），连接池对齐 25 | 竞品各自支持的连接池上限可能 &lt;25，取 `min(25, 官方上限)` 并在结果中标注 |
+| 网络拓扑 | localhost cross-container（wrk 在宿主机） | 与自测一致 |
+| 结果格式 | schema v1 JSON（`parse-wrk.py`） | 四家数据同构，`run-comparison.sh` 才能聚合 |
+| 端口 | 各家栈固定端口（fulla 5555 / Keycloak 8080 / Hydra 4444+4445 / Zitadel 8080） | 串行执行互不冲突；每家 setup 前置断言端口空闲 |
+
+### D2 — 竞品配置 = 官方推荐生产配置（不调优、不调差）
+
+**依据**：极限调优对比无公信力；故意调差是学术造假。
+
+| 竞品 | 配置基线 | 官方出处 |
+|------|---------|---------|
+| Keycloak | `start --optimized` + PostgreSQL，内存按官方建议 2GB 限额 | [Running Keycloak in a container](https://www.keycloak.org/server/containers) |
+| Ory Hydra | 官方 docker-compose + PostgreSQL DSN | [Ory Hydra docs](https://www.ory.sh/docs/hydra/self-hosted/deploy-hydra) |
+| Zitadel | 官方 compose（`setup mode` 初始化 + PostgreSQL） | [Set up ZITADEL with Docker Compose](https://zitadel.com/docs/self-hosting/deploy/compose) |
+
+每家竞品的 `setup.sh` 头部注释必须附官方文档链接；偏离官方默认的每一项（如连接池对齐）单独注释理由。
+
+**JVM 预热豁免**：Keycloak 的 JIT/GC 需要更长预热。warmup 对 Keycloak 延长到 60s（其余三家与 Fulla 自测口径一致取 5s，测量时长统一 10s），在结果中标注——这不是偏袒，是给 JIT 编译时间，否则测的是"未编译的解释执行"。
+
+### D3 — 场景映射：功能等价，不是路径等价
+
+各产品端点路径不同，映射到**同一功能**的端点（§四矩阵）。关键约束：
+
+- **S3 introspect 的 Ory 特例**：Hydra 的 introspect 在 admin 端口（4445）而非 public 端口，且生产部署中 admin 端口通常不对外。为公平，四家都测 introspect 但**在 COMPARISON.md 中标注 Ory 的 admin-port 语义差异**。
+- **认证方式**：client_credentials 用各产品的标准 client 认证（Basic 或 post，按其声明）。
+- **Zitadel S2 特例（JWT profile）**：Zitadel 的官方 M2M 路径是 Service User + private_key_jwt（token 端点**不支持** Basic 认证的 client_credentials）。wrk Lua 无法签名 JWT，故 setup 阶段用 python（pyjwt + cryptography，WSL 已具备）预签 client_assertion 池，exp 覆盖整个跑数窗口；若 Zitadel 强制 jti 单用则每档重签（等价 S5 的 --reissue 机制）。COMPARISON.md 附录注明"JWT profile 是 Zitadel 官方推荐的机器认证，功能等价"。
+
+### D4 — 排除 S4 auth_code：wrk 不可驱动
+
+Fulla 的 S4 是 `login → token` 两步 form POST（headless 可驱动）。但：
+- **Keycloak** auth_code 需要走其登录页 HTML 表单 + JS
+- **Ory Hydra** 需要外部 login/consent app 配合（Hydra 本身无登录 UI）
+- **Zitadel** 有自己的登录会话流
+
+统一驱动需要真实浏览器（Playwright），测的是"登录页渲染"而非"token 签发"。**首期排除 S4，COMPARISON.md 注明限制**；若后续需要，用"预签发 code + 单步 token 交换"近似（各产品预签发方式不同，复杂度高，Phase 0.6 再议）。
+
+### D5 — 竞品 token 池必须由其自身签发（不能 SQL 直插）
+
+Fulla 自测的 S3/S6 用 SQL 预种 token（`gen-tokens.py`）。**竞品不行**：
+- Keycloak 的 access token 是签名的 JWT，哈希/密钥格式私有
+- Hydra/Zitadel 同理
+
+**方案**：每家竞品的 `setup.sh` 通过其**自身的 token 端点**批量签发 token，把活跃 token 写入 token 池文件，Lua 场景脚本复用同一套 token-pool 逻辑（线程切片，复用 `s3-introspect.lua` 模式）。
+
+**池规模（v1.1 修正——两类池口径不同）**：
+- **S3/S6 池（可复用）**：token 只读验证不消耗，N=2000 足够；批量签发本身约 1–2 分钟（并行 xargs -P8 更快）。
+- **S5 池（单发单耗）**：每个 refresh token 用一次即失效，池必须 ≥ 该档 QPS × 测量时长 × 1.3 余量。Fulla 自测的实测口径：20,000 池 ÷ 10s ≈ 1,982 QPS（池刚好覆盖测量窗口）。竞品每档前须**重发池**（`run-scenario.sh` 新增 `--reissue "<cmd>"` 钩子，等价自测的 SQL `--reseed`，但走各家 API）。
+- **RT 不能来自 client_credentials**：RFC 6749 §4.4.3 规定该 grant 不得签发 refresh token。竞品 RT 池须经用户上下文流程获取——Keycloak 用 ROPC（direct access grants）；Hydra 用 accept 流（见 M2）；Zitadel 用 Session API/auth_code（见 M2）。
+
+### D6 — GC 抖动 = 长跑 P99 时间序列（Fulla 核心差异化证据）
+
+单次 30s 跑看不出 GC 周期。设计专门的**长跑测试**：
+
+```
+每家：c=32 固定，持续 5 分钟，场景钉 S6 userinfo
+（v1.1 修正：S5 不可用——池会耗尽；S2 有写放大——Fulla 每请求落库一条 token，
+5 分钟 ~8k QPS ≈ 240 万行，对四家工作负载构成不对称；S6 是读路径、token 池可复用、
+四家功能等价，是最公平的载波。Hydra 若 S6 标 N/A 则降级 S2 并在结果中标注。）
+采集：每 10s 窗口记录一次该窗口的 P99（wrk 不支持原生分段 → 30 个串行 10s 段近似）
+输出：P99 随时间的曲线（JSON 数组）
+预期：Keycloak 出现周期性 P99 尖峰（GC STW）；Ory 出现 Go GC 小尖峰；Fulla 平线
+```
+
+实现：`benchmarks/competitors/run-gc-jitter.sh`——循环调用 wrk `-d10s` 30 次串联，每段 parse 出 P99 存数组。**这是对外叙事最有力的一张图**（"零 GC 抖动"的可视化证据）。
+
+### D7 — 内存口径统一：容器全栈 RSS + 标注逻辑层
+
+Phase 0 承重验证发现 Fulla 容器 RSS ~2.4GB（含 Drogon 连接池/共享库 COW）与"50–120MB"声称口径不匹配。对比方案统一口径：
+
+| 口径 | 采集 | 用途 |
+|------|------|------|
+| 容器全栈 RSS | `docker stats` 稳态采样（复用 observe 脚本） | **对比表主口径**——四家同口径可比 |
+| 进程 PSS（可选） | `smem` / `/proc/*/smaps_rollup` | 消除 COW 共享页重复计数的补充口径 |
+
+在 COMPARISON.md 明确写"全栈容器 RSS，含各自运行时+连接池"，避免口径争议。
+
+---
+
+## 四、对比场景矩阵
+
+### 4.1 场景 × 竞品端点映射（已按官方文档核实）
+
+| 场景 | 功能 | Fulla | Keycloak | Ory Hydra | Zitadel |
+|------|------|-----------|----------|-----------|---------|
+| **S1** discovery | OIDC 发现文档 | `GET /.well-known/openid-configuration` | `GET /realms/{r}/.well-known/openid-configuration` | `GET /.well-known/openid-configuration` (public :4444) | `GET /.well-known/openid-configuration` |
+| **S2** client_credentials | 机器间 token | `POST /oauth2/token` | `POST /realms/{r}/protocol/openid-connect/token` | `POST /oauth2/token` (public :4444) | `POST /oauth/v2/token` |
+| **S3** introspect | token 内省 | `POST /oauth2/introspect` | `POST /realms/{r}/protocol/openid-connect/token/introspect` | `POST /admin/oauth2/introspect` (admin :4445) ⚠ | `POST /oauth/v2/introspect` |
+| **S5** refresh_token | token 刷新 | `POST /oauth2/token` (refresh) | `POST /realms/{r}/protocol/openid-connect/token` (refresh) | `POST /oauth2/token` (refresh) | `POST /oauth/v2/token` (refresh) |
+| **S6** userinfo | 用户信息 | `GET /oauth2/userinfo` | `GET /realms/{r}/protocol/openid-connect/userinfo` | `GET /userinfo` (public :4444) | `GET /oidc/v1/userinfo` |
+| ~~S4~~ auth_code | 用户登录 | ~~`login→token`~~ | ~~登录页不可 headless 驱动~~ | ~~需外部 consent app~~ | ~~登录会话流~~ |
+
+> ⚠ Ory introspect 的 admin-port 语义差异在结果中标注。Keycloak realm 名、Hydra public/admin 双端口、Zitadel 的 instance domain 都在各自 setup 脚本中固定为常量。
+
+端点出处：
+- Keycloak: [OpenID Connect endpoints](https://www.keycloak.org/docs/latest/securing_apps/)（`/realms/{realm}/protocol/openid-connect/*`）
+- Ory Hydra: [API docs](https://www.ory.sh/docs/hydra/reference/api)（public :4444 / admin :4445）
+- Zitadel: [OpenID Connect Endpoints](https://zitadel.com/docs/apis/openidoauth/endpoints)
+
+### 4.2 指标矩阵
+
+| 指标 | 采集方式 | 对比表列 |
+|------|---------|---------|
+| 稳态 QPS（err&lt;0.01% 最高档） | wrk 阶梯 + parse-wrk.py | ✅ |
+| P50 / P95 / P99（稳态档） | wrk `--latency` | ✅ |
+| 错误率 | wrk non-2xx | ✅（门槛列） |
+| 冷启动（→health 200） | 各家等价计时脚本 | ✅ |
+| 稳态容器 RSS | docker stats 采样 | ✅ |
+| GC 抖动（5min P99 曲线） | run-gc-jitter.sh | ✅（专项小节） |
+| driver CPU | run-scenario.sh 现有采样 | ✅（可信度标注） |
+
+---
+
+## 五、测试策略
+
+### 5.1 执行顺序（单机串行，防互相干扰）
+
+```
+1. Fulla    — 同 session 重跑（v1.1 修正：gcjitter/RSS/冷启动是 AC1/AC2 的必采项，
+                  Phase 0 未采过 gcjitter；且 R7 要求四家同一 session 连续跑以消除跨日
+                  环境漂移。2026-08-12 入仓数据保留为历史基线，同 session 新数据用于对比）
+2. Keycloak     — setup → 阶梯 → 长跑 → 冷启动 → teardown
+3. Ory Hydra    — 同上
+4. Zitadel      — 同上
+每家之间 docker compose down -v + 确认无残留容器/卷/网络
+```
+
+`run-comparison.sh --fresh` 全串行执行；`--only keycloak` 支持单家补跑。
+
+### 5.2 竞品 setup 约定（每家一个 setup.sh）
+
+每个 `setup.sh` 必须：
+1. 启动该竞品 + PostgreSQL（对齐连接池，见 D1）
+2. 等待健康（各家的 ready 探针：Keycloak `/realms/master`、Hydra `/health/ready`、Zitadel `/debug/healthz`）
+3. 初始化配置（realm/client/用户——用各家 CLI 或 admin API）
+4. **批量签发 token 池**（D5：N 次 client_credentials 请求 → `access_tokens.txt`）
+5. warmup 校验（一个 token 请求确认管线通）
+
+### 5.3 长跑 GC 抖动（D6）
+
+参数：`c = 各家稳态拐点档`，30 × 10s 段（共 5 分钟），段间无间隔。
+输出：`results/<date>-<sha>-<product>-gcjitter.json`（P99 数组 + 段时间戳）。
+
+### 5.4 冷启动
+
+各家独立计时：`docker compose up -d <idp>` → 轮询 ready 探针 200。
+记录两模式（含/不含 DB 预热）与自测 `measure-cold-start.sh` 对齐。
+
+### 5.5 环境元数据
+
+结果 JSON 的 `env` 块沿用 schema v1，新增 `product` / `product_version` 字段（parse-wrk.py 加一个透传参数），COMPARISON.md 表头列出版本。
+
+---
+
+## 六、验收标准（可勾选）
+
+> ✅ 2026-08-17 全部通过（M0–M3 交付，四产品同 session 实测 2026-08-17，COMPARISON.md 由 gen-comparison.py 生成）。
+> 🔄 2026-08-21 全量重跑刷新（同一设施，Fulla 换性能优化后基准档——wave-1/2 + LTO，见 G1 交付注）：**五场景全部领先**（此前 S5/S6 落后——S5 系测量预算伪影已修口径、S6 经 wave-2 用户/角色缓存反超）；GC 节新增跨产品环境噪声互证（四家同款尖峰）。调研报告 §3.1 已同步引用新表。
+
+| # | 验收项 | 衡量 | 状态 |
+|---|--------|------|------|
+| AC1 | **四家同口径对比表**：S1/S2/S3/S5/S6 × \{QPS, P99, RSS, 冷启动\} 入仓 `benchmarks/competitors/results/COMPARISON.md`，每行带产品版本号 | COMPARISON.md | ✅ |
+| AC2 | **GC 抖动曲线**：四家 5 分钟 P99 时间序列 JSON + 对比小节（Fulla 是否平线、Keycloak 是否有周期尖峰） | gcjitter JSON + 小节 | ✅（结论与预期相反，见 G4 注记：GC 语言全平线、Fulla 有环境层秒级尖峰——已在报告与研究报告中诚实修订） |
+| AC3 | **可复现**：`run-comparison.sh` 一键串行跑四家；README 含环境要求与复现步骤 | 复现指引 | ✅（`benchmarks/competitors/README.md`） |
+| AC4 | **公平性声明**：每家竞品的配置来源（官方文档链接）、偏离默认的每一项、warmup 差异（Keycloak 60s）均显式标注 | COMPARISON.md 附录 + setup.sh 注释 | ✅ |
+| AC5 | **诚实修订**：调研报告 §3.1 竞品列更新为"同环境实测"，§3.2 卖点若被证伪则收敛 | research.md 更新 | ✅（S5/S6 与 GC 抖动主张按实测收敛，见 §3.1/3.2 修订） |
+| AC6 | **S4 排除声明**：COMPARISON.md 注明 auth_code 场景的方法限制 | 限制小节 | ✅（附录 B.1） |
+
+### 实施勘误记录（v1.2，2026-08-17 落地时修订；v1.3 增补 2026-08-18 两项）
+
+实施过程中偏离本设计 v1.1 的决策，全部为公平性/可行性修正：
+
+1. **Zitadel 版本 v2.71.19 → v4.17.1**：v2.71 已落后两个大版本（当前稳定线 v4，与 Keycloak 26 / Hydra 26 同代），且 v4 为 eventstore/投影性能重写。测旧版会失真贬低 Zitadel，不可辩护。首次尝试的 `v1.80.0-v2.9-amd64` tag 实为 v1 时代 CockroachDB-only 镜像，废弃。
+2. **Zitadel S2 认证路径修正**：设计 D3 原表述"client_assertion（JWT profile）"在 v2.71/v4 实测均不可用——Zitadel token 端点对机器用户的 client_credentials 只走 Basic-secret（每请求哈希），官方 M2M 路径是 **RFC 7523 jwt-bearer 授权**（`grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=…`）。S2/S3 的等价性标注已按此更新。
+3. **Zitadel S3 认证换私钥**：#6220 官方建议——secret 认证每请求做密码哈希（CPU 瓶颈）；改用 OIDC app + private_key_jwt。实测对比：Basic 路径 S3 无法过错误门，私钥路径 2.9k QPS 零错误。
+4. **投影平复门**：mint ~2000 token 后立即开压，Zitadel CQRS 投影追赶会使 S1 出现 500 风暴（c=16 达 99.99% 错误）。run-all 前置 discovery 冒烟门（clean 才开跑），消除该伪影。
+5. **S5 Zitadel = N/A**（DG-2 提前裁决）：机器用户无 refresh token（RFC 6749 §4.4.3）、password grant 已移除、Session API→auth_code 属用户交互流（D4 同类排除理由）。限制小节注明。
+6. **docker-stats.sh 竖线 glob 回归修复**：bash 5.2 下 `case $x in $GLOB)`（GLOB 含 `|`）不再展开为多分支——Fulla 侧 RSS 采样自 M0 参数化起一直空采；改为拆分逐个匹配。该回归同时解释了 v1.1 后 Fulla RSS 数据缺失。
+7. **Fulla S2 scope 跟随 #43**：seed 摒弃 legacy `read/write`，bench 校验与 s2 lua 改用 `tokens:read`（同码同测，非口径变化）。
+8. **（v1.3）四产品 PG 15 → 17 同步升级**（2026-08-18，f789bda）：设计基线为"与自测相同 tag 的 `postgres:15-alpine`"。偏离动机：D1 同环境公平——维持四产品同 PG 大版本；Fulla 服务端 libpq 已是 17.x，client 17/server 15 的错位消除。Fulla 自身 15 vs 17 A/B 在噪声带内（无自身吞吐诉求）。deploy/ 的 compose 与 Helm 同步到 17（存量卷升级 runbook 见 `docs/operate/postgresql-major-upgrade.md`，CHANGELOG 已标 BREAKING）。
+9. **（v1.3）Fulla Redis 池 25 → 64**（2026-08-18，快赢 8838ac6）：设计 §5.2 连接池口径按 pool=25 对齐；实施时 cache-on 要求池 ≥ 预期并发（pool 20 时 S6 全连接超时 -18%），bench overlay 调至 64。竞品各按自家官方默认池口径运行（在 COMPARISON.md 公平性附录注明）。
+
+---
+
+## 七、实施计划（4 个 milestone，每步带验收标准）
+
+> v1.1：M0 为评审新增前置——共享设施的参数化改造（向后兼容，不带新 env 时行为不变）。
+
+### M0 — 共享设施参数化（前置，~0.5 天）
+
+| # | 步骤 | 内容 | 验收标准 |
+|---|------|------|---------|
+| M0.1 | `run-scenario.sh` 参数化 | (a) `READY_PATH` env（默认 `/health/ready`）——健康门探针可换竞品探针；(b) `RESULTS_DIR` env（默认 `benchmarks/results`）；(c) `WRK_LIB_DIR` 导出改为 `${WRK_LIB_DIR:-$BENCH_DIR/lib}`（竞品 lua 指向自家 lib）；(d) `BENCH_PRODUCT`/`BENCH_PRODUCT_VERSION` env 透传给 parse-wrk.py；(e) 通用 `--reissue "<cmd>"` 钩子：每档 warmup 前与 measured 前各执行一次（竞品 S5 用 API 重发 token 池，替代 Fulla 的 SQL `--reseed`）；(f) `--observe` 拆为 `--observe-stats`（仅 docker-stats）与 `--observe-metrics`（仅 scrape-metrics；竞品无 `/metrics` 不用） | **AC-M0.1a** 不带任何新 env 跑 Fulla S1 单档（c=2, -d10s）：行为与改造前一致（JSON schema、默认值、输出路径全不变）；**AC-M0.1b** `READY_PATH=<任意 200 路径> RESULTS_DIR=<tmp> BENCH_PRODUCT=x` 时健康门走新路径、JSON 落新目录且 env.product=x；**AC-M0.1c** `--reissue "touch $TMP/marker"` 冒烟：每档产生两个 marker（warmup 前+measured 前） |
+| M0.2 | `parse-wrk.py` 透传 | `--product`/`--product-version` CLI 参数 → env 块新增 `product`/`product_version` 字段（缺省 `fulla`/空） | **AC-M0.2** wrk 样例文本经管道解析，JSON 含两字段且值正确；不传参时缺省值不破坏现有聚合 |
+| M0.3 | `docker-stats.sh` 容器过滤参数化 | `CONTAINER_GLOB` env（默认保持 `*fulla-backend*|*fulla-postgres*|*fulla-redis*` 语义） | **AC-M0.3** `CONTAINER_GLOB='*keycloak*'` 采样时输出含 keycloak 容器行、不含 fulla 行 |
+| M0.4 | schema 文档同步 | `result-schema.md` env 块补 `product`/`product_version` 字段说明 | 文档字段表与实现一致（对照检查） |
+
+### M1 — Keycloak 对比（最重，先啃硬骨头，~2 天）
+
+配置基线（D2）：`quay.io/keycloak/keycloak:<pin 版本>` + `start --optimized` + `--memory 2G`（官方容器建议），PostgreSQL 用与自测**相同 image tag** 的 `postgres:15-alpine`，端口 8080。
+
+| # | 步骤 | 内容 | 验收标准 |
+|---|------|------|---------|
+| M1.1 | `docker-compose.yml` | keycloak + postgres；healthcheck 打 `/realms/master`；卷/网络显式前缀 `kc-bench-` | **AC-M1.1a** `up -d` 后探针 200；**AC-M1.1b** `down -v` 后 `docker ps -a`/`docker volume ls`/`docker network ls` 无 kc-bench 残留 |
+| M1.2 | `setup.sh` | 等健康 → `kcadm.sh` 建 realm `bench`、client `bench-svc`（confidential + service account + introspection 权限）、user `bench-user`（direct grant）→ **校准跑**（c=8 单档 S2/S5/S6 估 QPS）→ 按 `池 = QPS×10s×1.3` 生成 RT 池（ROPC 批量签发，xargs -P8 并行）+ AT 池 ≥2000（S3/S6 复用）→ warmup 验证一发 token 请求 | **AC-M1.2a** `set -euo pipefail`，任何 kcadm/curl 失败即非零退出；**AC-M1.2b** 结尾自检：两个池文件行数 ≥ 期望、单发 client_credentials 得 200；**AC-M1.2c** 幂等：`down -v` 后重跑 setup 成功 |
+| M1.3 | `scenarios/`（5 个 lua） | s1/s2/s3/s5/s6 按 §4.1 端点改写；S2 用 Basic（bench-svc）；S3 Basic + AT 池（线程切片，复用 s3 模式）；S5 RT one-shot 池；S6 Bearer AT 池 | **AC-M1.3** 每个场景 `wrk c=2 -d5s` 冒烟：非 2xx=0、socket 错误=0（S5 允许池尾 nil 关连接，但不得有 invalid_grant） |
+| M1.4 | 阶梯数据 | `WARMUP_S=60 DURATION_S=10` 阶梯 2→128 × 5 场景 → 35 个 JSON；S2 档挂 `--observe-stats` 采 RSS | **AC-M1.4a** 35 JSON 全带 `product=keycloak` + 版本；**AC-M1.4b** 每档 driver CPU &lt;80% 或 JSON 标 `limited=true`；**AC-M1.4c** RSS tsv 落盘且含 keycloak+postgres 行 |
+| M1.5 | GC 抖动 | `run-gc-jitter.sh`：S6 c=32，30×10s 段（D6） | **AC-M1.5** JSON 含 30 个 P99 数据点 + 段起始时间戳；无段失败 |
+| M1.6 | 冷启动 | 两模式：A=全新卷完整初始化（含 realm/client 建立）；B=预初始化卷仅重启 keycloak 容器 | **AC-M1.6** 2 个 JSON（mode A/B），含秒数与 RSS 峰值 |
+| M1.7 | `teardown.sh` | down -v + 残留断言 | 同 AC-M1.1b |
+| M1.8 | 首版两方对比 | Fulla 同 session 重跑（§5.1）+ Keycloak 数据 → 草稿对比表 | **AC-M1.8** 5 场景 × `QPS / P50/P95/P99 / RSS / 冷启动` 行齐、版本列齐 |
+
+### M2 — Ory Hydra + Zitadel（~3 天）
+
+**Hydra**：无内建用户体系。S5/S6 的用户 token 用官方 mock 模式 headless 驱动：`GET /oauth2/auth`（login 跳转）→ admin API `POST /admin/oauth2/auth/requests/login/accept` + `consent/accept` → code → token，纯 curl 可驱动（无需浏览器）。
+**Zitadel**：S2 走 JWT profile 预签 assertion 池（D3 特例）；S3 用 API client + Basic；S5/S6 优先 v2 Session API 建 password 会话 → auth_code 换用户 token。
+
+| # | 步骤 | 验收标准 |
+|---|------|---------|
+| M2.1 | Hydra compose（hydra v2 + PG，public 4444 / admin 4445）+ setup（client create + accept 流驱动签池）| 同 M1.1/M1.2 模式：探针 `/health/ready` 200；池文件行数自检；任何 curl/jq 失败非零退出 |
+| M2.2 | Hydra scenarios + 阶梯 + gcjitter + 冷启动 | 同 M1.3–M1.6 验收；S3 JSON/结果带 admin-port 标注 |
+| M2.3 | Zitadel compose（`setup` mode 初始化 + `start` mode 运行）+ setup（机器用户 JSON key、API client、人类用户） | 同 M1.1/M1.2；setup 两阶段（init/start）可分别重入 |
+| M2.4 | Zitadel scenarios + 阶梯 + gcjitter + 冷启动 | 同 M1.3–M1.6；S2 结果注明 JWT-profile 认证等价性 |
+
+**决策门（M2 内）**：
+- **DG-1**：Hydra accept 流若 curl 驱动不成（如强制 JS），S5/S6 标 N/A。判据：setup 能稳定取得带 `openid` scope 的用户 token。
+- **DG-2**：Zitadel Session API→auth_code 若 2 个工作日内驱动不成，S5/S6 标 N/A（S1/S2/S3 保底），限制小节写明。
+
+### M3 — 汇总 + 诚实修订（~1 天）
+
+| # | 步骤 | 验收标准 |
+|---|------|---------|
+| M3.1 | `gen-comparison.py` 聚合器 | 读四家 JSON 全自动生成 COMPARISON.md：主表（5 场景 × QPS/P50/P95/P99/RSS/冷启动 × 版本列）、GC 抖动小节、公平性附录（配置出处 + 偏离项 + warmup 差异）、限制小节（S4 排除、Ory admin-port、Zitadel JWT-profile、WSL2 声明）。**AC-M3.1**：无手填数字；缺某家某场景时显式 N/A 不缺行 |
+| M3.2 | `run-comparison.sh` 编排器 | `--fresh` 全串行（每家之间清场+残留断言）+ `--only <product>` 补跑 + 末尾自动调聚合器。**AC-M3.2**：一条命令从空环境到 COMPARISON.md |
+| M3.3 | research.md §3.1/§3.2 修订 | 竞品列改"同环境实测"；卖点按实测收敛。**AC-M3.3**：每个数字可溯源到入仓 JSON |
+| M3.4 | 文档收尾 | benchmarks/README.md 增 competitors 指引；本文档 §六验收勾选 | AC1–AC6 全勾 |
+
+---
+
+## 八、目录结构设计（仅设计）
+
+```
+benchmarks/competitors/
+├── README.md                      # 复现指引（环境/顺序/限制）
+├── run-comparison.sh              # 串行跑全部（或 --only <product>）
+├── run-gc-jitter.sh               # 5 分钟 P99 时间序列（D6）
+├── keycloak/
+│   ├── docker-compose.yml         # Keycloak + PG（对齐 D1）
+│   ├── setup.sh                   # start --optimized + kcadm 初始化 + token 池
+│   ├── teardown.sh
+│   ├── lib/generated/             # setup 产物：token 池文件（WRK_LIB_DIR 指向此处）
+│   └── scenarios/                 # s1/s2/s3/s5/s6.lua（端点按 §4.1）
+├── ory/
+│   ├── docker-compose.yml         # Hydra(+Kratos 如需) + PG
+│   ├── setup.sh                   # hydra client create + token 池
+│   ├── teardown.sh
+│   └── scenarios/
+├── zitadel/
+│   ├── docker-compose.yml
+│   ├── setup.sh                   # setup mode 初始化 + token 池
+│   ├── teardown.sh
+│   └── scenarios/
+└── results/
+    ├── <date>-<sha>-<product>-<scenario>-c<conn>.json   # 同 schema v1
+    ├── <date>-<sha>-<product>-gcjitter.json
+    └── COMPARISON.md              # 汇总对比表（gen-comparison.py 生成，M3）
+
+# 聚合器放共享 reporting/（与 parse-wrk.py 同层）：
+benchmarks/reporting/gen-comparison.py
+```
+
+**复用不复制**：`run-scenario.sh` / `parse-wrk.py` / `observe/` 直接引用 `benchmarks/fulla/` 与 `benchmarks/reporting/` 的现有实现（通过路径参数或环境变量），不为竞品复制第二份 runner。
+
+---
+
+## 九、风险与缓解
+
+| 风险 | 等级 | 影响 | 缓解 |
+|------|------|------|------|
+| **竞品社区质疑配置不公平** | 高 | 对外数据被推翻，信誉受损 | D2 官方推荐配置 + AC4 全量标注偏离项；发布前可请竞品社区 review setup 脚本 |
+| **Keycloak JIT/GC 预热不足，数字偏低被指不公平** | 高 | Keycloak 数字虚低 | warmup 延长 60s + 长跑前置 1 分钟丢弃段 |
+| **Hydra 无内建用户，S6 不可测** | 中 | 场景覆盖缺口 | Hydra 配最小 login/consent mock app（官方 brownfield 模式）；若复杂度超预期，S6 对 Hydra 标 N/A |
+| **S5 竞品池规模不足/重发太慢** | 中 | S5 数据失真或 setup 超时 | 校准跑定池规模（QPS×10s×1.3）；xargs -P8 并行签发；--reissue 每档重发（D5 v1.1） |
+| **Zitadel token 端点不支持 Basic client_credentials** | 中 | S2 无法按统一 Basic 口径测 | JWT profile 预签 assertion 池（官方推荐路径，pyjwt 签发）；COMPARISON 注明认证等价性（D3 v1.1） |
+| **Zitadel Session API→auth_code 驱动失败** | 中 | S5/S6 缺口 | 决策门 DG-2：2 个工作日不成标 N/A，S1/S2/S3 保底 |
+| **竞品 token 池签发慢（2000 次 API 调用）** | 低 | setup 时间长 | 并行签发（xargs -P8）；或降池到 500（S3/S6 池可复用，量够） |
+| **Fulla 某维度不领先** | 中 | 卖点叙事受损 | 这正是设施价值——诚实收敛到领先维度（演进方案 §二原则 1 的既定预案） |
+| **单机串行跑，环境漂移（系统更新/温度）** | 中 | 四家数据不同批不可比 | 同一 session 内连续跑完；每家结果带时间戳；复跑取中位数 |
+| **wrk 打不满 Go/Java 服务（driver 受限）** | 低 | 数字是下限 | 沿用 AC4 driver CPU 门；超 80% 标注 |
+
+---
+
+## 附录 A：与上游文档的关系
+
+| 上游 | 关系 |
+|------|------|
+| 基准设施设计（内部档案，已随 productization-evolution 目录转为本地维护） | 本文档是其 N1（Phase 0.5 竞品对比）的展开；复用其 runner/parser/schema/observe |
+| [演进方案]（productization-evolution-plan：本地维护档案） §三 Phase 0 P0 第 2 项 | 本文档是该工作项的落地设计 |
+| 调研报告（内部档案） §3.1 | 竞品列的**替换数据源**；M3 据实修订 |
+| `benchmarks/results/SUMMARY.md` | Fulla 侧基线（同环境自测，2026-08-12） |
+
+## 附录 B：决策记录
+
+| 决策 | 选择 | 备选与否决理由 |
+|------|------|---------------|
+| 对比对象 | Keycloak / Ory / Zitadel | Auth0（SaaS 不可自托管）否决 |
+| 场景范围 | S1/S2/S3/S5/S6 | S4（登录流不可 headless 驱动）排除，详见 D4 |
+| 配置基线 | 官方推荐生产配置 | 极限调优（军备竞赛无公信力）与默认 dev 配置（不公平）均否决 |
+| token 池 | 各家 API 自签发 | SQL 直插（签名格式私有）否决，详见 D5 |
+| 内存口径 | 容器全栈 RSS（主）+ PSS（补充） | 单一口径必有一方吃亏，双口径并列标注 |
+| warmup/measure 口径（v1.1） | 5s/10s，Keycloak warmup 60s | 与入仓自测数据一致；原文"其余四家 10s"与实际数据（5s/10s）不符，已修正 |
+| GC 抖动载波场景（v1.1） | S6 userinfo，c=32 固定 | S5（池耗尽）与 S2（Fulla 每请求写库、负载构成不对称）否决，详见 D6 |
+| Fulla 数据口径（v1.1） | 同 session 重跑 | "复用旧数据"与 AC2（gcjitter 必采）+ R7（同 session 消漂移）矛盾，已修正 |
+| S5 竞品池（v1.1） | 每档 API 重发（--reissue），池=QPS×10s×1.3 | 固定 2000 池（单发单耗会耗尽）否决；RT 不取自 client_credentials（RFC 6749 §4.4.3 禁止） |

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/admin-e2e-testing-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/admin-e2e-testing-guide.md
@@ -1,0 +1,936 @@
+# Playwright E2E 自动化测试接入指南
+
+> 基于 OAuth2 Admin 项目实践总结，面向其他前端项目的 Playwright E2E 测试接入参考。
+
+---
+
+## 目录
+
+1. [核心原理](#1-核心原理)
+2. [项目初始化](#2-项目初始化)
+3. [Mock API 层设计](#3-mock-api-层设计)
+4. [测试文件组织](#4-测试文件组织)
+5. [测试编写模式](#5-测试编写模式)
+6. [进阶技巧](#6-进阶技巧)
+7. [CI/CD 集成](#7-cicd-集成)
+8. [常见问题](#8-常见问题)
+
+---
+
+## 1. 核心原理
+
+### 1.1 为什么选择请求拦截而不是真实后端
+
+| 方案 | 优点 | 缺点 |
+|------|------|------|
+| **请求拦截 Mock** | 无需后端依赖、执行快(&lt;5s)、稳定不 flaky、可自由控制响应 | 不验证前后端集成 |
+| **真实后端** | 验证端到端集成 | 需要数据库/缓存/服务、慢(分钟级)、环境依赖多、数据隔离难 |
+| **MSW (Mock Service Worker)** | 浏览器层拦截、更贴近真实 | 配置复杂、需要 Service Worker 支持 |
+
+本项目选择 **Playwright 原生 `page.route()` 请求拦截**，理由：
+- 零额外依赖（Playwright 内置）
+- API 简洁直观
+- 拦截发生在网络层之前，性能最好
+- 支持精确匹配 URL 模式和 HTTP 方法
+- 支持在单个测试中覆盖全局 Mock
+
+### 1.2 请求拦截工作流程
+
+```
+┌──────────────┐      HTTP 请求       ┌──────────────────┐
+│  前端应用代码  │ ───────────────────→ │  page.route()    │
+│  (浏览器)     │                      │  URL 模式匹配     │
+│              │ ←─────────────────── │  route.fulfill() │
+└──────────────┘     Mock 响应         └──────────────────┘
+                                          ↑ 不经过网络层
+                                     (无真实 HTTP 连接)
+```
+
+Playwright 的 `page.route()` 在浏览器网络层拦截请求，**请求不会离开浏览器进程**。这意味着：
+- 不需要启动后端服务
+- 不需要网络连接
+- 响应是即时的，无延迟
+- 测试完全确定性，无网络 flaky
+
+### 1.3 三层架构
+
+```
+tests/e2e/
+├── helpers/
+│   └── mock-api.ts          ← Layer 1: Mock 数据 + 拦截器
+├── auth.spec.ts             ← Layer 2: 测试用例
+├── applications.spec.ts
+└── ...
+
+playwright.config.ts         ← Layer 3: Playwright 配置
+```
+
+| 层次 | 职责 | 修改频率 |
+|------|------|---------|
+| **Mock 层** | 定义 Mock 数据常量 + `setupAuthenticatedMocks()` 全局拦截函数 | 后端 API 变更时 |
+| **测试层** | 编写具体测试用例，调用 Mock 层提供的函数 | 新功能/新页面时 |
+| **配置层** | Playwright 运行参数、浏览器、webServer | 项目初始化时 |
+
+---
+
+## 2. 项目初始化
+
+### 2.1 安装依赖
+
+```bash
+npm install -D @playwright/test
+npx playwright install chromium
+```
+
+仅需 Chromium，无需安装 WebKit/Firefox。E2E 测试的目标是验证功能逻辑，不是跨浏览器兼容性。
+
+### 2.2 Playwright 配置
+
+创建 `playwright.config.ts`：
+
+```typescript
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',        // 测试文件目录
+  fullyParallel: true,            // 全并行执行（测试间无依赖时开启）
+  forbidOnly: !!process.env.CI,   // CI 禁止 test.only（防止误提交）
+  retries: process.env.CI ? 2 : 0, // CI 重试 2 次（抗 flaky）
+  workers: process.env.CI ? 1 : undefined, // CI 单 worker（避免资源竞争）
+  reporter: 'html',               // HTML 测试报告
+
+  use: {
+    baseURL: 'http://localhost:5174',  // 应用基础 URL（配合 page.goto() 使用）
+    trace: 'on-first-retry',           // 失败重试时记录 trace（调试用）
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',              // 自动启动 dev server
+    url: 'http://localhost:5174/',       // 等待此 URL 可访问
+    reuseExistingServer: !process.env.CI, // 本地复用已运行的 server
+    timeout: 30000,                      // 启动超时 30s
+  },
+})
+```
+
+**关键配置说明：**
+
+| 配置项 | 作用 | 推荐值 |
+|--------|------|--------|
+| `baseURL` | `page.goto('/path')` 时自动拼接此前缀 | 开发服务器地址 |
+| `webServer` | 自动启动/复用 dev server | 开发模式 + CI 模式区分 |
+| `trace` | 失败时生成 trace 文件，可用 `npx playwright show-trace` 调试 | `on-first-retry` |
+| `fullyParallel` | 多个 test 文件并行执行 | `true`（Mock 模式下安全） |
+| `retries` | 失败重试次数 | CI: 2, 本地: 0 |
+
+### 2.3 package.json 脚本
+
+```json
+{
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui"
+  }
+}
+```
+
+### 2.4 目录结构
+
+```
+your-project/
+├── playwright.config.ts
+├── package.json
+├── src/                        ← 应用源码
+└── tests/
+    └── e2e/
+        ├── helpers/
+        │   └── mock-api.ts     ← Mock 数据 + 拦截函数
+        ├── auth.spec.ts        ← 认证相关测试
+        ├── page-a.spec.ts      ← 页面 A 测试
+        └── page-b.spec.ts      ← 页面 B 测试
+```
+
+---
+
+## 3. Mock API 层设计
+
+Mock API 层是整个测试体系的**核心**。设计好这一层，编写测试用例会非常简单。
+
+### 3.1 文件结构
+
+`tests/e2e/helpers/mock-api.ts` 分为三个部分：
+
+```
+Part 1: Mock 数据常量    →  定义所有 API 的假数据
+Part 2: setupAuthenticatedMocks()  →  注册全局路由拦截
+Part 3: 辅助函数         →  loginAsAdmin() 等常用操作
+```
+
+### 3.2 Mock 数据常量
+
+**原则：数据尽量真实，字段与后端 API 响应一致。**
+
+```typescript
+// ✅ 好的设计：字段名、类型与真实 API 一致
+export const MOCK_USERS = [
+  {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    username: 'admin',
+    email: 'admin@example.com',
+    email_verified: true,    // boolean，不是字符串
+    mfa_enabled: true,
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440001',
+    username: 'testuser',
+    email: 'test@example.com',
+    email_verified: false,
+    mfa_enabled: false,
+  },
+]
+
+// ❌ 不好的设计：字段名随意、数据不真实
+export const users = [
+  { uid: 1, name: 'a', mail: 'a@b' },  // 字段名不匹配真实 API
+]
+```
+
+**为什么需要多组数据？**
+
+Mock 数据至少准备两种状态，覆盖不同的 UI 表现：
+- `email_verified: true` + `false` → 测试"已验证"和"待验证"Badge
+- `mfa_enabled: true` + `false` → 测试"已开启"和"未开启"Badge
+
+### 3.3 路由拦截：setupAuthenticatedMocks()
+
+这是最关键的函数，负责拦截前端发出的所有 API 请求。
+
+```typescript
+import { Page } from '@playwright/test'
+
+export async function setupAuthenticatedMocks(page: Page) {
+  // 拦截规则：** 是通配符，匹配任何 origin
+  await page.route('**/api/users', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ users: MOCK_USERS }),
+    })
+  })
+}
+```
+
+**URL 匹配模式说明：**
+
+| 模式 | 匹配范围 | 示例 |
+|------|---------|------|
+| `**/api/users` | 任何 origin + 路径精确匹配 | `http://localhost:5174/api/users` ✅ |
+| `**/api/admin/logs**` | 路径前缀匹配（含查询参数） | `/api/admin/logs?page=2` ✅ |
+| `**/api/admin/clients/*` | 路径 + 单段通配 | `/api/admin/clients/vue-client` ✅ |
+| `**/api/admin/clients/*/reset-secret` | 多段路径混合 | `/api/admin/clients/vue-client/reset-secret` ✅ |
+
+**同一个 URL，不同 HTTP 方法：**
+
+```typescript
+await page.route('**/api/admin/clients', async (route) => {
+  if (route.request().method() === 'GET') {
+    await route.fulfill({ status: 200, body: JSON.stringify({ clients: MOCK_CLIENTS }) })
+  } else if (route.request().method() === 'POST') {
+    await route.fulfill({ status: 201, body: JSON.stringify({ client_id: 'new-123' }) })
+  } else {
+    // 未预期的方法，交给下一个 handler 或真实网络
+    await route.continue()
+  }
+})
+```
+
+**子资源路由优先级：**
+
+Playwright 路由匹配按注册顺序，**更具体的路由应先注册**：
+
+```typescript
+// ✅ 正确：更具体的路由先注册
+await page.route('**/api/admin/clients/*/reset-secret', ...)  // 先匹配
+await page.route('**/api/admin/clients/*', ...)                // 后匹配（兜底）
+
+// 实际上 Playwright 的通配符匹配有隐式优先级
+// 但在 handler 内主动判断更安全：
+await page.route('**/api/admin/clients/*', async (route) => {
+  const url = route.request().url()
+  if (url.includes('/scopes') || url.includes('/reset-secret')) {
+    await route.continue()  // 跳过，让更具体的 handler 处理
+    return
+  }
+  // ... 处理 DELETE / GET / PUT
+})
+```
+
+### 3.4 辅助函数：loginAsAdmin()
+
+```typescript
+export async function loginAsAdmin(page: Page) {
+  await page.goto('/login')
+  await page.fill('input[type="text"]', 'admin')
+  await page.fill('input[type="password"]', 'admin')
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/dashboard')  // 等待登录成功跳转
+}
+```
+
+**设计要点：**
+- 通过 UI 操作完成登录（模拟真实用户行为）
+- 依赖 `setupAuthenticatedMocks()` 已拦截认证 API
+- `waitForURL` 确保登录完成，后续测试处于已认证状态
+
+### 3.5 适配其他项目的 Mock 模板
+
+```typescript
+// === helpers/mock-api.ts 模板 ===
+
+import { Page } from '@playwright/test'
+
+// ---- Part 1: Mock 数据 ----
+
+export const CURRENT_USER = {
+  id: '1',
+  name: 'Test User',
+  email: 'test@example.com',
+  role: 'admin',
+}
+
+export const MOCK_ITEMS = [
+  { id: '1', title: 'Item A', status: 'active' },
+  { id: '2', title: 'Item B', status: 'inactive' },
+]
+
+// ---- Part 2: 全局路由拦截 ----
+
+export async function setupAuthenticatedMocks(page: Page) {
+  // 认证相关
+  await page.route('**/auth/login', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token: 'mock-jwt-token', user: CURRENT_USER }),
+    })
+  })
+
+  await page.route('**/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(CURRENT_USER),
+    })
+  })
+
+  // 业务数据
+  await page.route('**/api/items', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: MOCK_ITEMS }),
+      })
+    } else if (route.request().method() === 'POST') {
+      const body = JSON.parse(route.request().postData() || '{}')
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'new-' + Date.now(), ...body }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // 单项操作（GET / PUT / DELETE）
+  await page.route('**/api/items/*', async (route) => {
+    if (route.request().method() === 'DELETE') {
+      await route.fulfill({ status: 204 })
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_ITEMS[0]),
+      })
+    }
+  })
+}
+
+// ---- Part 3: 辅助函数 ----
+
+export async function loginAs(page: Page, username = 'admin', password = 'admin') {
+  await page.goto('/login')
+  await page.fill('[name="username"]', username)
+  await page.fill('[name="password"]', password)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/dashboard')
+}
+```
+
+---
+
+## 4. 测试文件组织
+
+### 4.1 命名规范
+
+```
+tests/e2e/
+  ├── helpers/
+  │   └── mock-api.ts         ← 固定命名，所有测试共享
+  ├── auth.spec.ts             ← 认证/登录相关
+  ├── {page-name}.spec.ts      ← 每个页面一个文件
+  └── navigation.spec.ts       ← 全局导航/布局
+```
+
+**一个页面 = 一个 spec 文件**，按功能域划分，不按操作类型划分。
+
+### 4.2 test.describe 分组
+
+```typescript
+test.describe('页面/功能名称', () => {
+  // beforeEach: 统一 setup
+  test.beforeEach(async ({ page }) => {
+    await setupAuthenticatedMocks(page)
+    await loginAsAdmin(page)
+    // 导航到目标页面
+    await page.click('nav a:has-text("Target Page")')
+    await page.waitForURL('**/target-page')
+  })
+
+  // 测试用例按：渲染 → 数据 → 交互 → 边界 排列
+  test('displays page title', ...)
+  test('shows data from API', ...)
+  test('button click triggers action', ...)
+  test('shows error on failure', ...)
+})
+```
+
+### 4.3 测试用例命名
+
+使用**陈述句**描述预期行为，而非操作步骤：
+
+```typescript
+// ✅ 好：描述预期结果
+test('displays users list with correct columns', ...)
+test('shows error on login failure', ...)
+test('delete button removes item from list', ...)
+
+// ❌ 不好：描述操作步骤
+test('clicks button and checks result', ...)
+test('test 1', ...)
+```
+
+---
+
+## 5. 测试编写模式
+
+### 5.1 标准测试流程（beforeEach 模式）
+
+**最常用的模式**，90% 的测试都遵循这个流程：
+
+```typescript
+test.describe('User Management', () => {
+  test.beforeEach(async ({ page }) => {
+    // Step 1: 注册全局 Mock
+    await setupAuthenticatedMocks(page)
+    // Step 2: 模拟登录
+    await loginAsAdmin(page)
+    // Step 3: 导航到目标页面
+    await page.click('nav a:has-text("Users")')
+    await page.waitForURL('**/users')
+  })
+
+  test('displays user table', async ({ page }) => {
+    await expect(page.locator('h2')).toContainText('Users')
+    await expect(page.locator('th:has-text("Username")')).toBeVisible()
+  })
+})
+```
+
+**流程图：**
+
+```
+beforeEach:
+  setupAuthenticatedMocks(page)
+       ↓
+  loginAsAdmin(page)
+       ↓
+  导航到目标页面 + waitForURL
+       ↓
+  ═══════════════════════════
+  ↓  test case 1 执行      ↓
+  ↓  test case 2 执行      ↓
+  ↓  ...                   ↓
+  ═══════════════════════════
+```
+
+### 5.2 页面渲染验证
+
+验证页面正确显示数据：
+
+```typescript
+test('displays users list with correct columns', async ({ page }) => {
+  // 验证标题
+  await expect(page.locator('h2')).toContainText('Users')
+  // 验证表头
+  await expect(page.locator('th:has-text("Username")')).toBeVisible()
+  await expect(page.locator('th:has-text("Email")')).toBeVisible()
+  // 验证数据行（来自 Mock 数据）
+  const tableBody = page.locator('tbody')
+  await expect(tableBody.getByRole('cell', { name: 'admin', exact: true })).toBeVisible()
+})
+```
+
+### 5.3 表单交互测试
+
+验证表单填写、提交、响应：
+
+```typescript
+test('creates a new application and shows secret', async ({ page }) => {
+  // 1. 触发弹窗
+  await page.click('button:has-text("Create Application")')
+  // 2. 验证弹窗出现
+  await expect(page.locator('h3:has-text("Create Application")')).toBeVisible()
+  // 3. 填写表单
+  await page.fill('input[placeholder="My App"]', 'Test Application')
+  await page.selectOption('select', 'CONFIDENTIAL')
+  // 4. 提交
+  await page.locator('.fixed button[type="submit"]').click()
+  // 5. 验证结果
+  await expect(page.locator('h3:has-text("Client Secret")')).toBeVisible()
+  await expect(page.locator('.font-mono.select-all')).toContainText('generated-secret-abc123xyz')
+})
+```
+
+### 5.4 Modal/对话框测试
+
+```typescript
+test('opens and closes role assignment modal', async ({ page }) => {
+  // 打开
+  await page.click('button:has-text("Assign Roles")')
+  await expect(page.locator('h3:has-text("Assign Roles")')).toBeVisible()
+
+  // 关闭
+  await page.click('button:has-text("Cancel")')
+  await expect(page.locator('h3:has-text("Assign Roles")')).not.toBeVisible()
+})
+
+// 原生 confirm 对话框处理
+test('delete with confirmation', async ({ page }) => {
+  page.on('dialog', (dialog) => dialog.accept())  // 自动接受 confirm
+  await page.click('button:has-text("Delete")')
+  await expect(page.locator('h2')).toContainText('Applications')
+})
+```
+
+### 5.5 分页测试
+
+```typescript
+test('pagination sends correct page parameter', async ({ page }) => {
+  // 构造足够多的数据以启用"下一页"
+  const manyItems = Array.from({ length: 50 }, (_, i) => ({
+    id: i + 1, title: `Item ${i}`, status: 'active',
+  }))
+
+  let requestedPage = 1
+  await page.route('**/api/items**', async (route) => {
+    const url = new URL(route.request().url())
+    requestedPage = parseInt(url.searchParams.get('page') || '1')
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify({ items: requestedPage === 1 ? manyItems : MOCK_ITEMS }),
+    })
+  })
+
+  // 导航触发重新加载
+  await page.click('nav a:has-text("Dashboard")')
+  await page.click('nav a:has-text("Items")')
+  await page.waitForURL('**/items')
+
+  // 点击下一页
+  const nextBtn = page.locator('button:has-text("Next")')
+  await expect(nextBtn).not.toBeDisabled()
+  await nextBtn.click()
+  await expect(page.locator('text=Page 2')).toBeVisible()
+  expect(requestedPage).toBe(2)
+})
+```
+
+### 5.6 导航测试
+
+```typescript
+test('sidebar navigation works for all pages', async ({ page }) => {
+  // 验证导航项可见
+  await expect(page.locator('nav a:has-text("Dashboard")')).toBeVisible()
+  await expect(page.locator('nav a:has-text("Users")')).toBeVisible()
+
+  // 点击并验证 URL + 页面标题
+  await page.click('nav a:has-text("Users")')
+  await expect(page).toHaveURL(/\/users/)
+  await expect(page.locator('h2')).toContainText('Users')
+
+  // 返回验证
+  await page.click('nav a:has-text("Dashboard")')
+  await expect(page).toHaveURL(/\/dashboard/)
+})
+```
+
+---
+
+## 6. 进阶技巧
+
+### 6.1 覆盖全局 Mock（测试异常场景）
+
+这是本方案最强大的特性：**在单个测试中覆盖全局 Mock，无需修改 setupAuthenticatedMocks()**。
+
+**原理：** `page.route()` 后注册的 handler 优先匹配。后注册的会覆盖先注册的同 URL 模式。
+
+```typescript
+test.describe('Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupAuthenticatedMocks(page)  // 全局 Mock：health 返回 ok
+    await loginAsAdmin(page)
+  })
+
+  test('displays healthy status', async ({ page }) => {
+    await expect(page.locator('text=Healthy')).toBeVisible()  // 使用全局 Mock
+  })
+
+  test('shows unhealthy status when backend is down', async ({ page }) => {
+    // 关键：在全局 Mock 之后注册，覆盖全局的 health 响应
+    await page.route('**/health/ready', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'error', message: 'Database unreachable' }),
+      })
+    })
+
+    await loginAsAdmin(page)  // 重新登录以触发 health check
+    await expect(page.locator('text=Unhealthy')).toBeVisible()
+  })
+})
+```
+
+**常见覆盖场景：**
+
+```typescript
+// 场景 1：API 返回错误
+await page.route('**/oauth2/login', async (route) => {
+  await route.fulfill({ status: 401, body: JSON.stringify({ error: 'invalid_credentials' }) })
+})
+
+// 场景 2：API 返回空数据
+await page.route('**/api/admin/clients', async (route) => {
+  if (route.request().method() === 'GET') {
+    await route.fulfill({ status: 200, body: JSON.stringify({ clients: [] }) })
+  } else {
+    await route.continue()
+  }
+})
+
+// 场景 3：非管理员用户
+await page.route('**/oauth2/userinfo', async (route) => {
+  await route.fulfill({
+    status: 200,
+    body: JSON.stringify({ sub: '123', username: 'user', roles: ['user'] }),
+  })
+})
+
+// 场景 4：MFA 要求
+await page.route('**/oauth2/login', async (route) => {
+  await route.fulfill({
+    status: 200,
+    body: JSON.stringify({ mfa_required: true, mfa_token: 'mfa-token-123' }),
+  })
+})
+```
+
+### 6.2 捕获请求体验证
+
+验证前端发送的请求参数是否正确：
+
+```typescript
+test('assigns roles with correct request body', async ({ page }) => {
+  let requestBody: any = null
+
+  // 覆盖全局 Mock，同时捕获请求体
+  await page.route('**/api/admin/users/*/roles', async (route) => {
+    requestBody = JSON.parse(route.request().postData() || '{}')
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify({ message: 'Roles updated' }),
+    })
+  })
+
+  // 执行操作
+  await page.locator('button:has-text("Assign Roles")').first().click()
+  await page.fill('input[placeholder="admin, user"]', 'admin, editor')
+  await page.click('button:has-text("Save Roles")')
+
+  // 验证请求体
+  expect(requestBody).toEqual({ roles: ['admin', 'editor'] })
+})
+```
+
+### 6.3 空状态测试
+
+验证列表为空时的 UI 表现：
+
+```typescript
+test('shows empty state when no items exist', async ({ page }) => {
+  // 覆盖 Mock 返回空列表
+  await page.route('**/api/items', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ status: 200, body: JSON.stringify({ items: [] }) })
+    } else {
+      await route.continue()
+    }
+  })
+
+  // 导航走再回来，触发数据重新加载
+  await page.click('nav a:has-text("Dashboard")')
+  await page.click('nav a:has-text("Items")')
+  await page.waitForURL('**/items')
+
+  // 验证空状态提示
+  await expect(page.locator('text=No items yet')).toBeVisible()
+  await expect(page.locator('button:has-text("Create your first item")')).toBeVisible()
+})
+```
+
+**为什么需要"导航走再回来"？**
+
+因为 `beforeEach` 中已经导航到了目标页面，数据已经加载。覆盖 Mock 后需要触发组件重新挂载数据重新获取。两个方法：
+1. 导航到其他页面再回来（推荐，模拟真实用户操作）
+2. `await page.reload()`（简单，但有些组件可能不重新请求）
+
+### 6.4 验证请求查询参数
+
+```typescript
+test('filter sends correct parameters', async ({ page }) => {
+  let capturedUrl = ''
+  await page.route('**/api/items**', async (route) => {
+    capturedUrl = route.request().url()
+    await route.fulfill({ status: 200, body: JSON.stringify({ items: [] }) })
+  })
+
+  // 执行筛选操作
+  await page.selectOption('select[name="status"]', 'active')
+  await page.click('button:has-text("Filter")')
+
+  // 验证 URL 参数
+  const url = new URL(capturedUrl)
+  expect(url.searchParams.get('status')).toBe('active')
+})
+```
+
+---
+
+## 7. CI/CD 集成
+
+### 7.1 GitHub Actions 示例
+
+```yaml
+name: E2E Tests
+
+on: [push, pull_request]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+```
+
+### 7.2 CI 配置要点
+
+| 配置 | CI 值 | 本地值 | 原因 |
+|------|-------|-------|------|
+| `workers` | 1 | 自动(多) | CI 资源有限，避免竞争 |
+| `retries` | 2 | 0 | CI 网络不稳定，重试抗 flaky |
+| `reuseExistingServer` | `false` | `true` | CI 必须启动新 server |
+| `forbidOnly` | `true` | `false` | 防止 `test.only` 被提交 |
+
+---
+
+## 8. 常见问题
+
+### Q1: 测试偶尔失败（flaky）怎么办？
+
+1. 检查是否用了 `page.waitForTimeout()` — 改用 `waitForSelector` / `waitForURL` / `expect().toBeVisible()`
+2. 检查 Mock 是否有条件竞争 — 确保所有 API 都被拦截，没有未 Mock 的请求
+3. 开启 `trace: 'on-first-retry'`，用 `npx playwright show-trace` 分析失败
+
+### Q2: 某个请求没被拦截怎么办？
+
+- 检查 URL 模式是否匹配（`**` 通配符范围）
+- 打开浏览器开发者工具，看实际请求的完整 URL
+- 在 handler 内加 `console.log(route.request().url())` 调试
+
+### Q3: 如何测试文件上传？
+
+```typescript
+// 监听 file chooser 事件
+const [fileChooser] = await Promise.all([
+  page.waitForEvent('filechooser'),
+  page.click('button:has-text("Upload")'),  // 触发文件选择
+])
+await fileChooser.setFiles({
+  name: 'test.csv',
+  mimeType: 'text/csv',
+  buffer: Buffer.from('name,value\ntest,123'),
+})
+```
+
+### Q4: 如何在不启动 dev server 的情况下测试？
+
+修改 `playwright.config.ts`，移除 `webServer` 配置，手动启动 dev server 后运行测试：
+
+```bash
+# 终端 1
+npm run dev
+
+# 终端 2
+npm run test:e2e
+```
+
+### Q5: Mock 模式和真实后端测试如何共存？
+
+```
+tests/
+├── e2e/
+│   ├── helpers/
+│   │   ├── mock-api.ts      ← Mock 模式
+│   │   └── api-client.ts    ← 真实 API 调用
+│   ├── auth.spec.ts          ← Mock 测试
+│   └── ...
+└── integration/
+    └── full-flow.spec.ts     ← 真实后端集成测试
+```
+
+使用不同的 `playwright.config.ts`：
+- `playwright.config.ts` — Mock 模式（日常开发、每次提交）
+- `playwright.integration.config.ts` — 真实后端（发布前、 nightly）
+
+---
+
+## 9. 后端集成测试故障排查
+
+### 问题：测试脚本第二次运行时全部失败
+
+**症状**：
+```
+POST http://localhost:5174/oauth2/login 401 (Unauthorized)
+```
+
+后端日志：
+```
+WARN  Account locked for user: admin until 1779441748
+INFO  [METRIC] oauth2_login_failures_total reason=bad_credentials
+```
+
+**原因**：
+OAuth2 系统实现了账号锁定机制。当登录失败次数达到阈值时，账号会被临时锁定：
+- 5次失败 → 锁定1分钟
+- 10次失败 → 锁定5分钟
+- 15次失败 → 锁定30分钟
+- 20次以上 → 锁定1小时
+
+**解决方案**：
+
+#### 方案1：使用自动清理的测试脚本
+
+后端测试脚本（如 `test-admin-endpoints.ps1`）已经在结束时自动重置账号锁定状态。
+
+对于本地PostgreSQL数据库，需要配置数据库密码：
+
+```powershell
+# 编辑测试脚本，找到清理部分，设置密码
+$env:PGPASSWORD = "your_password"  # 修改为实际密码
+```
+
+#### 方案2：手动重置账号锁定
+
+```powershell
+# 使用重置脚本
+$env:PGPASSWORD = "your_password"
+.\scripts\backend\reset-account-lockout.ps1
+$env:PGPASSWORD = $null
+
+# 或直接使用SQL
+psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET failed_login_count = 0, locked_until = 0 WHERE username='admin';"
+```
+
+#### 方案3：等待锁定自动解除
+
+根据失败次数，等待相应的时间后账号会自动解锁。
+
+**预防措施**：
+
+1. **使用专用测试账号**：不要在测试中使用生产admin账号
+2. **确保凭证正确**：检查测试脚本中的用户名和密码
+3. **测试后自动清理**：在测试脚本末尾添加清理代码
+
+详细说明请参考：[账号锁定机制](operate/account-lockout.md)
+
+---
+
+## 附录 A: 从零接入检查清单
+
+将此清单用于新项目的 E2E 测试接入：
+
+- [ ] `npm install -D @playwright/test`
+- [ ] `npx playwright install chromium`
+- [ ] 创建 `playwright.config.ts`
+- [ ] 创建 `tests/e2e/helpers/mock-api.ts`
+- [ ] 定义 Mock 数据常量（与后端 API 响应结构一致）
+- [ ] 实现 `setupAuthenticatedMocks(page)` — 拦截所有认证 + 业务 API
+- [ ] 实现 `loginAsAdmin(page)` — UI 登录辅助函数
+- [ ] 创建第一个测试文件（建议从 auth 开始）
+- [ ] 添加 `package.json` 脚本
+- [ ] 配置 CI pipeline
+
+## 附录 B: Admin 前端 E2E 测试统计
+
+| 指标 | 数值 |
+|------|------|
+| 测试文件 | 16 |
+| 测试用例 | 174 |
+| 执行时间 | ~1 分钟 |
+| 后端依赖 | 无（全 Mock） |
+| 浏览器 | Chromium |
+| 并行执行 | 是 |
+| Mock API 端点 | 15+ |
+
+---
+
+> 本文档基于 fulla Admin 前端项目实践总结。项目源码：`frontends/admin/tests/e2e/`

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/admin-test-cases.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/admin-test-cases.md
@@ -1,0 +1,262 @@
+# OAuth2 Admin Console - Test Cases
+
+> Admin backend-path: `/admin/` | Framework: Vue 3 + TailwindCSS | Playwright E2E
+
+## Module 1: Login / Authentication
+
+### 1.1 Admin Login Page (`/admin/login`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-LOGIN-001 | Valid admin credentials | Enter valid admin username/password, click Sign in | Redirect to Dashboard (`/admin/`) | P0 |
+| A-LOGIN-002 | Empty username | Leave username blank, click Sign in | Form does not submit (HTML5 required) | P1 |
+| A-LOGIN-003 | Empty password | Leave password blank, click Sign in | Form does not submit (HTML5 required) | P1 |
+| A-LOGIN-004 | Both fields empty | Click Sign in with empty fields | Form does not submit | P1 |
+| A-LOGIN-005 | Wrong password | Enter valid username + wrong password | Red error banner displayed, stays on login page | P0 |
+| A-LOGIN-006 | Non-existent user | Enter unregistered username + any password | Error message shown | P0 |
+| A-LOGIN-007 | Non-admin user | Enter credentials of user without admin role | Error message: requires admin role | P0 |
+| A-LOGIN-008 | SQL injection in username | Enter `' OR 1=1 --` as username | Error message, no data leak | P0 |
+| A-LOGIN-009 | XSS in username | Enter `<script>alert('xss')</script>` | Input rendered as text, no script execution | P0 |
+| A-LOGIN-010 | Whitespace-only username | Enter spaces only, click Sign in | Form does not submit | P1 |
+| A-LOGIN-011 | Loading state | Submit valid credentials | Button shows "Signing in...", disabled during request | P2 |
+| A-LOGIN-012 | Browser back after login | Login successfully, press browser Back | Redirect to Dashboard (auth guard active) | P1 |
+| A-LOGIN-013 | Direct access to protected page | Navigate to `/admin/users` without auth | Redirect to `/admin/login` | P0 |
+| A-LOGIN-014 | Session persistence | Login, close tab, reopen `/admin/` | Session restored, Dashboard shown | P1 |
+| A-LOGIN-015 | Concurrent login attempts | Rapidly click Sign in multiple times | Only one request sent (button disabled) | P2 |
+
+### 1.2 Logout
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-LOGOUT-001 | Normal logout | Click "Sign out" in sidebar | Session cleared, redirect to login page | P0 |
+| A-LOGOUT-002 | Access after logout | Logout, navigate to `/admin/users` | Redirect to login page | P0 |
+| A-LOGOUT-003 | Browser back after logout | Logout, press browser Back | Redirect to login (no cached page) | P1 |
+
+---
+
+## Module 2: Dashboard (`/admin/`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-DASH-001 | Stats display on load | Navigate to Dashboard | 4 stat cards shown: Total Users, Applications, Active Tokens, Failures Today | P0 |
+| A-DASH-002 | System health indicators | View Dashboard | System Status (green/red dot), Database status, Redis status displayed | P0 |
+| A-DASH-003 | Quick action links | Click each Quick Action card | Navigates to correct page (Applications/Users/Roles/Scopes) | P1 |
+| A-DASH-004 | Loading state | Observe page during API call | Stats show "—" while loading, then update | P2 |
+| A-DASH-005 | API failure handling | Simulate `/health/ready` failure | Red error banner shown, System Status shows "Unhealthy" | P0 |
+| A-DASH-006 | Stats API failure | Simulate `/api/admin/dashboard/stats` failure | Error banner displayed with descriptive message | P0 |
+| A-DASH-007 | Failures today = 0 | When no failures today | Number displayed in normal text color (not red) | P2 |
+| A-DASH-008 | Failures today > 0 | When failures exist | Number displayed in red color | P2 |
+
+---
+
+## Module 3: Applications (`/admin/applications`)
+
+### 3.1 Application List
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-APP-001 | List loads successfully | Navigate to Applications page | Table shows client_id, name, type, grant_types, created_at | P0 |
+| A-APP-002 | Empty list | When no clients exist | Table shows "No clients found" or empty state | P1 |
+| A-APP-003 | Navigate to detail | Click a client row | Navigates to `/admin/applications/:id` | P0 |
+| A-APP-004 | Delete client | Click Delete on a client, confirm dialog | Client removed from list, success message | P0 |
+| A-APP-005 | Delete client cancel | Click Delete, cancel confirm dialog | Client remains in list | P1 |
+| A-APP-006 | Reset secret from list | Click Reset Secret, confirm | Secret modal shows new secret | P0 |
+
+### 3.2 Create Application
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-APP-CR-001 | Create CONFIDENTIAL client | Fill name, type=CONFIDENTIAL, redirect URIs, select grant types, submit | Client created, secret modal shown with new secret | P0 |
+| A-APP-CR-002 | Create with empty name | Leave name empty, submit | Form validation prevents submission or API error shown | P0 |
+| A-APP-CR-003 | No grant type selected | Deselect all grant types, submit | Error: "Please select at least one grant type" | P0 |
+| A-APP-CR-004 | Multiple grant types | Select authorization_code + refresh_token + client_credentials | Client created with comma-separated grant types | P1 |
+| A-APP-CR-005 | Duplicate client name | Create two clients with same name | Second creation succeeds (name is not unique key) or proper error | P1 |
+| A-APP-CR-006 | Very long redirect URI | Enter redirect URI > 2048 chars | Either succeeds or server returns validation error gracefully | P2 |
+| A-APP-CR-007 | Invalid redirect URI format | Enter `not-a-url` as redirect URI | Validation error shown | P1 |
+| A-APP-CR-008 | Device code grant type | Select `urn:ietf:params:oauth:grant-type:device_code` | Client created with device_code grant | P1 |
+| A-APP-CR-009 | Close modal without submit | Open create modal, click Cancel | Modal closes, no API call | P1 |
+| A-APP-CR-010 | Loading state during create | Submit create form | Button shows "Creating...", disabled | P2 |
+
+### 3.3 Application Detail (`/admin/applications/:id`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-APP-DT-001 | Info tab loads | Open application detail | Client name, redirect URIs, grant types displayed in editable form | P0 |
+| A-APP-DT-002 | Save name change | Edit client name, click Save | Success message, name updated | P0 |
+| A-APP-DT-003 | Save with no changes | Click Save without modifying anything | Message: "No changes to save" | P1 |
+| A-APP-DT-004 | Edit redirect URIs | Change redirect URIs (multi-line), save | URIs saved as comma-separated, displayed correctly on reload | P0 |
+| A-APP-DT-005 | Invalid application ID | Navigate to `/admin/applications/non-existent-id` | Error message displayed | P1 |
+| A-APP-DT-006 | Scopes tab | Switch to Scopes tab | Available scopes shown with checkboxes, current scopes checked | P0 |
+| A-APP-DT-007 | Save scopes | Check/uncheck scopes, click Save | Scopes updated, success message | P0 |
+| A-APP-DT-008 | Reset secret | Click Reset Secret, confirm | New secret shown in modal | P0 |
+| A-APP-DT-009 | Copy to clipboard | Click copy button for secret | Secret copied, "Copied to clipboard" message | P2 |
+| A-APP-DT-010 | Credentials tab | Switch to Credentials tab | Client ID displayed, reset secret option available | P1 |
+
+---
+
+## Module 4: Users (`/admin/users`)
+
+### 4.1 User List
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-USR-001 | List loads | Navigate to Users page | Table with Username, Email, Verified, MFA, Actions columns | P0 |
+| A-USR-002 | Verified badge | User has email_verified=true | Green "Verified" badge shown | P1 |
+| A-USR-003 | Unverified badge | User has email_verified=false | Yellow "Pending" badge shown | P1 |
+| A-USR-004 | MFA enabled | User has mfa_enabled=true | Green "Enabled" badge | P1 |
+| A-USR-005 | MFA disabled | User has mfa_enabled=false | Gray "Off" badge | P1 |
+| A-USR-006 | Navigate to user detail | Click "Details" link | Navigates to `/admin/users/:id` | P0 |
+| A-USR-007 | API error | Simulate GET /api/admin/users failure | Error banner displayed | P0 |
+
+### 4.2 Role Assignment (List Page Modal)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-USR-RL-001 | Assign single role | Click "Assign Roles", enter "admin", save | Roles updated, modal closes | P0 |
+| A-USR-RL-002 | Assign multiple roles | Enter "admin, user" (comma-separated) | Both roles assigned | P0 |
+| A-USR-RL-003 | Empty role input | Click save with empty role input | No API call (button disabled or input validation) | P1 |
+| A-USR-RL-004 | Whitespace roles | Enter ", , admin, " | Only "admin" assigned (trimmed, filtered) | P1 |
+| A-USR-RL-005 | Non-existent role | Enter "superadmin" | API error or graceful handling | P1 |
+| A-USR-RL-006 | Cancel role assignment | Open modal, click Cancel | Modal closes, no changes | P1 |
+| A-USR-RL-007 | Loading state | Submit role assignment | Button shows "Saving...", disabled | P2 |
+
+### 4.3 User Detail (`/admin/users/:id`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-USR-DT-001 | Info tab loads | Open user detail | Username, email, email_verified shown in editable form | P0 |
+| A-USR-DT-002 | Edit email | Change email, save | Email updated, success message | P0 |
+| A-USR-DT-003 | Toggle email verified | Toggle verified checkbox, save | Verification status updated | P0 |
+| A-USR-DT-004 | No changes save | Click Save without changes | "No changes" message | P1 |
+| A-USR-DT-005 | Roles tab | Switch to Roles tab | Available roles as checkboxes, current roles selected | P0 |
+| A-USR-DT-006 | Save roles | Check/uncheck roles, save | Roles updated, success message | P0 |
+| A-USR-DT-007 | Disable user | Click "Disable User", confirm dialog | User disabled, status updated | P0 |
+| A-USR-DT-008 | Enable user | Click "Enable User" | User enabled, status updated | P0 |
+| A-USR-DT-009 | Security tab | Switch to Security tab | Lock status, login attempts, locked_until shown | P1 |
+| A-USR-DT-010 | Locked user indicator | View locked user | "Locked" status with remaining time shown | P1 |
+| A-USR-DT-011 | Non-existent user | Navigate to `/admin/users/999999` | Error message displayed | P1 |
+| A-USR-DT-012 | Concurrent role edit | Two admins edit same user's roles simultaneously | Last write wins or conflict error | P2 |
+
+---
+
+## Module 5: Roles (`/admin/roles`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-ROLE-001 | List roles | Navigate to Roles page | Table with Name, Description, Users count, Actions | P0 |
+| A-ROLE-002 | Built-in role indicators | View admin/user roles | "built-in" badge shown | P1 |
+| A-ROLE-003 | Built-in roles cannot be deleted | View actions for built-in roles | No "Delete" button shown | P0 |
+| A-ROLE-004 | Create role | Click Create, enter name + description, submit | Role created, appears in table | P0 |
+| A-ROLE-005 | Create role empty name | Submit with empty name | Button disabled (form validation) | P0 |
+| A-ROLE-006 | Create duplicate role name | Create role with existing name | API error shown: role already exists | P0 |
+| A-ROLE-007 | Edit role description | Click Edit, change description, save | Description updated | P0 |
+| A-ROLE-008 | Delete custom role | Click Delete on custom role, confirm | Role deleted, removed from table | P0 |
+| A-ROLE-009 | Delete role cancel | Click Delete, cancel confirm dialog | Role remains | P1 |
+| A-ROLE-010 | Role with assigned users | Delete a role that has users assigned | Confirm dialog appears; after deletion, users lose that role | P1 |
+| A-ROLE-011 | Empty role list | When no custom roles exist | Only built-in roles shown (admin, user) | P2 |
+| A-ROLE-012 | XSS in role name | Enter `<script>alert(1)</script>` as name | Name rendered as text, no script execution | P0 |
+| A-ROLE-013 | Very long role name | Enter name > 100 chars | Either succeeds or proper validation error | P2 |
+
+---
+
+## Module 6: Scopes (`/admin/scopes`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-SCP-001 | List scopes | Navigate to Scopes page | Table with Name, Description, Mapped Role, Default, Admin-only, Actions | P0 |
+| A-SCP-002 | Built-in scope indicators | View openid/profile/email/admin | "built-in" badge or non-deletable | P1 |
+| A-SCP-003 | Create scope | Fill name, description, mapped_role, toggle is_default/requires_admin_role, submit | Scope created, appears in table | P0 |
+| A-SCP-004 | Create scope empty name | Submit with empty name | Button disabled or validation error | P0 |
+| A-SCP-005 | Create duplicate scope | Create scope with existing name | API error: scope already exists | P0 |
+| A-SCP-006 | Edit scope | Click Edit, change description/mapped_role/toggles, save | Scope updated | P0 |
+| A-SCP-007 | Toggle is_default | Set is_default=true for a scope | Scope marked as default | P1 |
+| A-SCP-008 | Toggle requires_admin_role | Set requires_admin_role=true | Scope marked as admin-only | P1 |
+| A-SCP-009 | Delete scope | Click Delete on custom scope, confirm | Scope deleted | P0 |
+| A-SCP-010 | Delete built-in scope | Try to delete openid/admin | Delete button not shown or error | P0 |
+| A-SCP-011 | XSS in scope name | Enter `<img onerror=alert(1) src=x>` as name | Rendered as text | P0 |
+
+---
+
+## Module 7: Tokens (`/admin/tokens`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-TOK-001 | List tokens | Navigate to Tokens page | Table with token_prefix, client_id, user_id, scope, created_at, expires_at | P0 |
+| A-TOK-002 | Filter by client_id | Enter client_id filter, click Apply | Only tokens for that client shown | P0 |
+| A-TOK-003 | Filter by user_id | Enter user_id filter, click Apply | Only tokens for that user shown | P0 |
+| A-TOK-004 | Clear filters | Click "Clear Filters" | Filters reset, all tokens shown | P1 |
+| A-TOK-005 | Revoke single token | Click Revoke on a token, confirm dialog | Token revoked, removed from list | P0 |
+| A-TOK-006 | Revoke by client | Click bulk action "Revoke by Client", confirm | All tokens for that client revoked | P0 |
+| A-TOK-007 | Revoke by user | Click "Revoke by User" (requires user_id filter), confirm | All tokens for that user revoked | P0 |
+| A-TOK-008 | Revoke by user without filter | Click "Revoke by User" without user_id filter | No action (guard: `if (!userIdFilter.value) return`) | P1 |
+| A-TOK-009 | Pagination | When tokens > per_page (50) | Page navigation works, page parameter sent in API | P1 |
+| A-TOK-010 | Empty token list | When no tokens exist | Table shows empty state | P2 |
+| A-TOK-011 | Confirm cancel | Click Revoke, cancel confirm dialog | Token not revoked | P1 |
+| A-TOK-012 | Timestamp formatting | Verify created_at/expires_at display | Formatted as locale string, not raw ISO | P2 |
+
+---
+
+## Module 8: Audit Logs (`/admin/logs`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-LOG-001 | List loads | Navigate to Audit Logs page | Table with timestamp, action, user, details | P0 |
+| A-LOG-002 | Empty logs | When no audit logs exist | Empty state displayed | P1 |
+| A-LOG-003 | Pagination | When logs > per_page | Pagination controls work | P1 |
+| A-LOG-004 | Filter by action type | Filter by specific action | Filtered results shown | P1 |
+| A-LOG-005 | Timestamp ordering | View multiple logs | Sorted by timestamp descending (newest first) | P1 |
+
+---
+
+## Module 9: Settings (`/admin/settings`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-SET-001 | Page loads | Navigate to Settings page | Current settings displayed in editable form | P0 |
+| A-SET-002 | Save settings | Modify setting value, click Save | Success message, settings updated | P0 |
+| A-SET-003 | Invalid setting value | Enter invalid value | Validation error shown | P1 |
+| A-SET-004 | No changes save | Click Save without changes | "No changes" or settings re-fetched | P2 |
+
+---
+
+## Module 10: Navigation & Layout
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-NAV-001 | Sidebar navigation | Click each nav item | Correct page loads, active item highlighted | P0 |
+| A-NAV-002 | Active state on detail pages | Navigate to `/admin/applications/:id` | "Applications" nav item highlighted | P1 |
+| A-NAV-003 | Top bar title | Navigate between pages | Top bar shows current page name | P2 |
+| A-NAV-004 | User info in sidebar | After login | Username initial avatar, name, email shown | P2 |
+| A-NAV-005 | Responsive layout | Resize to mobile width | Sidebar collapses or becomes hamburger menu | P1 |
+
+---
+
+## Module 11: Cross-Cutting Concerns
+
+### 11.1 Error Handling
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-ERR-001 | Network error | Disable network during API call | Error banner with user-friendly message | P0 |
+| A-ERR-002 | 401 Unauthorized | Let session expire, make API call | Redirect to login page | P0 |
+| A-ERR-003 | 403 Forbidden | Admin-only operation by non-admin | Error message, no data exposed | P0 |
+| A-ERR-004 | 500 Server error | Trigger server error | Error banner, no crash | P0 |
+| A-ERR-005 | Success message auto-dismiss | Perform successful action | Success message disappears after 3 seconds | P2 |
+| A-ERR-006 | Error message auto-dismiss | Trigger error message | Error message disappears after 5 seconds | P2 |
+
+### 11.2 Security
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-SEC-001 | CSRF protection (CORS same-origin) | Submit forms / send API requests | Bearer-token architecture: auth token is NOT in a cookie, so classic CSRF does not apply. Protection is enforced by backend CORS with strict exact-match Origin allowlist (no wildcards) — `main.cc` origin check. Cross-origin requests from non-allowlisted origins are rejected | P0 |
+| A-SEC-002 | Token storage | After login | Auth token not in URL or localStorage in plaintext | P0 |
+| A-SEC-003 | Route guard bypass | Manually enter `/admin/users` URL without auth | Redirected to login | P0 |
+| A-SEC-004 | Client secret display | View/create client secret | Secret shown only once, not persisted in page state | P0 |
+
+### 11.3 Performance
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| A-PERF-001 | Large user list | Load 1000+ users | Page renders without freezing, pagination working | P1 |
+| A-PERF-002 | Dashboard concurrent requests | Load Dashboard | Two API calls fire in parallel (Promise.all) | P2 |
+| A-PERF-003 | Lazy-loaded routes | Navigate to each page | Only required component loaded (code splitting) | P2 |

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/ci-cd-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/ci-cd-guide.md
@@ -1,0 +1,178 @@
+# CI/CD 流水线指南 (CI/CD Guide)
+
+本文档说明项目的持续集成与持续交付（CI/CD）机制，基于 **GitHub Actions**。
+
+---
+
+## 1. 流水线概览
+
+CI 配置位于 `.github/workflows/ci.yml`，由三个 fail-fast 串联的 Job（含一条可复用工作流矩阵）组成：
+
+```
+Push/PR 到 master (及 workflow_dispatch)
+        │
+        ├── FAST gate
+        │     ├── static-checks (ubuntu-22.04) — 源码级守卫：
+        │     │     arch-guard / migration-check / api-diff /
+        │     │     测试命名 / manage 脚本对等 / OpenAPI 校验 /
+        │     │     OpenAPI 治理门（三层一致性 + 版本同步）
+        │     └── frontend (_frontend.yml) — 前端属性测试
+        │
+        ├── openapi-governance (openapi-governance.yml, PR 触发) —
+        │     oasdiff 破坏性变更门（base vs PR 的 openapi.yaml；
+        │     豁免清单 tools/openapi-governance/oasdiff-breaking-ignore.md）
+        │
+        ├── MAIN gate
+        │     └── build-test (_build-test.yml × {linux, windows, macos} 矩阵)
+        │           ├── 安装系统依赖 / Conan
+        │           ├── 配置并构建 (Conan + cmake --preset，带缓存)
+        │           ├── [linux] 启动 Postgres/Redis 容器并等待就绪
+        │           ├── [linux] 初始化数据库 Schema
+        │           ├── 运行 ctest + 命名发布门禁
+        │           └── [失败时] 上传测试日志 Artifact
+        │
+        └── RELEASE gate
+              └── sdk-smoke (_sdk-smoke.yml) — 全栈 find_package 冒烟
+```
+
+---
+
+## 2. 触发条件
+
+```yaml
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+- **Push to master**：每次合并到 master 后自动触发全量检查。
+- **Pull Request**：每次 PR 创建/更新时在合并前自动触发，作为门禁检查。
+- **workflow_dispatch**：支持手动触发。
+- **并发控制**：同一分支的新运行会取消其进行中的旧运行。
+
+---
+
+## 3. 核心 Job 详解：`build-test`
+
+`build-test` 是一条可复用工作流（`_build-test.yml`），由 `ci.yml` 以 `{linux, windows, macos}` 矩阵调用，三个平台执行同一套 Conan + `cmake --preset` 构建与 CTest 测试，仅在需要时通过矩阵输入启用数据库。
+
+### 3.1 Service Containers（仅 linux 矩阵腿）
+
+CI 在 Linux 矩阵腿中用 Docker 容器启动 Postgres 和 Redis，并通过真实查询（非仅 `pg_isready`）确保就绪：
+
+| Service | 镜像 | 端口 | 密码 |
+|---|---|---|---|
+| PostgreSQL | `postgres:17-alpine` | `5432` | `123456` |
+| Redis | `redis:7-alpine` | `6379` | 无（CI 环境简化配置）|
+
+> PostgreSQL 镜像与 deploy 默认（`postgres:17-alpine`，2026-08-18 起）对齐——CI 覆盖的
+> 就是部署目标大版本（含 V025 分区/V026 等 migration 在 17 上的行为）。
+
+> **WARNING** **注意**：CI 中 Redis 无密码，因此测试配置通过环境变量 `FULLA_REDIS_PASSWORD=""` 覆盖。Windows/macOS 矩阵腿 `use_database=false`，改用内存存储配置（`config.ci.json`）。
+
+### 3.2 构建缓存策略
+
+为加速 CI 构建速度，对 Conan 依赖做缓存：
+
+| 缓存 | 缓存键 | 内容 |
+|---|---|---|
+| **Conan 依赖缓存** | `conan-{OS}-v1-cpp17-{conanfile.py + conan.lock hash}` | `~/.conan2` 目录（第三方依赖，含 Drogon）|
+
+初次构建约需 **15-20 分钟**；缓存命中后降至 **3-5 分钟**。
+
+### 3.3 数据库初始化
+
+测试前执行 migration 脚本初始化数据库：
+
+```bash
+# 按顺序执行所有 migration 文件
+for f in apps/server/migrations/V*.sql; do
+    psql -h localhost -U fulla_user -d fulla_db -f "$f"
+done
+
+# 执行 seed 数据（开发/测试环境）
+for f in apps/server/seed/*.sql; do
+    psql -h localhost -U fulla_user -d fulla_db -f "$f"
+done
+```
+
+> **注意**: 旧的 `sql/001_*.sql` ~ `sql/004_*.sql` 文件已废弃并删除，所有 schema 定义统一在 `apps/server/migrations/` 目录中管理。
+
+### 3.4 测试执行
+
+```bash
+ctest -V -C Release --output-on-failure --timeout 120
+```
+
+- `-V` : 详细输出
+- `--output-on-failure` : 失败时打印测试标准输出
+- `--timeout 120` : 单个测试最长 2 分钟
+
+### 3.5 失败日志上传
+
+测试失败时，CI 会自动打包并上传以下内容作为 Artifact（保留 7 天）：
+- `build/Testing/` — CTest 测试报告
+- `apps/server/logs/` — 应用运行日志
+
+---
+
+## 4. 镜像构建与签名
+
+CI 流水线本身不构建 Docker 镜像。容器镜像的多架构构建、推送 GHCR、cosign 签名与 syft SBOM 由 `release.yml` 在打 SemVer Tag（`vX.Y.Z`）时完成。详见 [Releases & Supply Chain Security](https://github.com/voidvec/fulla#releases--supply-chain-security)。
+
+---
+
+## 5. 本地复现 CI 环境
+
+如需本地模拟 CI 行为：
+
+```powershell
+# 1. 启动基础设施（CI 中使用 Service Container，本地用 Docker）
+docker run -d -p 5432:5432 -e POSTGRES_USER=fulla_user -e POSTGRES_PASSWORD=123456 -e POSTGRES_DB=fulla_db postgres:17-alpine
+docker run -d -p 6379:6379 redis:7-alpine
+
+# 2. 初始化数据库
+$env:PGPASSWORD = "123456"
+Get-ChildItem "apps\server\migrations\V*.sql" | Sort-Object Name | ForEach-Object {
+    psql -h localhost -U fulla_user -d fulla_db -f $_.FullName
+}
+Get-ChildItem "apps\server\seed\*.sql" | ForEach-Object {
+    psql -h localhost -U fulla_user -d fulla_db -f $_.FullName
+}
+
+# 3. 构建并运行测试（build.bat 走 Conan + cmake --preset，Release 落到 build/windows-msvc）
+.\scripts\backend\build.bat -release
+cd build\windows-msvc
+$env:FULLA_REDIS_PASSWORD = ""
+ctest -V -C Release --output-on-failure
+```
+
+---
+
+## 6. 多平台矩阵
+
+多平台 CI 已合并进 `ci.yml` 的 `build-test` Job，通过 `include` 矩阵在同一套可复用工作流（`_build-test.yml`）上跑三个平台。
+
+### Quick Reference
+
+- **Workflow File:** `.github/workflows/ci.yml`（调用 `_build-test.yml`）
+- **Platforms:** Linux (ubuntu-22.04), Windows (windows-2022), macOS (macos-14)
+- **Trigger:** Push to master, pull requests, manual workflow dispatch
+- **Runtime:** ~15-20 minutes cold cache, ~3-5 minutes warm cache per platform
+
+### Platform-Specific Features
+
+每个平台的差异仅通过矩阵输入表达（无复制粘贴的流水线）：
+
+- **Linux:** 系统依赖经 apt 安装；用 Docker 容器跑 PostgreSQL/Redis；执行数据库初始化与命名发布门禁
+- **Windows:** Conan 依赖管理，MSVC 2022 编译器；内存存储配置（`use_ci_config`），无外部 DB
+- **macOS:** Homebrew（仅 `brew update`）；arm64 构建（`-s arch=armv8`，runner 为 `macos-14`）；内存存储配置
+
+---

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/testing-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/testing-guide.md
@@ -1,0 +1,299 @@
+# 测试策略与执行指南 (Testing Guide)
+
+本文档说明项目的测试分层策略、各测试文件的覆盖范围，以及如何在本地执行全套测试。
+
+---
+
+## 1. 测试前置要求
+
+在运行测试前，请确保以下服务已就绪：
+
+| 服务 | 地址 | 说明 |
+|---|---|---|
+| **PostgreSQL** | `localhost:5432` | 数据库名: `fulla_db` / 用户: `fulla_user` / 密码: `123456` |
+| **Redis** | `localhost:6379` | 密码: `123456`（与 `config.json` 一致）|
+
+> **快速启动基础设施**：如果你使用 Docker，可以单独启动 postgres 和 redis 容器:
+> ```powershell
+> docker run -d -p 5432:5432 -e POSTGRES_USER=fulla_user -e POSTGRES_PASSWORD=123456 -e POSTGRES_DB=fulla_db postgres:17-alpine
+> docker run -d -p 6379:6379 redis:7-alpine redis-server --requirepass 123456
+> ```
+
+---
+
+## 2. 测试分层
+
+测试编译为**两类可执行文件**：
+
+1. **按库的 gtest 二进制文件**（Domain 层，纯单元测试，无 DB/无 Drogon）：
+   - `libs/common/test/fulla-common-test` — `ConfigManager`、`ErrorCatalog`、`Result`、值对象
+   - `libs/common/testing/test/fulla-common-testing-test` — 假实现（`FakeClock`/`FakeCryptoProvider`/`FakeLogger` 等）的确定性验证
+   - `libs/oauth2/test/fulla-oauth2-test` — `TokenService`/`AuthorizationService`/`ClientService`/`JwkManager`/`Pkce`/`ScopeDecisionEngine`/`TokenCrypto`
+   - `libs/identity/test/fulla-identity-test` — `AuthService`/`MfaService`/`TotpUtils`/`SessionManager`/`WebAuthnService`/社交登录（Google/WeChat/GitHub）
+   - 这些用 gtest（非 `DROGON_TEST`），由各 lib 的 `test/CMakeLists.txt` 通过 `gtest_discover_tests` 注册为独立 ctest 条目。
+
+2. **主测试二进制文件 `tests/fulla-tests`**（`DROGON_TEST` 框架，包含所有需要 Drogon/DB 的层级）：
+
+| 层级 | 目录 | 覆盖范围 | 外部依赖 |
+|---|---|---|---|
+| **Level 1 — 单元测试** | `tests/unit/`（`config/`、`error/`、`utils/`、`validation/`、`plugin/`、`schema/`、`subject/`、`initorder/`） | 纯逻辑：错误信封、密码哈希、PKCE/CryptoUtils、RuleSet 校验、配置加载、OpenAPI 生成 | 无 |
+| **Level 2 — 契约测试** | `tests/contract/` | 跨后端（Postgres/Redis/Memory）的仓储契约一致性：`IClientRepository`/`IGrantRepository`/`ITokenRepository`/`IConsentRepository`/`IUserRepository` | Memory 必跑；Postgres/Redis 在 `getPostgresClientOrNull()`/`getRedisClientOrNull()` 返回空时自动 skip |
+| **Level 3 — 集成测试** | `tests/integration/`（`auth/`、`token/`、`storage/`、`concurrency/`、`error/`、`plugin/`） | 完整业务流程、并发竞态、错误信封、插件组装 | Postgres / Redis（memory-only 模式 `-DFULLA_MEMORY_TESTS_ONLY=ON` 下跑 Memory 子集） |
+| **Level 4 — 安全测试** | `tests/security/` | SQL 注入、XSS、命令注入、CORS、Token 安全、速率限制 | Postgres / Redis |
+| **Level 5 — E2E/功能** | `tests/e2e-backend/`、`tests/performance/` | OAuth2 完整流程、性能基准 | Postgres + Redis + Drogon App |
+
+> 内存模式：配置 `-DFULLA_MEMORY_TESTS_ONLY=ON` 可在**无外部 DB** 时跑完整套件（Postgres/Redis 测试自动 skip）——这是 Windows CI 的做法。
+
+> 安全测试用例数、功能测试用例数与覆盖清单见各目录下的测试文件头注释；本节不再硬编码具体数量（数量随迭代增长，统一以 §7 的实测统计为准）。
+
+### DROGON_TEST 断言书写规范 — `CHECK`/`REQUIRE` 内禁止裸布尔运算符 [#MUST]
+
+drogon 的 `CHECK`/`REQUIRE` 是**宏不是函数**：`CHECK_INTERNAL__` 把表达式展开为
+`(drogon::test::internal::Decomposer() <= expr)`，而宏实参替换不加括号，所以**裸写的
+`a || b`（或 `a && b`）会重结合成 `(Decomposer() <= a) || b`**——结果静默错误，症状像
+"断言随机挂"。真实案例（PR #68 调试）：`CHECK(body.isMember("error") || body.isMember("code"))`
+失败，但 `LOG_INFO` 打出的原始 body 里明明有 `error` 键。
+
+**规则**：`CHECK(...)`/`REQUIRE(...)` 的顶层实参里出现 `||`/`&&` 时，必须满足其一：
+
+```cpp
+// ✅ 拆成两条断言（首选——失败信息更精确）
+CHECK(body.isMember("error"));
+CHECK(body.isMember("code"));
+
+// ✅ 整体加括号（外层括号让链式表达式作为一个操作数绑定到 <=）
+CHECK((a != std::string::npos || b != std::string::npos));
+
+// ✅ 仓库既有先例：显式 (bool) 转换（tests/e2e-backend/oauth2_flows/FunctionalTest.cc）
+CHECK((bool)(response.find("code=") != std::string::npos ||
+             response.find("error") != std::string::npos));
+
+// ❌ 禁止：裸顶层布尔链（宏展开后语义被破坏）
+CHECK(body.isMember("error") || body.isMember("code"));
+```
+
+说明：运算符嵌套在**调用/下标/子表达式括号内**（如 `CHECK(f(a || b))`、`CHECK(x == (a || b))`）
+不受影响——它在绑定给 `<=` 之前已求值。`CHECK_THROWS`/`REQUIRE_THROWS` 系列走 `EVAL__`
+路径，也不受影响。
+
+**CI 强制**：`tools/test/scripts/drogon_macro_bool_check.py` 扫描 `tests/` 树并对违规
+报错（static-checks 步骤，与命名规范检查并列）；`--selftest` 可自验。
+
+### Level 4 补充明细 — 安全测试 (Security Tests)
+
+| 测试文件 | 覆盖范围 |
+|---|---|
+| `SecurityTest.cc` | SQL 注入、XSS、命令注入、输入验证、CORS、Token 安全、速率限制、健康检查安全 |
+
+覆盖要点：输入验证（注入/长度/空值）、认证授权（无效凭据、速率限制）、CORS 双向、敏感数据传递、Token 安全（无效/缺失授权码与 Refresh Token）、安全头（含 HSTS）、暴力破解防护、健康检查信息泄露。
+
+### Level 5 补充明细 — E2E / 功能测试 (Functional Tests)
+
+| 测试文件 | 覆盖范围 | 依赖 |
+|---|---|---|
+| `IntegrationE2ETest.cc` | 模拟完整 OAuth2 授权码流程：HTTP 请求 → 授权 → 登录 → 换 Token → UserInfo 验证 | Postgres + Redis + 运行中的 Drogon App |
+| `FunctionalTest.cc` | OAuth2 完整流程、错误处理、UTF-8/Emoji 字符、健康检查、RBAC、Token 生命周期、输入验证、速率限制 | Postgres + Redis |
+
+覆盖要点：完整授权码流程、错误场景、UTF-8/Emoji 边界、RBAC 未授权路径、Token 生命周期异常路径、超长输入、速率限制检测、端点可用性。
+
+> 用例数量随版本演进，**以 `ctest -N` 实测为准**（当前全套基线见 §7）。
+
+---
+
+## 3. 执行方式
+
+### 方式一：通过 CTest（推荐）
+
+```powershell
+# 在构建完成后执行（目录为 build/<preset>，Windows Release 为 windows-msvc）
+cd build\windows-msvc
+ctest -C Release --output-on-failure --timeout 120
+```
+
+> **输出策略**：默认仅打印失败用例的日志与末尾汇总（`成功数 / 失败数 / 总数`）。如需查看每个用例（含通过用例）的完整输出，加 `--verbose`（`-V`）；如需完全静默、只看汇总行，加 `-Q`。`manage.sh test-backend -q` / `manage.ps1 test-backend -q` 等价于 `-Q`。
+
+### 方式二：直接运行测试可执行文件
+
+测试可执行文件内部会自动启动 Drogon App 实例（`test_main.cc` 中通过信号量同步），**无需手动启动后端服务**。
+
+```powershell
+cd build\windows-msvc\tests\Release
+.\fulla-tests.exe
+```
+
+### 方式三：使用 manage 脚本
+
+`manage.ps1`（Windows）/ `manage.sh`（Linux/macOS）封装了与 CI 相同的构建+测试流程：
+
+```powershell
+# 构建并运行后端测试套件（与 manage.sh test-backend 等价）
+.\manage.ps1 test-backend
+
+# 完整循环：构建 + 单元/集成测试 + 管理端点 API 测试
+.\manage.ps1 full-test
+
+# 仅跑管理端点 / OAuth2 端点的 API 脚本
+.\manage.ps1 test-admin-endpoints
+.\manage.ps1 test-oauth2-endpoints
+```
+
+---
+
+## 4. 测试输出示例
+
+```
+All tests passed (N assertions in M tests)
+```
+
+如果出现失败，失败的测试名称和断言位置会被打印：
+```
+In test case SomeTestName
+  SomeTestFile.cc:63  FAILED:
+    CHECK(c.has_optional())
+```
+
+**常见失败原因**：
+- Redis 或 PostgreSQL 服务未启动 → 检查服务是否可达
+- Redis 密码不匹配 → 检查 `config.json` 中的 `passwd` 字段
+- 数据库未初始化 → 执行 `apps/server/migrations/` 目录下的迁移脚本（后端在 `FULLA_AUTO_MIGRATE=true` 时也会自动执行）
+
+---
+
+## 5. CI 中的测试
+
+每次 Push 到 `master` 或发起 PR 时，GitHub Actions CI 会自动执行：
+
+1. 启动 Postgres 和 Redis Service Container
+2. 初始化数据库 Schema
+3. 编译项目
+4. 运行 `ctest`
+
+详见 [CI/CD 指南](../contribute/ci-cd-guide)。
+
+---
+
+## 6. 测试报告 (Test Reports)
+
+历史的安全/功能测试报告、Bug 状态分析与连接泄漏验证报告属于过程性档案，已随文档治理移出仓库（维护者本地保存）。当前测试状态以 CI 与本节口径为准：
+
+- **CI 全绿**是合入门槛（三平台矩阵，见 [CI/CD 指南](ci-cd-guide.md)）。
+- 安全与功能覆盖面见 §2 Level 4/5 明细；数量以 `ctest -N` 实测为准。
+- 历史报告中的结论性内容（如 April 快照中发现的安全缺陷）已修复并沉淀为回归测试用例。
+
+---
+
+## 7. 测试覆盖率总结
+
+### 总体测试状态
+
+> 以下数字为**实测统计**（Windows MSVC Release 构建，无外部 DB，Postgres/Redis 测试 skip）。在带 Postgres+Redis 的环境（如 Linux CI 或本地 WSL+Docker）下，被 skip 的契约/集成测试会激活，ctest 条目数会进一步增加。
+
+| 测试来源 | 通过 | 失败 | 总计 | 通过率 |
+|---------|------|------|------|--------|
+| **按库 gtest 二进制**（2026-06 基线快照；当前全套 ctest 为 501，以 `ctest -N` 实测为准） | 364 | 0 | 364 | 100% |
+| **主测试二进制 ctest 条目**（含 Contract 标签 + OAuth2Tests 全量） | 450 | 0 | 450 | 100% |
+
+> 注：两列数字有重叠关系——主二进制内含所有 `DROGON_TEST` 单元/集成测试（作为一个 `OAuth2Tests` 条目运行）；按库 gtest 二进制是 Domain 层的纯单元测试，独立编译运行。`450` 条 ctest 中 84 条带 `Contract` 标签（可用 `ctest -L Contract` 单独跑）。
+
+### 代码覆盖率
+
+实测行覆盖率（gcov，gcc 13.3 Debug 构建，WSL Ubuntu 24.04，Postgres+Redis 激活；排除 ORM 自动生成的 `models/`；测量于 7ba8068，全部 5 个测试二进制均已执行）：
+
+| 库 | 行覆盖 | 备注 |
+|---|---|---|
+| libs/common | 69.4% (318/458) | ErrorCatalog/ErrorTypes/ErrorContext/ConfigManager（由 per-lib gtest 二进制 `fulla-common-test` 驱动）；ConfigManager 环境相关分支与 ErrorCatalog 部分分支未覆盖 |
+| libs/identity | **96.9%** (590/609) | Auth/Mfa/WebAuthn/Social/Totp/Session |
+| libs/storage-memory | **97.1%** (431/444) | Memory 后端全方法覆盖（CI 必跑路径） |
+| libs/oauth2 | **92.1%** (627/681) | TokenService/AuthService/ClientService/JwkManager/Pkce |
+| libs/storage-redis | 46.2% (306/663) | 契约测试覆盖 getClient/validate/grant/token/consent 主路径；Lua 脚本与 transaction CRUD 待补 |
+| libs/storage-postgres | 43.9% (727/1657) | 契约测试覆盖主路径；剩余盲区为事务/错误回退分支（需注入故障才能触发） |
+| libs/drogon | **53.5%** (4807/8978) | admin 0%→55-69%、admin 控制器 0%→91-100%；authorize/health/discovery/mfa/deviceauth/userselfservice/apidoc 控制器补强；社交 OAuth 控制器经 mock 注入补强（Google 38.3%、WeChat 30.6%、GitHub 32.5%）；WebAuthn 39.2%（非加密 stub，无需 authenticator） |
+| **整体** | **57.9%** (7806/13490) | 上表逐库求和（`scripts/measure_coverage.py` 的 OVERALL 即逐库之和）；从 48.5% 基线提升 +9.4pp |
+
+> 上一轮基线为 48.5% (7091/14631)；本轮通过 admin 层 HTTP 集成测试 + 控制器补强 + 社交 OAuth/WebAuthn 的 mock 注入测试（`tests/common/SocialMockFixture.h` + `libs/identity/include/fulla/identity/testing/` 的共享 Fake）将整体提升到 57.9%。社交 OAuth 的 Google/WeChat/GitHub 均可经 mock 注入在 memory 模式下跑（注入路径不写 DB）；其中 GitHub happy-path 最初因 `issueTokensForUser` 直连 `getDbClient()` 无法在 memory 模式覆盖，随后已重构为经 `OAuth2Plugin::saveTokenPair` 存储抽象持久化（见 `SocialLoginHttpTest.cc` 的 `Integration_P0_GitHubLogin_FakeExchange_ReturnsTokens`），happy-path 现已可测（GitHubController 从 5.9% 提升到 32.5%）；WebAuthn 为非加密 stub，Postgres 模式下完整可测。注：此前文档的 58.8% 系旧逐库数字求和（其中 common 的 98.8% 为陈旧数据，现 `libs/common/src` 仅 4 个源文件 458 行，实测 69.4%）；本表已全部替换为 7ba8068 的实测值。剩余盲区：storage-postgres 事务/错误回退分支（需故障注入）。
+
+#### ⚠ 实测覆盖率必须跑全部 5 个测试二进制
+
+实测数字依赖**全部 5 个测试二进制**都执行（仅跑主二进制 `fulla-tests` 会漏掉 4 个 per-lib gtest 二进制贡献的 domain 层覆盖率，common 会被低估到 ~60%）：
+
+1. `libs/common/test/fulla-common-test`（40 用例）
+2. `libs/common/testing/test/fulla-common-testing-test`（43 用例）
+3. `libs/identity/test/fulla-identity-test`（130 用例）
+4. `libs/oauth2/test/fulla-oauth2-test`（151 用例）
+5. `tests/fulla-tests`（450 条 ctest，含所有 `DROGON_TEST` 单元/集成/契约/admin HTTP 测试）
+
+在 coverage 构建目录下依次运行这 5 个二进制后再聚合 `.gcda`。
+
+#### ⚠ gcovr 路径匹配 bug —— 用 `scripts/measure_coverage.py` 代替
+
+`gcovr 8.6` 对部分文件（如 `ClientManagementService.cc`）会误报 **0%**：raw `gcov` 明确显示 `Lines executed:55.79% of 328`，但 gcovr 的 `--print-summary` 只列出文件名不带百分比（gcovr 的源路径匹配对含绝对路径 + Drogon 头文件的 `.gcov` 输出处理不一致）。这是 gcovr 的已知路径匹配问题，不是零计数 bug（gcov flush 工作正常，见下）。
+
+**可靠的聚合方式**：`scripts/measure_coverage.py` 直接用 `gcov -j`（JSON 格式，每文件 `{file, lines[{count, unexecuted_block}]}`）聚合，绕过 gcovr 的文本路径匹配。用法：
+
+```bash
+cd <repo>
+# 先跑全部 5 个二进制（见上一节），再生成 JSON + 聚合：
+find build/linux-coverage/libs -path "*/src/*" -name "*.gcda" ! -path "*/models/*" \
+  | xargs -I{} bash -c 'cd "$(dirname {})" && gcov -j "$(basename {})" >/dev/null 2>&1'
+find build/linux-coverage/libs -path "*/src/*" -name "*.gcov.json.gz" ! -path "*/models/*" \
+  | python3 scripts/measure_coverage.py
+```
+
+gcovr 仍可用于生成逐文件 HTML 报告（`--html-details`），但**汇总百分比以 `scripts/measure_coverage.py` 为准**。
+
+#### 覆盖率工具链
+
+- `cmake/Coverage.cmake`（`oauth2_apply_gcov(target)`）给每个 first-party 库 + 测试可执行文件加 `-fprofile-arcs -ftest-coverage`，并显式链接 libgcov（仅 GCC；Clang 的 profile 运行时由 `-fprofile-arcs` 链接选项自动提供，无 libgcov）。
+- `tests/test_main.cc` 在两处 `std::_Exit()` 前显式调用 `__gcov_dump()`：因为 `_Exit` 绕过 `atexit`，libgcov 的计数器 flush 不会自动执行（否则 gcov 读到全 0 计数）。这是 Drogon 测试框架 fast-exit 与 gcov 的已知交互，需在测试 main 里手动补 flush。（注：4 个 per-lib gtest 二进制正常退出，不走 `_Exit`，因此它们不需要手动 flush。）
+- 覆盖率当前阶段性目标：60%（7ba8068 实测 57.9%）。剩余盲区集中在难以 HTTP 测试的分支：WebAuthn 典礼/加密深分支、UserSelfService（需逆向 auth 前置 filter）、storage-postgres 事务/错误回退分支（需故障注入）。社交 OAuth 控制器已可通过 `SocialMockFixture.h` 的 Fake 注入在 memory 模式下覆盖（GitHub happy-path 经 `saveTokenPair` 存储抽象重构后不再依赖 `getDbClient()`）。ORM 自动生成的 `libs/storage-postgres/src/models/*.cc` 已从分母排除。
+
+---
+
+## 8. 手动验证与 API 测试 (Manual Validation)
+
+除了自动化测试套件外，项目还提供了用于手动验证端点功能的工具和脚本。
+
+### 8.1 PowerShell 自动化验证脚本
+项目提供了完整的 OAuth2 端点测试脚本：`scripts/backend/test-oauth2-endpoints.ps1`。
+
+**使用方法：**
+```powershell
+# 临时绕过执行策略运行测试
+powershell -ExecutionPolicy Bypass -File scripts/backend/test-oauth2-endpoints.ps1
+```
+该脚本会依次执行健康检查、登录、授权码交换、UserInfo 访问及管理员面板验证。
+
+### 8.2 多环境 API 测试 (curl)
+不同的命令行工具对 curl 语法的支持不同：
+
+*   **PowerShell (推荐)**: 使用 `Invoke-RestMethod`。
+*   **Git Bash**: 支持标准的 Unix 单引号语法。
+*   **CMD**: 需要使用双引号并转义 `&` 符号为 `^&`。
+
+**示例：登录并获取 JSON 响应**
+```bash
+# Git Bash 示例
+curl -X POST http://127.0.0.1:5555/oauth2/login \
+  -d 'username=admin&password=admin&client_id=vue-client&redirect_uri=http://localhost:5173/callback&json=true'
+```
+
+---
+
+## 9. 故障排查 (Troubleshooting)
+
+### 9.1 常见问题与对策
+*   **服务器无法启动**：检查端口 5555 是否被占用 (`netstat -ano | findstr :5555`)，并确保 `config.json` 路径正确。
+*   **登录失败 (400)**：确认用户名密码匹配，且数据库中存在该用户。检查 `redirect_uri` 是否与配置完全一致。
+*   **Token 交换失败**：授权码 (Code) 仅能使用一次且有有效期。确保 `client_id` 和 `client_secret` 正确。
+*   **PowerShell 脚本限制**：如提示“禁止运行脚本”，请使用 `-ExecutionPolicy Bypass` 参数。
+
+### 9.2 调试技巧
+*   **日志级别**：排错时可在 `config.json` 中临时将 `log_level` 调为 `DEBUG`（甚至 `TRACE`）以获取详细输出，定位完成后调回 `INFO`。完整的六级语义与约定见 [observability.md §3.2](../operate/observability.md)。
+*   **实时日志**：使用 `Get-Content apps/server/logs/drogon.log -Wait -Tail 20` 监控运行状态。
+
+---
+
+**相关文档**:
+- [Security Architecture](../architecture/security-architecture.md) - 安全加固与安全架构设计
+- [Data Consistency](../architecture/data-persistence.md) - 数据一致性和威胁模型
+- [API Reference](../domains/api-reference.md) - API 接口文档

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/user-frontend-test-cases.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/user-frontend-test-cases.md
@@ -1,0 +1,285 @@
+# OAuth2 User Frontend - Test Cases
+
+> User frontend path: `/` | Framework: Vue 3 + TailwindCSS | Playwright E2E
+
+## Module 1: Authentication
+
+### 1.1 Login Page (`/login`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-LOGIN-001 | Valid credentials | Enter valid username/password, click Sign In | Redirect to Dashboard (`/`) | P0 |
+| U-LOGIN-002 | Empty username | Submit with empty username | HTML5 required validation prevents submit | P1 |
+| U-LOGIN-003 | Empty password | Submit with empty password | HTML5 required validation prevents submit | P1 |
+| U-LOGIN-004 | Wrong password | Enter valid user + wrong password | Error alert displayed | P0 |
+| U-LOGIN-005 | Non-existent user | Enter unregistered username | Error message shown | P0 |
+| U-LOGIN-006 | SQL injection | Enter `' OR 1=1 --` as username | Error message, no unauthorized access | P0 |
+| U-LOGIN-007 | XSS in username | Enter `<script>alert('xss')</script>` | Rendered as text, no script execution | P0 |
+| U-LOGIN-008 | Loading state | Submit valid credentials | Button shows loading spinner, disabled | P2 |
+| U-LOGIN-009 | Redirect after login | Login with `?redirect=/profile` in URL | Redirect to `/profile` after login | P0 |
+| U-LOGIN-010 | Already authenticated | Navigate to `/login` while logged in | Redirect to Dashboard | P0 |
+| U-LOGIN-011 | GitHub social login | Click "Sign in with GitHub" | Redirected to GitHub OAuth page | P1 |
+| U-LOGIN-012 | GitHub client_id not configured | When `VITE_GITHUB_CLIENT_ID` is empty | GitHub button still visible, link has no client_id | P2 |
+| U-LOGIN-013 | Link to register | Click "create a new account" link | Navigate to `/register` | P1 |
+| U-LOGIN-014 | Link to forgot password | Click "Forgot password?" | Navigate to `/forgot-password` | P1 |
+| U-LOGIN-015 | Browser autofill | Use browser autofill for credentials | Form submits correctly with autofilled values | P2 |
+
+### 1.2 MFA Challenge
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-MFA-001 | MFA required flow | Login with MFA-enabled user | MFA challenge form shown (6-digit input) | P0 |
+| U-MFA-002 | Valid MFA code | Enter correct 6-digit TOTP code | Login succeeds, redirect to Dashboard | P0 |
+| U-MFA-003 | Invalid MFA code | Enter wrong 6-digit code | Error message displayed | P0 |
+| U-MFA-004 | Less than 6 digits | Enter "1234" | Submit button disabled (`mfaCode.length !== 6`) | P1 |
+| U-MFA-005 | More than 6 digits | Input limited to 6 chars (maxlength=6) | Cannot enter more than 6 digits | P1 |
+| U-MFA-006 | Non-numeric input | Enter letters in MFA field | Input limited by `inputmode="numeric"` | P1 |
+| U-MFA-007 | Back to login | Click "Back to login" link | MFA form hidden, login form shown | P1 |
+| U-MFA-008 | Loading state | Submit MFA code | Button shows loading state, disabled | P2 |
+| U-MFA-009 | Expired MFA token | Wait for mfa_token to expire, then submit code | Error message, may need to re-login | P1 |
+
+### 1.3 Registration Page (`/register`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-REG-001 | Valid registration | Fill username, email, password (6+ chars), matching confirm, submit | Success message shown, auto-redirect to login after 2s | P0 |
+| U-REG-002 | Password too short | Enter 5-char password | Error: "Password must be at least 6 characters" | P0 |
+| U-REG-003 | Passwords don't match | Enter different passwords | Error: "Passwords do not match" | P0 |
+| U-REG-004 | Duplicate username | Register with existing username | Error message from API | P0 |
+| U-REG-005 | Duplicate email | Register with existing email | Error message from API | P0 |
+| U-REG-006 | Empty username | Submit with empty username | Form submits successfully (username is optional) | P1 |
+| U-REG-007 | Empty email | Submit with empty email | HTML5 required validation | P1 |
+| U-REG-008 | Invalid email format | Enter "not-an-email" | HTML5 email validation prevents submit | P1 |
+| U-REG-009 | SQL injection in username | Enter `'; DROP TABLE users;--` | Error or registration fails safely | P0 |
+| U-REG-010 | XSS in username | Enter `<script>alert(1)</script>` | Rendered as text | P0 |
+| U-REG-011 | Very long username | Enter username > 255 chars | API validation error or truncation handled | P2 |
+| U-REG-012 | Loading state | Submit valid form | Button shows "Creating...", disabled | P2 |
+| U-REG-013 | Success redirect timing | After successful registration | Success message visible, then redirect after 2s | P2 |
+| U-REG-014 | Link to login | Click "Sign in" link | Navigate to `/login` | P1 |
+| U-REG-015 | Already authenticated | Navigate to `/register` while logged in | Redirect to Dashboard | P1 |
+
+### 1.4 Forgot Password (`/forgot-password`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-FP-001 | Valid email | Enter registered email, submit | Success message shown (anti-enumeration: always success) | P0 |
+| U-FP-002 | Unregistered email | Enter non-existent email | Still shows success message (anti-enumeration) | P0 |
+| U-FP-003 | Invalid email format | Enter "not-email" | HTML5 email validation | P1 |
+| U-FP-004 | Empty email | Submit with empty email | HTML5 required validation | P1 |
+| U-FP-005 | Loading state | Submit form | Button shows "Sending...", disabled | P2 |
+| U-FP-006 | Back to login link | Click "Back to Login" | Navigate to `/login` | P1 |
+| U-FP-007 | API error handling | Simulate network error during submit | Still shows success (anti-enumeration by design) | P1 |
+
+### 1.5 Reset Password (`/reset-password`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-RP-001 | Valid reset token | Navigate with valid token, enter new password | Password reset succeeds, redirect to login | P0 |
+| U-RP-002 | Expired reset token | Navigate with expired token | Error: token expired or invalid | P0 |
+| U-RP-003 | Invalid reset token | Navigate with random token | Error message | P0 |
+| U-RP-004 | No token in URL | Navigate to `/reset-password` without token | Error or redirect to forgot-password | P1 |
+
+### 1.6 Email Verification (`/verify-email`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-VE-001 | Valid verification token | Navigate with valid token | Email verified, success message | P0 |
+| U-VE-002 | Expired token | Navigate with expired token | Error message, option to resend | P1 |
+| U-VE-003 | Already verified | Verify already-verified email | Message: already verified | P1 |
+| U-VE-004 | Invalid token | Navigate with random token | Error message | P0 |
+
+---
+
+## Module 2: OAuth2 Flows
+
+### 2.1 Authorization Callback (`/callback`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-CB-001 | Valid authorization code | Navigate with `?code=xxx` | Code exchanged, redirect to Dashboard | P0 |
+| U-CB-002 | Error from provider | Navigate with `?error=access_denied` | Error displayed: "access_denied" or description | P0 |
+| U-CB-003 | No code parameter | Navigate to `/callback` without params | Error: "No authorization code received" | P0 |
+| U-CB-004 | Loading spinner | Observe during code exchange | Spinner shown while "Completing sign in..." | P2 |
+| U-CB-005 | Invalid authorization code | Navigate with `?code=invalid_code` | Error message from token exchange failure | P0 |
+| U-CB-006 | Expired authorization code | Use code after 10-minute expiry | Error message | P1 |
+| U-CB-007 | Back to login link | Click "Back to Login" | Navigate to `/login` | P1 |
+
+### 2.2 GitHub Callback (`/callback/github`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-GH-001 | Valid GitHub code | GitHub redirects with valid code | User authenticated via GitHub, redirected to Dashboard | P1 |
+| U-GH-002 | GitHub auth denied | User denies GitHub authorization | Error message displayed | P1 |
+| U-GH-003 | New GitHub user | First-time GitHub login | Account auto-created with GitHub profile info | P1 |
+
+### 2.3 Consent Page (`/consent`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-CON-001 | Approve consent | Review requested scopes, click Approve | Authorization code returned to client | P0 |
+| U-CON-002 | Deny consent | Click Deny | Error returned to client, user redirected | P0 |
+| U-CON-003 | Scope display | View consent page | All requested scopes listed with descriptions | P0 |
+| U-CON-004 | No scopes requested | Consent page with no scopes | Minimal consent or handled gracefully | P2 |
+
+### 2.4 Device Verification (`/device/verify`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-DV-001 | Valid device code | Enter valid device code, verify | Device authorized | P0 |
+| U-DV-002 | Invalid device code | Enter wrong code | Error: invalid or expired code | P0 |
+| U-DV-003 | Expired device code | Enter expired code | Error message | P1 |
+| U-DV-004 | Empty device code | Submit without entering code | Validation error | P1 |
+
+---
+
+## Module 3: Account Pages (Protected)
+
+### 3.1 Dashboard (`/`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-DASH-001 | Dashboard loads | Login, view Dashboard | Welcome message with username, Account ID, Email, Roles displayed | P0 |
+| U-DASH-002 | No roles | User with no assigned roles | "None" displayed in roles section | P1 |
+| U-DASH-003 | Multiple roles | User with admin + user roles | Both role badges displayed | P1 |
+| U-DASH-004 | Quick links | Click Edit Profile / Security / Authorized Apps | Navigates to correct page | P0 |
+| U-DASH-005 | Unauthenticated access | Navigate to `/` without auth | Redirect to `/login?redirect=/` | P0 |
+| U-DASH-006 | Session restore | Reopen browser to `/` with valid session | Session restored via `auth.restoreSession()`, Dashboard shown | P0 |
+| U-DASH-007 | Session restore failure | Reopen browser with expired session | Redirect to login with redirect param | P1 |
+
+### 3.2 Profile Page (`/profile`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-PROF-001 | Profile loads | Navigate to Profile | Username, Account ID, Email, Verification status, Roles shown | P0 |
+| U-PROF-002 | Email verified | User with verified email | Green "Verified" badge | P1 |
+| U-PROF-003 | Email unverified | User with unverified email | Yellow "Unverified" badge, "Resend verification" link shown | P0 |
+| U-PROF-004 | Resend verification | Click "Resend verification email" | Success: "Verification email sent!", disappears after 3s | P0 |
+| U-PROF-005 | Resend verification failure | Simulate API failure | Error message displayed | P1 |
+| U-PROF-006 | No email | User without email | "N/A" displayed for email, no resend link | P2 |
+| U-PROF-007 | API failure | Simulate GET /api/me failure | Error: "Failed to load profile" | P0 |
+| U-PROF-008 | Loading state | Observe during page load | "Loading..." placeholder shown | P2 |
+
+### 3.3 Security Page (`/security`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-SEC-001 | Page loads | Navigate to Security | Password change form, MFA section, WebAuthn section displayed | P0 |
+| U-SEC-002 | Change password - valid | Enter old + new password (6+ chars, matching), submit | Success message, fields cleared | P0 |
+| U-SEC-003 | Change password - mismatch | New password != confirm | Error: "Passwords do not match" | P0 |
+| U-SEC-004 | Change password - too short | New password < 6 chars | Error: "Password must be at least 6 characters" | P0 |
+| U-SEC-005 | Change password - wrong old | Enter incorrect old password | Error message from API | P0 |
+| U-SEC-006 | Change password - empty fields | Submit with empty old password | Form validation or API error | P1 |
+| U-SEC-007 | MFA setup | Click "Setup MFA" | QR code and secret key displayed | P0 |
+| U-SEC-008 | MFA verify - valid code | Enter correct TOTP code after setup | Success: "MFA enabled successfully!", MFA now active | P0 |
+| U-SEC-009 | MFA verify - invalid code | Enter wrong code | Error message | P0 |
+| U-SEC-010 | MFA disable - valid password | Enter password, click Disable MFA | Success: "MFA disabled" | P0 |
+| U-SEC-011 | MFA disable - empty password | Click Disable without entering password | Error: "Password required to disable MFA" | P1 |
+| U-SEC-012 | MFA disable - wrong password | Enter wrong password | Error message from API | P0 |
+| U-SEC-013 | WebAuthn register | Click "Register Passkey" | Browser WebAuthn dialog shown | P1 |
+| U-SEC-014 | WebAuthn register cancel | Cancel browser dialog | Error: "Passkey registration was cancelled or timed out" | P1 |
+| U-SEC-015 | WebAuthn not supported | Access from unsupported browser | WebAuthn section hidden or "not supported" message | P1 |
+| U-SEC-016 | Delete account - correct username | Enter matching username, click Delete | Account deleted, redirected to login | P0 |
+| U-SEC-017 | Delete account - wrong username | Enter non-matching username | Error: "Username does not match" | P0 |
+| U-SEC-018 | Delete account - empty username | Click Delete without username | Validation prevents submission | P1 |
+| U-SEC-019 | Loading states | Submit any form | Buttons show loading state, disabled during request | P2 |
+
+### 3.4 Authorized Apps (`/authorized-apps`)
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-APP-001 | List authorized apps | Navigate to Authorized Apps | Each app shows name, client_id, scopes, Revoke button | P0 |
+| U-APP-002 | Empty list | User has no authorized apps | "No authorized applications" empty state | P1 |
+| U-APP-003 | Revoke app | Click Revoke, confirm dialog | App removed from list, success message | P0 |
+| U-APP-004 | Revoke cancel | Click Revoke, cancel confirm | App remains in list | P1 |
+| U-APP-005 | Revoke failure | Simulate API failure on revoke | Error message displayed | P0 |
+| U-APP-006 | App without name | App has client_id but no name | client_id displayed as fallback name | P1 |
+| U-APP-007 | Success message auto-dismiss | After successful revoke | Success message disappears after 3s | P2 |
+| U-APP-008 | Loading state | During initial load | "Loading..." placeholder shown | P2 |
+
+---
+
+## Module 4: Navigation & Layout
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-NAV-001 | Top navigation links | Click Overview/Profile/Security/Authorized Apps | Correct page loads, active link highlighted | P0 |
+| U-NAV-002 | Logo link | Click logo | Navigate to Dashboard | P1 |
+| U-NAV-003 | User dropdown | Click user avatar | Dropdown with Profile, Security, Sign Out | P0 |
+| U-NAV-004 | Dropdown navigation | Click Profile in dropdown | Navigate to `/profile`, dropdown closes | P1 |
+| U-NAV-005 | Click outside dropdown | Open dropdown, click outside | Dropdown closes | P1 |
+| U-NAV-006 | Logout from dropdown | Click "Sign Out" | Session cleared, redirect to login | P0 |
+| U-NAV-007 | Sticky header | Scroll page content | Header remains visible at top | P2 |
+| U-NAV-008 | Responsive nav | Resize to mobile width | Nav collapses to hamburger or minimal layout | P1 |
+| U-NAV-009 | Active nav state | Navigate to `/security` | "Security" nav link highlighted with indigo background | P1 |
+
+---
+
+## Module 5: Cross-Cutting Concerns
+
+### 5.1 Error Handling
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-ERR-001 | Network error | Disable network during API call | Error message displayed, no crash | P0 |
+| U-ERR-002 | 401 Unauthorized | Let session expire, make API call | Redirect to login page | P0 |
+| U-ERR-003 | 500 Server error | Trigger server error | Error message, no crash | P0 |
+| U-ERR-004 | Success message auto-dismiss | Perform successful action | Success message disappears after 3-4 seconds | P2 |
+| U-ERR-005 | Error normalization | Receive non-standard API error | Error normalized via `errorAdapter`, user-friendly message | P1 |
+
+### 5.2 Security
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-SEC-001 | Route guard - protected pages | Navigate to `/profile` without auth | Redirect to `/login?redirect=/profile` | P0 |
+| U-SEC-002 | Route guard - guest pages | Navigate to `/login` while authenticated | Redirect to Dashboard | P0 |
+| U-SEC-003 | Token not in URL | After login | Access token not visible in URL | P0 |
+| U-SEC-004 | Password field masking | View all password fields | Type="password", characters masked | P1 |
+| U-SEC-005 | Anti-enumeration (forgot password) | Submit unregistered email | Same success message as registered email | P0 |
+| U-SEC-006 | CSRF on password change | Change password request | Proper auth headers included | P0 |
+| U-SEC-007 | localStorage cleared on logout | Logout, check localStorage | Auth tokens removed | P0 |
+| U-SEC-008 | localStorage cleared on account delete | Delete account | localStorage.clear() called | P0 |
+
+### 5.3 Session Management
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-SESS-001 | Session restore on page reload | Refresh page while logged in | Session restored, no redirect to login | P0 |
+| U-SESS-002 | Session expire during use | Wait for token expiry, make API call | Redirect to login | P0 |
+| U-SESS-003 | Multiple tabs | Open app in two tabs, logout in one | Other tab redirects to login on next navigation | P1 |
+| U-SESS-004 | Token refresh | Access token expires, refresh token valid | New access token obtained seamlessly | P1 |
+
+### 5.4 Performance
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-PERF-001 | Lazy-loaded routes | Check network tab during navigation | Only required chunks loaded (code splitting) | P2 |
+| U-PERF-002 | Large authorized apps list | User with 50+ authorized apps | Page renders without lag | P1 |
+| U-PERF-003 | WebAuthn credential list | User with many registered passkeys | Credentials listed efficiently | P2 |
+
+### 5.5 Accessibility
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-A11Y-001 | Form labels | Inspect all form inputs | All inputs have associated labels | P1 |
+| U-A11Y-002 | Required field indicators | View registration form | Required fields marked (asterisk or "required" attribute) | P1 |
+| U-A11Y-003 | Keyboard navigation | Tab through login form | All interactive elements reachable, focus visible | P1 |
+| U-A11Y-004 | Submit on Enter | Press Enter in password field | Form submits | P1 |
+| U-A11Y-005 | Error announcement | Trigger form error | Error message readable by screen reader | P2 |
+| U-A11Y-006 | Autocomplete attributes | Inspect login form | autocomplete="username", "current-password" set correctly | P2 |
+
+---
+
+## Module 6: Edge Cases & Stress Scenarios
+
+| ID | Test Case | Steps | Expected Result | Priority |
+|----|-----------|-------|-----------------|----------|
+| U-EDGE-001 | Unicode username | Register with `用户名` as username | Handled correctly or validation error | P1 |
+| U-EDGE-002 | Email with + addressing | Register with `user+tag@example.com` | Accepted and handled correctly | P1 |
+| U-EDGE-003 | Very long password | Enter 1000-char password | Accepted or validation error with message | P2 |
+| U-EDGE-004 | Special characters in password | Enter `P@$$w0rd!#%^&*()` | Password accepted | P1 |
+| U-EDGE-005 | Browser back after logout | Logout, press browser Back | Redirect to login (no cached authenticated page) | P1 |
+| U-EDGE-006 | Direct URL to OAuth callback | Navigate to `/callback` directly | Error: "No authorization code received" | P1 |
+| U-EDGE-007 | Double-click submit | Rapidly double-click Sign In | Only one request sent (button disabled) | P2 |
+| U-EDGE-008 | Slow network | Login on slow 3G connection | Loading state shown, eventually completes or times out | P2 |
+| U-EDGE-009 | WebAuthn in HTTP context | Access via HTTP (not HTTPS) | WebAuthn gracefully unavailable | P1 |
+| U-EDGE-010 | Multiple MFA setup attempts | Click Setup MFA multiple times | Only one setup flow active at a time | P2 |

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/versioning-and-release.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/versioning-and-release.md
@@ -1,0 +1,299 @@
+# Versioning & Release Policy
+
+Fulla 的版本号方案、bump 判定规则、发布节奏、预发布与补丁通道，以及
+版本发布的标准操作流程（SOP）。
+
+本文档是版本治理（governance）的单一出处。**版本工程的"怎么做"（CI 流水
+线、签名、SBOM）由 [`.github/workflows/release.yml`](https://github.com/voidvec/fulla/blob/master/.github/workflows/release.yml)
+实现；本文回答的是"何时发版、bump 什么、为什么"。** 二者冲突时，以本文为
+准并修流水线。
+
+> 相关文档：
+> - [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2 声明了 ABI / 源码级
+>   SemVer 承诺与弃用流程，本文是其版本治理侧的展开。
+> - [CI/CD Guide](../contribute/ci-cd-guide) 描述 release 流水线在整体 CI 中的位置。
+
+---
+
+## 1. 版本号方案
+
+### 1.1 SemVer 2.0.0
+
+Fulla 遵循 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)：
+
+```
+MAJOR.MINOR.PATCH[-prerelease]
+   1  .  0 .  0  -rc.1
+```
+
+| 段 | bump 依据（简述，详见 §2 决策表） | 兼容性承诺 |
+|---|---|---|
+| **MAJOR** | 破坏性变更（breaking change） | 无 —— 用户需改代码 |
+| **MINOR** | 新增功能、向后兼容 | 源码兼容 |
+| **PATCH** | 向后兼容的缺陷修复 | 源码兼容 |
+| **prerelease** | `-alpha.N` / `-beta.N` / `-rc.N` | 无承诺 |
+
+> v1.x 的"源码兼容"边界由 [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2
+> 明确：仅覆盖 `libs/*/include/fulla/**` 公共头的**源码级 API**，不承诺
+> 二进制 ABI。
+
+### 1.2 版本号单一来源（SSoT）
+
+| 组件 | 版本来源 | 同步校验 |
+|---|---|---|
+| C++ 库 + server | [`cmake/Version.cmake`](https://github.com/voidvec/fulla/blob/master/cmake/Version.cmake) 的 `MAJOR/MINOR/PATCH` | ✅ `tools/api-diff/api_diff.py` 交叉校验 `Version.cmake` / `CMakeLists.txt project(VERSION)` / `conanfile.py version` |
+| Docker 镜像 | 由 `release.yml` 从 `Version.cmake` 读取 | GHCR tag = `<version>` |
+| DB schema | `apps/server/migrations/V0NN_*.sql` 编号 | **不耦合产品版本**（见 §6） |
+
+**任何版本发布的第一步都是改 `cmake/Version.cmake`**；三处版本号漂移会被
+`api-diff` 在 `release.yml` 的 `version-check` job 拦截。
+
+---
+
+## 2. 版本号 bump 决策表
+
+一个改动到底触发 MAJOR / MINOR / PATCH bump？按下表判定。**当多行命中时，
+取最高级别（MAJOR > MINOR > PATCH）。**
+
+| 改动类型 | → MAJOR | → MINOR | → PATCH |
+|---|:---:|:---:|:---:|
+| SDK 公共头**删除 / 重命名 / 签名变更 / 默认实参变更**（api-diff 判为 BREAKING） | ✅ | | |
+| 公共 API **行为语义变更**（返回值含义、错误码、副作用、协议字段语义） | ✅ | | |
+| 最低 C++ 标准 / 编译器版本提升 | ✅ | | |
+| Drogon / Postgres / Redis **大版本**依赖升级 | ✅ | | |
+| 配置项**删除**或**改默认值且旧行为无法兼容** | ✅ | | |
+| DB schema 的**破坏性 migration**（删列 / 改类型无回填 / 重命名） | ✅ | | |
+| 新增 SDK API / 新 OAuth2 端点 / 新 OIDC claim | | ✅ | |
+| 已有 API 的**新增可选参数 / 字段**（带默认值） | | ✅ | |
+| 新增可选配置项（旧配置仍可工作） | | ✅ | |
+| 新增可选依赖 | | ✅ | |
+| 性能优化（不改公共 API） | | ✅ | |
+| `feat:` conventional commit（无 `!`） | | ✅ | |
+| `fix:` conventional commit —— API 行为回归到"正确" | | | ✅ |
+| 安全漏洞修复（CVE 类，不改 API） | | | ✅ |
+| 文档 / 测试 / CI 修复（若决定发版） | | | ✅ |
+| 纯 `docs: / test: / chore: / build: / ci:` 提交 | | | 不发版 |
+
+### Conventional Commits → bump 自动映射
+
+提交前缀与 bump 的默认映射（`!` 后缀或 `BREAKING CHANGE:` footer 强制升
+MAJOR）：
+
+```
+feat:     → MINOR      feat!:    → MAJOR
+fix:      → PATCH      fix!:     → MAJOR
+perf:     → PATCH      perf!:    → MAJOR
+refactor: → 不发版（除非 !）
+docs/test/chore/build/ci: → 不发版
+```
+
+scope 不改变默认映射，但 maintainer 可按 scope 上调（见 §3）。`cliff.toml`
+的 commit parser 已与上表对齐。
+
+---
+
+## 3. 安全 hardening 的"灰色地带"——显式取舍声明
+
+OAuth/OIDC 合规审计产生的一类改动特殊：它们**收紧了原本宽松的行为**（例：
+强制 redirect_uri https、强制 PKCE、CONFIDENTIAL 客户端 refresh grant 强制
+client_secret）。这类改动：
+
+- **严格 SemVer 视角**：是 breaking（依赖旧宽松行为的下游会断）。
+- **行业惯例**：多在 MINOR bump 内推进，Release Notes 显著标注。
+
+**Fulla 的取舍：**
+
+> 安全 hardening 在 **MINOR** 内推进，**不强制 MAJOR**。理由：本项目此前的
+> "宽松行为"本身就是 spec 违规（bug），修复是回归正确，不是产品语义的有意
+> 改变。但每次此类改动**必须**在 Release Notes 的 **⚠️ Breaking (security
+> hardening)** 小节显式列出，并给出迁移指引。
+
+这是**显式权衡**，不是含糊处理。若某次 hardening 的影响面经评估确实广泛
+（例：移除整个 grant type），仍应走 MAJOR + pre-release 通道（见 §5）。
+
+---
+
+## 4. 发布节奏（cadence）
+
+采用**混合模式**：周期性 MINOR + 按需 PATCH + 紧急安全 hotfix。
+
+| 事件 | 触发条件 |
+|---|---|
+| **计划性 MINOR**（新功能） | 每 **4–6 周** 一次；或累计 ≥ 3 个 `feat:` commit 时 |
+| **PATCH**（bug fix） | 累计 ≥ 5 个 `fix:` commit；或有用户报告的 bug 已修复 |
+| **紧急安全 PATCH** | P0 / CVE 漏洞修复后**立即**（不等 cadence） |
+| **MAJOR** | 有 breaking change 累积时；必须走 pre-release 通道（§5） |
+
+节奏是**指引不是教条**：无值得发版的改动时跳过一个周期完全正常；反之 P0
+安全修复永远立即发版。
+
+---
+
+## 5. Pre-release 通道
+
+正式 MAJOR 发布前走阶梯式预发布：
+
+```
+v2.0.0-alpha.1 → alpha.2 → … → v2.0.0-beta.1 → … → v2.0.0-rc.1 → … → v2.0.0
+```
+
+| 阶段 | 语义 | 接受的改动 |
+|---|---|---|
+| `alpha.N` | 功能可能不全，CI 不保证通过 | 任何（含新功能、行为调整） |
+| `beta.N` | 功能冻结，征集反馈 | bug fix + 反馈驱动的非破坏调整 |
+| `rc.N` | 发布候选 | **仅** P0/P1 bug fix |
+| （去后缀） | 正式版 | 不接受新改动 |
+
+**镜像 tag 规则**：
+- 正式版 → 打 `<version>` **和** `latest`
+- pre-release → **只打** `<version>`（如 `v2.0.0-rc.1`），**不打** `latest`
+
+> **当前流水线状态**：`release.yml` 的 tag 触发模式 `v[0-9]+.[0-9]+.[0-9]+`
+> **不接受后缀**，故 pre-release tag 当前不会触发发版。启用 pre-release
+> 通道需扩展该正则以匹配 `v[0-9]+.[0-9]+.[0-9]+(-[a-z]+\.[0-9]+)?`，并在
+> `github-release` job 按 tag 是否含 `-` 决定是否标记 GitHub Release 为
+> "Pre-release" 且跳过 `latest` manifest 合并。这是本 policy 的**待实施
+> 改造项**（见 §11）。
+
+---
+
+## 6. DB Schema 版本与产品版本解耦
+
+Fulla 用编号式 migration（`V001_*` … `V0NN_*`），编号独立递增。
+
+- **新增 migration（加表 / 加列 / 加索引）** = 向后兼容 → 触发 **MINOR** 评估。
+- **破坏性 migration（删列 / 改类型无回填 / 重命名）** → 触发 **MAJOR** 评估。
+- Schema 版本表只记录 migration 应用历史，**不**映射到 `MAJOR.MINOR.PATCH`。
+
+---
+
+## 7. Release Branch 与 Patch Release
+
+当 v1.2.0 发布后，主线开发 v1.3.0。若 v1.2.0 发现 P0 漏洞：
+
+```
+master:  ──●──●──●──●──●──●──→  (开发 v1.3.0)
+               \
+release/1.2:    └──●(cherry-pick fix)──● tag v1.2.1
+```
+
+**约定**：
+- 分支命名：`release/<MAJOR>.<MINOR>`（如 `release/1.2`）。
+- 该分支**只接受 cherry-pick 的 bug fix**，不接受新功能。
+- 每个 patch release 打一个 `v<MAJOR>.<MINOR>.<PATCH>` tag，触发 `release.yml`。
+- **维护窗口**：仅维护**最新一个** release branch 的 patch。上一个 branch
+  在新 minor 发布后 EOL（不提供 LTS —— 见 §8）。
+
+---
+
+## 8. LTS（长期支持）
+
+**当前阶段不提供 LTS。** 仅维护最新 minor 的 patch release。当下游用户规模
+增长、升级成本显现时再评估是否引入 LTS（如 Node.js / Kubernetes 模式）。
+
+---
+
+## 9. `latest` tag 语义与生产部署
+
+- `:latest` 指向**最新正式版**（不含 pre-release）。
+- [`deploy/docker/docker-compose.prod.yml`](https://github.com/voidvec/fulla/blob/master/deploy/docker/docker-compose.prod.yml)
+  使用 `${FULLA_VERSION:-latest}`：部署便利的默认值。
+- ⚠️ **生产部署应显式 pin 到具体版本号**（`FULLA_VERSION=1.2.0`），
+  不要依赖 `latest` —— 它会在新版本发布时不可控地滚动。
+
+---
+
+## 10. 弃用流程（Deprecation）
+
+与 [SDK Runtime Contract](../sdk/sdk-runtime-contract.md) §2 一致：
+
+1. 在当次 MINOR 发布时，用 `[[deprecated("Use X instead; removed in vN.0")]]`
+   标注被弃用的 API。
+2. Release Notes 的 **Deprecated** 段记录该弃用 + 迁移指引。
+3. **至少保留一个 MINOR 周期**（建议两个）。
+4. 在下一个 MAJOR 删除。
+
+非 SDK 的弃用（配置项、端点参数）遵循同样的"标注 → 过渡 → 删除"流程，
+标注方式用 Release Notes + 配置加载时的 LOG_WARNING。
+
+---
+
+## 11. 版本发布标准操作流程（SOP）
+
+### 11.1 正式版 MINOR / PATCH（从 master）
+
+```sh
+# 1. 确认 master 绿（CI 全过）
+git checkout master && git pull
+
+# 2. 更新版本号 SSoT
+#    编辑 cmake/Version.cmake 的 MINOR 或 PATCH
+
+# 3. 校验 API 表面（关键步骤）
+python3 tools/api-diff/api_diff.py
+#   - additive drift（新增头/新增声明）→ MINOR 允许，ratify:
+#       python3 tools/api-diff/api_diff.py --update-baseline
+#   - breaking drift（删/改声明）→ 必须先确认 MAJOR 已 bump；
+#     若属"私有成员/include 重排"等不影响消费表面的改动，需 review 后:
+#       python3 tools/api-diff/api_diff.py --force --update-baseline
+
+# 4. 生成 CHANGELOG 草稿，再手工策展
+git cliff --unreleased --tag vX.Y.Z --prepend CHANGELOG.md
+#   手工编辑要点：
+#     - 归类到 Added / Fixed / Changed / Security / Deprecated / ⚠️ Breaking
+#     - 安全 hardening 进 ⚠️ Breaking (security hardening) 小节 + 迁移指引
+#     - 删除无信息量的条目
+
+# 5. 提交版本号 + baseline + CHANGELOG
+git add cmake/Version.cmake tools/api-diff/*.baseline CHANGELOG.md
+git commit -m "chore(release): vX.Y.Z"
+
+# 6. 打 tag 并推送 —— 触发 release.yml
+git tag vX.Y.Z
+git push origin master --tags
+```
+
+`release.yml` 自动完成：version-check → SDK tarball → 多架构镜像 → cosign
+签名 → SBOM → GitHub Release（含 git-cliff 生成的 notes + 验证指引）。
+
+### 11.2 紧急安全 PATCH（从 release branch）
+
+```sh
+# 1. 基于 release/<MAJOR>.<MINOR> 分支 cherry-pick fix commit
+git checkout release/1.2
+git cherry-pick <fix-commit-sha>
+
+# 2. 在该分支上 bump PATCH（步骤同 11.1 的 2–6，但操作对象是 release branch）
+```
+
+### 11.3 MAJOR（走 pre-release 通道）
+
+```sh
+# 1. 在 master（或专用候选分支）上累积 breaking 改动
+# 2. bump MAJOR，依次打 prerelease tag：
+git tag v2.0.0-alpha.1 && git push --tags   # → alpha 阶段
+# ... 反馈迭代 ...
+git tag v2.0.0-beta.1  && git push --tags   # → beta 阶段
+git tag v2.0.0-rc.1    && git push --tags   # → rc 阶段（仅修 P0/P1）
+# 3. rc 通过后去掉后缀即正式版：
+git tag v2.0.0         && git push --tags
+# 4. 正式版发布后创建 release/2.0 分支
+git checkout -b release/2.0 v2.0.0 && git push origin release/2.0
+```
+
+> ⚠️ §5 已述：pre-release tag 当前**不触发** `release.yml`。启用此通道前
+> 需先完成流水线改造（见 §12 待办）。
+
+---
+
+## 12. 待办（本 policy 与现状的差距）
+
+| # | 项 | 解决的问题 |
+|---|---|---|
+| **T1** | 写本文档（✅ 本文件） | 此前无成文 bump 规则 |
+| **T2** | 执行 v1.0.0 以来的首次正式发版（v1.0.1 或 v1.1.0） | 840 个 commit 堆积在 v1.0.0 后未释放 |
+| **T3** | 扩展 `release.yml` tag 触发模式 + `latest` 跳过逻辑，启用 pre-release 通道 | 当前 prerelease tag 不触发发版 |
+| **T4** | 在 prod 部署文档（`docker-deployment.md`）加 `latest` 警告交叉引用 | 默认 `latest` 对生产有滚动风险 |
+| **T5** | 定义 release branch 命名约定并在 README 加指针（首次实际需要时再立分支） | patch release 流程未实例化 |
+
+T1 是本文件；T2 是当务之急；T3–T5 可在对应场景首次出现时落地。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/documentation-governance.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/documentation-governance.md
@@ -1,0 +1,200 @@
+# 文档治理设计 v4 — 基于全文深读的内容裁决 · 双语 Docusaurus 站点
+
+> 状态：v4（2026-08-27）。v1 目录级分类 → v2 四路全文深读的内容级裁决（file:line 证据）
+> → v3 落地终稿（IA 三层模型、Phase A/B 完成、上站前质检）→ **v4：英文主站 +
+> zh-CN locale 双语切换**（docs/ 为英文正本，中文树在 website/i18n/zh-CN/），
+> Phase C 三篇深潜完成。
+> 原则：**入库是给别人看的（stranger 能据此完成一件事）；留在本地是给维护者和 agent 看的。**
+
+## 一、入库判据（不变）
+
+1. **可执行**：stranger 依此完成一件事（部署/集成/排查/贡献）；
+2. **可决策**：记录理解系统所必需的设计决策及理由（ADR）；
+3. **可信任**：对外承诺（安全策略、合规尽调、版本政策、测量报告与方法论）。
+
+## 二、逐篇内容裁决（136 文件 + 根部文档）
+
+### 2.1 docs/backend/（23 篇 md + swagger-ui 静态资源）
+
+| 文件 | 裁决 | 关键内容证据 |
+|---|---|---|
+| architecture-overview.md | **SITE-READY** | 章节事实全部与现状吻合；建议补 identity 包与缓存装饰器一笔 |
+| ci-cd-guide.md | **SITE-READY** | 与 8 个实际 workflow 核对无硬伤；补 clients-sdk/security 两条一句话 |
+| docker-deployment.md | **SITE-READY** | 与 compose 实测全吻合；池参数按 bench 结论（64）更新 |
+| sdk-integration-guide.md | **SITE-READY** | 仅 L8 `.kiro` 来源路径失效需修 |
+| sdk-runtime-contract.md | **SITE-READY** | 仅 L7 `.kiro` 路径失效需修 |
+| versioning-and-release.md | **SITE-READY** | 治理单一出处；L294 "840 commits" 待办被版本重置超越需改写 |
+| api-reference.md | **REWRITE** | L226 end_session"不验签"已被 #78 推翻（同文错误表却收录 4006，自相矛盾）；L254 Google 路由错；§6 教旧 openapi.json 工作流与治理门冲突 |
+| configuration-guide.md | **REWRITE** | L38 PG15→17；L69 缓存层写成 "future"（已上线且 config.json:152 有配置块）；L132 end_session 旧语义；L176 JWKS 路径错；环境变量表仅 5 个远不全 |
+| data-persistence.md | **REWRITE** | §3 与 §6 对 Redis 存储是否弃用自相矛盾（L96 vs L205）；schema 停在 V002（现 V026）；`fulla:cache:` 键空间缺席；吸收 data-consistency 后补延迟双删一节 |
+| observability.md | **REWRITE** | 缺 #80 缓存失效指标；`oauth2_*` vs `fulla_*` 指标命名口径未澄清；审计示例 2026-01 陈旧 |
+| oidc-guide.md | **REWRITE** | L21/34 JWKS 路由错（实为 `/.well-known/jwks.json`，照抄会拿不到密钥）；缺 end_session/backchannel 集成义务、auth_time/acr/amr、官方 SDK 通道 |
+| rbac-guide.md | **REWRITE** | L62 "roles 进 JWT 未来支持"已实现（TokenService.cc:334）；完全缺 scope 层（V023 双闸模型）；手工 SQL 授予过时（有 admin API） |
+| security-architecture.md | **REWRITE** | L36 secret 传输说法违反 F-017（默认 Basic 头）；威胁表未覆盖 PR#85 已修威胁（#78 伪造登出/#79 缓存竞态/#54 软删除绕过） |
+| testing-guide.md | **REWRITE** | L274 测试数 364+450（实为 501）；L86-119 四月快照；L195-263 四份"[DOC]（已归档）"悬空引用 |
+| data-consistency.md | **MERGE → data-persistence** | 窄而正确，但缺 #79 延迟双删这一最新一致性内容 |
+| docker-guide.md | **MERGE → docker-deployment** | 与后者六成重叠；L19 容器命名 `oauth2-{service}` 漏改；保留其独有：命名规范表/调试容器/full_test_docker 脚本 |
+| google-guide.md + wechat-guide.md | **MERGE → social-login.md** | 同构孪生篇；google L45 无按钮 vs L53 点按钮自相矛盾；以 GitHub 已接线为主线索 |
+| plugin-integration.md | **MERGE → sdk-integration-guide** | 后者 §3 的 quickstart 子集 |
+| security-hardening.md | **MERGE → security-architecture** | 限流数字与 config.prod.json 全面不符（3/2/5 vs 文档 5/5/10）；四月快照与悬空引用删除；须注明 Hodor 仅 prod 启用 |
+| database-encoding-guide.md | **LOCAL** | 单机 SQL_ASCII 排查记录；含危险的 pg catalog DELETE 建议 |
+| documentation-standards.md | **LOCAL** | 仓库目录元规则，随 CONTRIBUTING 走；本治理落地时改写 |
+| ddd-domain-model.md | **ARCHIVE** | 自称"未经评审提案"；现状映射诚实，是未来演进底稿非现状文档 |
+
+### 2.2 docs/ops/ + admin/ + frontend/ + performance-optimization/（16 篇）
+
+| 文件 | 裁决 | 关键证据 |
+|---|---|---|
+| ops/account-lockout.md | **SITE-READY** | 扎实；凭证口径需统一（见矛盾 #1） |
+| ops/postgresql-major-upgrade.md | **SITE-READY** | 最新且准确；修 L122 deploy 名；**补入 docs/README 索引（现在漏挂）** |
+| ops/deployment.md | **REWRITE（小）** | L571-583 initdb.d 手动迁移在 prod 不可执行（迁移已烘焙进镜像）；L783 Prometheus 直连与 loopback 绑定矛盾；性能调优节已正确同步最新结论 |
+| ops/deployment-windows-docker-desktop.md | **REWRITE** | 测试数 55/51 过期（实 59/52）；"80% 通过即成功"坏口径；6 处本机路径；admin123 凭证冲突 |
+| ops/verification-checklist.md | **REWRITE** | dev 容器表混入不存在的 nginx；`oauth2_migrations` 表名错（实 schema_migrations）；硬编码密码 WinDockerTest2024!；表数量门槛 >=7 过期；同文两个 admin 邮箱 |
+| ops/security-checklist.md | **MERGE → backend/security-hardening** | 整改结项备忘；L76-84 两条 filter-branch 命令复制粘贴事故 |
+| admin/e2e-testing-guide.md | **REWRITE（轻）** | L903 死链；附录"7 文件/53 用例"实为 16/174；§9 与 account-lockout 全篇重复 |
+| admin/test-cases.md | **SITE-READY** | 无硬伤，与实际 spec 对应健康 |
+| frontend/test-cases.md | **SITE-READY** | 无硬伤，覆盖当前功能面 |
+| performance-optimization/ 全部 7 篇 | **LOCAL** | prompt 是 AI 会话产物；wave 报告/仪器化/非代码方案/内存调查全是内部证据链（基线代际混乱，混排上站会呈现三个互相矛盾的 QPS 世界观）；面向用户的结论已正确抽取到 ops/deployment §性能调优；upstream-drogon-session-issue.md 是上游约束唯一记录，issue 发出后转链接再 ARCHIVE |
+
+### 2.3 docs/history/（60 篇）：ADR 矿
+
+**修正 v1 误判**：superpowers/specs/ 并非全部会话产物——其中 2 篇是真设计文档。
+
+- **ADR 转化清单（11 + 1 备选，按优先级）**——每篇已提炼决策陈述：
+  1. **产品 + 双 SDK 架构与依赖铁律**（sdk-refactor §2/§4.1/§5.2：Domain 禁 Drogon、oauth2/identity 互不依赖、端口下沉 common、arch-guard 强制）
+  2. **Drogon 自注册符号链接策略**（sdk-refactor §5.5/§5.7：显式 registerController 替代 whole-archive + 插件零改动方案 A）
+  3. **ErrorCatalog 单一权威与双通道错误**（error-code AD-1..6 + auth-flow-gap "不折叠原则"与 G7 防枚举例外）
+  4. **Opaque Access Token + 凭据哈希存储 + 迁移不可变**（production_hardening_spec §五；**注意**：决策表写 Argon2id 实际落地 PBKDF2-SHA256 310K，转 ADR 时必须修正）
+  5. **email 为主登录标识**（email-first §7 五项决策，V020 在库）
+  6. **异步回调生命周期模式**（并发审计四主线；CacheMap 线程安全语义结论）
+  7. **MFA 第二因子会话绑定**（mfa-fix：pending 绑定 + 防枚举同码，V022 在库）
+  8. **首方 SPA 登录凭证暴露面控制**（mfa_auth_code_pkce §6 修正版 + 现状 authService.ts：AJAX+PKCE 闭包、token 不落 localStorage、托管登录页方案搁置）
+  9. **ORM 生成模型豁免 + 迁移冻结**（repo-refactor §0/§1.2——已穿越两次重构验证）
+  10. **限流选型 Hodor**（superpowers/specs：令牌桶三级限流，config.prod 在用）
+  11. **集成测试平台分档**（http-integration-plan：DB-backed 测试限 Linux、进程内起 app、社交面不可达结论）
+  12. （备选）**客户端认证 PUBLIC/CONFIDENTIAL 分类**（client-secret spec）
+  另：productization/done/async-refactor-assessment 蒸馏"**为何 C++17 禁协程**"一页 ADR（贡献者必问）。
+- **ARCHIVE 保留 11 篇**（history/README + 各 bugfix/审计原始记录 + 6 篇 superseded 设计）；
+- **LOCAL 37 篇**（全部 tasks/requirements/plans 类 checkbox 文档与过程稿）；
+- **DELETE 1 篇**：PRD/frontend_design.md（是 frontend/oauth2_frontend_design.md 的严格子集+更早快照，已 diff 确认）。
+
+### 2.4 productization-evolution/ + branding/（25 篇）：两处对 v1 的硬修正
+
+- **LOCAL 21 篇**（含 content-strategy "去 AI 味+软文流程"——公开即自伤；progress-status 枚举未修复安全项 #71/#73——不进站放大；research 含未公开定价 $499/$5000）；
+- **例外一（SITE，benchmark 区）：in-progress/competitor-benchmark-design.md 必须保持入库**——README 徽章链的 COMPARISON.md 与双语 README、benchmarks/competitors/README 共**三处公开入口指向它**；内容为可公开方法论（三同原则/官方配置出处/诚实修订记录），环境披露（WSL2 8vCPU/16GB）是复现性必需且已在公开 README 中；出库即断三条公开链。迁移：为它脱离即将出库的目录单独安家（建议挪至 `docs/benchmark/`）；
+- **例外二（SITE，档案/信任区）：done/oauth-oidc-compliance-audit.md 保持入库**——31 项全部已修复的 RFC 合规尽调，CHANGELOG.md:453 公开引用；是评估者眼中的信任资产（加"2026-08-07 基线快照"标注）；
+- **branding/rename-impact-fulla.md → ARCHIVE 入库但先脱敏**：删除/泛化 §L9 本机路径与工作区细节（含完整磁盘路径、记忆库哈希、WSL 路径）；压缩 P0 "先占资产"步骤（暴露 fulla.dev/PyPI 占位意图）；CHANGELOG:40 引用其 §3，出库断链；
+- **branding/repo-professionalization-audit.md → ARCHIVE 入库**：AGENTS.md 公开引用其为入库标准；
+- **branding/rename-candidates.md → LOCAL（最高敏感级）**：暴露 fulla.dev 未注册状态 + 9 个备选名可用性清单 + 自贬评估——资产落袋前等于给抢注者递情报；
+- 卫生项：`.mimosa/` 会话 JSON 已混入 docs/productization-evolution/（未跟踪）→ .gitignore 增补 `.mimosa/`（已有？核实）。
+
+## 三、跨文档矛盾登记簿（Phase A 必修清单）
+
+深读发现的矛盾**必须在上站前修平**，否则站点会把矛盾双语放大：
+
+| # | 矛盾 | 定谳依据 |
+|---|---|---|
+| 1 | **admin 默认凭证三种口径**（'admin' vs admin123 vs admin/admin123+admin-console 双客户端） | 以 apps/server/seed/dev_admin_user.sql 实测定谳，全站统一 |
+| 2 | end_session "不验签"（api-reference L226、configuration-guide L132）vs 错误表收录 4006 | 代码已强制验签（#78）；两处正文改写 |
+| 3 | Redis 缓存层 "future"（configuration-guide L69）vs 已上线（architecture-overview L12 还指错章节） | config.json cache 块为准；configuration-guide 补缓存配置节 |
+| 4 | CHANGELOG 宣称指标全改 `fulla_*` vs 代码实发 `oauth2_*`（authforge_* 前缀的已改） | **已在本 PR 修正 CHANGELOG 措辞** |
+| 5 | JWKS 路径三个版本（/oauth2/jwks、/oauth2/.well-known/jwks.json、/.well-known/jwks.json） | DiscoveryController.cc:60 定谳 |
+| 6 | PG 版本 15 vs 17（configuration-guide L38） | 17 |
+| 7 | Google 路由 /google/login vs /api/google/login | Controller 定谳 |
+| 8 | rbac-guide 单闸角色模型 vs api-reference 双闸（role+scope）vs "JWT roles 未来支持" | 现状=双闸+roles 已签发 |
+| 9 | 测试数量 364+450 vs 501；e2e "7 文件/53 用例" vs 16/174 | 脚本与 spec 实测 |
+| 10 | verification-checklist 的 oauth2-nginx(dev)/oauth2_migrations/WinDockerTest2024!/表名无前缀 | compose/V001/实配置定谳 |
+| 11 | docs/README.md 索引摘要 "session unbounded leak ~730B" vs 调查报告 v2 已撤回（TTL 有界 750B） | 后者定谳；README 重写时消化 |
+| 12 | 两个限流器（Hodor 全局 vs F-018 失败计数）从未说明并存关系与启用条件 | 重写时合并讲清 |
+
+## 四、Docusaurus 内容源（核心决策不变，素材清单更新）
+
+**站源 = docs/ 本体，零拷贝。** 站点七区与现状素材的映射（"现成"=SITE-READY，"重写后"=REWRITE/MERGE 完成）：
+
+| 站区 | 内容源 | 状态 |
+|---|---|---|
+| intro | README 能力地图复用 + Quick Start（README Path A/B） | 现成 |
+| architecture | architecture-overview + security-architecture（重写后）+ 模块地图 | 1 现成 1 重写 |
+| domains | social-login（合并后）、oidc-guide（重写后）、rbac/access-control（重写后）、token-lifecycle（**新写**：吸收 data-persistence 一节+refresh family）、session-management（**新写**：吸收 drogon#278 结论）、multi-tenancy（**新写**） | 3 重写 + 3 新写 |
+| sdk | sdk-integration-guide（吸收 plugin-integration）+ sdk-runtime-contract + 官方 Python/Go 说明（client-sdk 设计的"auth 手写"理由 200 字） | 基本现成 |
+| operate | deployment（小修）、docker-deployment（吸收 docker-guide）、configuration-guide（重写后）、observability（重写后）、account-lockout、postgresql-major-upgrade、verification-checklist（重写后）、testing/e2e/ci-cd/versioning（contribute 区亦可） | 4 现成 4 重写 |
+| benchmark | COMPARISON.md + **competitor-benchmark-design.md（新家 docs/benchmark/）** + benchmarks/README | 现成 |
+| adr | **12 篇新转化 ADR** + ddd-domain-model（标注提案）+ 合规尽调报告（信任档案）+ rename-impact（脱敏后）+ professionalization-audit | 新建 |
+| API | openapi.yaml 直渲染（swagger-ui 静态资源不上站，属服务器托管物） | 插件 |
+
+双语（v4 修订）：**英文为主站语言**（fulla.dev 默认 locale = en，`/` 服务英文，
+`/zh-CN` 服务中文，导航栏语言切换）。`docs/` 是**英文正本**（单一事实源）；
+中文树镜像于 `website/i18n/zh-CN/docusaurus-plugin-content-docs/current/`（同构
+目录、同 URL）。**翻译纪律**：改动 docs/ 英文文档的 PR 必须同步改中文对应文件
+（同 PR 双写）；三份历史档案（合规尽调/改名影响/仓库审计）双语均为中文正文 +
+英文语言说明头。GitHub 门面 README.md 为英文、README.zh-CN.md 为中文并链接
+fulla.dev/zh-CN。
+
+### 四·A、终稿信息架构（2026-08-26 定稿）
+
+内容资产分**三层**，各层有明确边界与进入判据：
+
+**第 1 层：`docs/`（英文正本，入库 + 上站）+ `website/i18n/zh-CN/`（中文译本）**
+—— 站点内容源（Docusaurus 默认 locale 读 `../docs`，zh-CN locale 读 i18n 树，同构零漂移）。
+只收"stranger 可据此完成一件事 / 理解一个决策 / 建立一份信任"的用户向内容：
+
+```
+docs/（英文）与 website/i18n/zh-CN/.../current/（中文）同构：
+├── intro.md                     # 站点入口（快速路由表）
+├── README.md                    # GitHub 侧索引（Docusaurus exclude，不上站）
+├── documentation-governance.md  # 本文档（治理规则，贡献者区引用）
+├── architecture/   # 评估+深潜：architecture-overview / security-architecture / data-persistence
+├── domains/        # 领域指南：api-reference / oidc-guide / rbac-guide / social-login /
+│                  #          token-lifecycle / session-management / multi-tenancy（Phase C 新增）
+├── sdk/            # C++ SDK：sdk-integration-guide / sdk-runtime-contract
+├── operate/        # 运维：deployment / docker-deployment / deployment-windows-docker-desktop /
+│                  #        configuration-guide / observability / account-lockout /
+│                  #        postgresql-major-upgrade / verification-checklist
+├── contribute/     # 贡献：testing-guide / ci-cd-guide / versioning-and-release /
+│                  #        admin-test-cases / user-frontend-test-cases / admin-e2e-testing-guide
+├── benchmark/      # 竞品基准方法论（competitor-benchmark-design；结果表在仓库 benchmarks/）
+└── adr/            # ADR-0001..0012 + 三份历史档案（中文正文 + 双语说明头）
+```
+
+**第 2 层：仓库内非 docs 资产（入库、不上站）** —— 站内以绝对链接引用，不复制：
+
+| 资产 | 角色 |
+|---|---|
+| `README.md` / `README.zh-CN.md` | GitHub 门面（能力地图、Quick Start、徽章） |
+| `benchmarks/competitors/results/COMPARISON.md` | 基准结果表（评估区链接） |
+| `apps/server/openapi.yaml` | API 契约 SSoT（api-reference 导读指向它） |
+| `.claude/rules/`、`TECH_SPECS.md`、`AGENTS.md` | 维护者契约（贡献者区可链接，不入站内容） |
+
+**第 3 层：`docs-local/`（不入库，磁盘保留）** —— 维护者与 agent 的过程档案（history、
+productization-evolution、branding、performance-optimization、performance 报告等）。
+gitignore；判据：不满足第一层三判据（可执行/可决策/可信任）中任何一条的过程性文档。
+
+**wiki 分工**：GitHub wiki 是自动生成的中文快照镜像（repowiki 转换），不做双向同步；
+其 Home 指向 fulla.dev 为权威内容源（中文读者直达 /zh-CN）。站点与 wiki 内容重叠时以 `docs/` 为准。
+
+**边界速判**：新文档先问"stranger 需要它吗？"——需要 → `docs/` 对应分区；只有维护者/
+agent 需要 → `docs-local/`；是结果数据而非文档 → 仓库数据目录（如 `benchmarks/`）；
+是对外承诺 → `docs/` + 版本化（CHANGELOG 引用）。
+
+## 五、执行 Phase（v3 进度标注）
+
+- **Phase A（内容修复与重组）——已完成**（8783c8e5 + 6049e3d3 + 7e5cd55a + d33d1ec3 + 45ca1f30）：
+  A1 修矛盾登记簿 12 项 ✓（上站前三区复审补漏：verification-checklist/deployment-windows 残留口径二次清扫 ✓）；
+  A2 六组 MERGE 落地 ✓；A3 ADR 转化 12 篇 ✓（status/source/双标题规范统一 ✓）；
+  A4 出库 LOCAL 类 ✓（2 例外迁新家 ✓；**补执行缺口**：合规尽调报告/rename-impact（脱敏版）/
+  professionalization-audit 三份档案此前误落 docs-local，现已入 docs/adr/ 并修复 CHANGELOG 两处断链 ✓）；
+  A5 docs/README.md 重写 ✓。
+  新增收尾：语言统一（全站简体中文，architecture-overview/configuration-guide 中文化 ✓）。
+- **Phase B（站骨架）——已完成**（8a7e3b96）：website/ + 受众分区 sidebar + Pages 部署 + 死链守门。
+  收尾项：GitHub Pages 源切换为 GitHub Actions（用户网页操作）+ 首页/主题专业化（本 PR）。
+- **Phase C（内容补齐 + 双语化）——已完成**（docs/phase-c-i18n 分支）：
+  三篇新写深潜（token-lifecycle / session-management / multi-tenancy）双语言落地 ✓；
+  api-reference §6 已改为 OpenAPI 治理流程、正文统一简体（Phase A 收尾）✓；
+  **英文主站 i18n**：docs/ 转为英文正本（~40 篇全量翻译），中文树迁至
+  website/i18n/zh-CN/，导航栏语言切换，editUrlLocalized 双语言编辑链 ✓；
+  deployment 会话节去重（尺寸表单一出处 = session-management）✓。
+  持续义务：同 PR 双写（en 改动 ⇒ zh 同步）。
+
+## 六、验收标准（不变，略增）
+
+v1 四条全部保留，另加：⑤ 矛盾登记簿 12 项全部关闭；⑥ CHANGELOG 引用的文档链接零断链（合规报告、rename-impact §3）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/api-reference.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/api-reference.md
@@ -1,0 +1,404 @@
+# OAuth2 API 接口文档
+
+> **完整 API 规范**: 手工维护的 OpenAPI 源文件为 [`apps/server/openapi.yaml`](https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml)（**唯一契约源**，CI 通过 `openapi-spec-validator` + 治理门校验三层一致性与版本同步）；Swagger UI（`/docs/api`）在线浏览的是运行时由 Controller 代码生成的 `apps/server/docs/api/openapi.json`（派生产物）。
+
+本服务提供基于 OAuth2.0 标准（RFC 6749）的认证授权服务。
+
+## 端点分类概览 (Endpoint Categories)
+
+| 分类 | 描述 | 前缀 |
+|------|------|------|
+| **Password Reset** | 密码重置请求与确认（基于邮件验证码） | `/api/password-reset` |
+| **Email Verification** | 邮箱验证发送与确认 | `/api/email/verify` |
+| **MFA (Multi-Factor Auth)** | TOTP 设置、验证、恢复码管理 | `/api/me/mfa`（登录补全为 `/oauth2/mfa/verify`） |
+| **Admin API** | 用户管理、客户端管理、审计日志（需 admin 角色） | `/api/admin` |
+| **User Self-Service** | 用户个人资料更新、密码修改、会话管理 | `/api/user` |
+| **OIDC Discovery** | OpenID Connect 发现端点与 JWKS | `/.well-known/openid-configuration`, `/oauth2/jwks` |
+
+---
+
+## 1. 授权端点 (Authorization Endpoint)
+
+用于请求用户授权，获取 Authorization Code。
+
+- **URL**: `/oauth2/authorize`
+- **Method**: `GET`
+- **Access**: 公开 (需登录)
+
+### 请求参数 (Query Parameters)
+
+| 参数名 | 必选 | 描述 | 示例 |
+|---|---|---|---|
+| `response_type` | 是 | 必须为 `code` | `code` |
+| `client_id` | 是 | 客户端 ID | `vue-client` |
+| `redirect_uri` | 是 | 回调地址 (需完全匹配) | `http://localhost:5173/callback` |
+| `scope` | 否 | 申请的权限范围 | `openid profile` |
+| `state` | 建议 | 防止 CSRF 的随机串 | `xyz123` |
+| `code_challenge` | 否 | PKCE code challenge（PUBLIC 客户端默认强制） | `dBjftJeZ4CVK...` |
+| `code_challenge_method` | 否 | `plain` 或 `S256`（提供 challenge 时默认 `plain`） | `S256` |
+| `nonce` | 否 | OIDC nonce（防重放），openid scope 时回显到 id_token | `n-0S6_WzA2Mj` |
+| `prompt` | 否 | OIDC 提示值，空格分隔：`none`/`login`/`consent`/`select_account`（§3.1.2.1）。`none` 禁止 UI；`login` 强制重认证；`consent` 强制同意页。`none` 与其他值并用 → 400 | `none` |
+| `max_age` | 否 | 认证最大允許年齡（秒）。session auth_time 超齡 → 強制重认证 | `3600` |
+
+### 响应
+
+**成功响应**：
+重定向至 `redirect_uri`，并附带 `code` 和 `state`。
+
+```http
+HTTP/1.1 302 Found
+Location: http://localhost:5173/callback?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz123
+```
+
+**错误响应**：
+直接返回 JSON 错误或重定向带 error 参数。
+
+```json
+{
+  "error": "invalid_client",
+  "error_description": "Unknown client_id"
+}
+```
+
+---
+
+## 2. 令牌端点 (Token Endpoint)
+
+用于使用 Authorization Code 换取 Access Token。
+
+- **URL**: `/oauth2/token`
+- **Method**: `POST`
+- **Access**: 公开 (需 Client 认证)
+- **Content-Type**: `application/x-www-form-urlencoded`
+
+### 请求参数 (Form Data)
+
+| 参数名 | 必选 | 描述 | 示例 |
+|---|---|---|---|
+| `grant_type` | 是 | 必须为 `authorization_code` | `authorization_code` |
+| `code` | 是 | 上一步获取的 code | `SplxlOBeZQQYbYS6WxSbIA` |
+| `redirect_uri` | 是 | 必须与获取 code 时一致 | `http://localhost:5173/callback` |
+| `client_id` | 是 | 客户端 ID | `vue-client` |
+| `client_secret` | 是 | 客户端密钥 (用于验证) | `vue-secret` |
+
+### 响应
+
+**成功 (200 OK)**:
+
+```json
+{
+  "access_token": "2YotnFZFEjr1zCsicMWpAA",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+  "scope": "openid profile"
+}
+```
+
+**响应头（F-019，RFC 6749 §5.1 / RFC 7009 §2.2.1）**：所有 token / introspect /
+revoke 成功响应都带 `Cache-Control: no-store` 与 `Pragma: no-cache`，禁止中间
+代理缓存含憑证的响应体。
+
+*(注：`grant_type=refresh_token` 需先通过客户端认证（F-003/F-017，RFC 6749 §3.2.1/§6）：认证方式必须匹配客户端注册的 `token_endpoint_auth_method`——`client_secret_basic`（默认）仅接受 HTTP Basic（body 携带 `client_secret` 会被拒）；`client_secret_post` 仅接受表单字段；PUBLIC 客户端仅发 `client_id`（携带 secret 会被拒）。缺失或错误返回 401 `invalid_client`。refresh token 持久化仅 Postgres 后端支持；`storage_type="redis"` 已弃用，该模式下 refresh grant 返回 `unsupported_grant_type`（F-005）。)*
+
+**失败 (400/401)**:
+
+```json
+{
+  "error": "invalid_grant",
+  "error_description": "Authorization code has expired"
+}
+```
+
+**失败 (429 Too Many Requests)** — F-018 限流：`/oauth2/token`、
+`/oauth2/introspect`、`/oauth2/revoke` 与 device_code 轮询共享一個进程内滑动窗口
+限流器，按 `(client_ip, client_id)` 分桶。窗口内（默认 60s）**失败**計数達閾值
+（默认 30，可經 `custom_config["auth"]["rate_limit"]` 配置 `max_failures` /
+`window_seconds`）后，后续請求返回 429。仅計失败（认证/校验失败），成功清零。
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 42
+Content-Type: application/json
+
+{
+  "error": "invalid_request",
+  "error_description": "Too many failed attempts; please retry later"
+}
+```
+
+---
+
+## 3. 用户信息端点 (UserInfo Endpoint)
+
+用于验证 Access Token 并获取用户信息。
+
+- **URL**: `/oauth2/userinfo`
+- **Method**: `GET`
+- **Access**: 受保护 (Bearer Token)
+
+### 请求头 (Headers)
+
+Authorization: `Bearer {access_token}`
+
+### 响应
+
+**成功 (200 OK)**:
+
+```json
+{
+  "sub": "admin",
+  "name": "admin",
+  "email": "admin@example.com",
+  "email_verified": true,
+  "picture": "..."
+}
+```
+
+**失败 (401 Unauthorized)**:
+
+```json
+{
+  "error": "invalid_token"
+}
+```
+
+**失败 (403 Forbidden)** — F-023：access token scope 不含 `openid`，或为 M2M
+token（subject `client:*`）。响应附带
+`WWW-Authenticate: Bearer error="insufficient_scope"`：
+
+```json
+{
+  "error": "insufficient_scope",
+  "error_description": "The access token does not have the openid scope required for userinfo"
+}
+```
+
+### 3.x 路徑→required-scope 映射（F-010 最小资源-scope 模型）
+
+`OAuth2AuthFilter` / `AuthorizationFilter` 在 access token 校验通过后，按請求
+路徑強制最小 required-scope（RFC 6750 §3.1）。token scope 不足时返回 403，
+响应附带 `WWW-Authenticate: Bearer realm="fulla", error="insufficient_scope",
+scope="<required>"`，其中 `scope` 屬性命名解锁该资源所需的 scope。
+
+| 路徑 | Required Scope | 備注 |
+|---|---|---|
+| `/oauth2/userinfo` | `openid` | 与 userinfo handler 内的 F-023 检查并存（defense-in-depth） |
+| `/api/me`、`/api/me/*` | `profile` | 經 `OAuth2AuthFilter` |
+| `/api/admin/*` | `admin` | 經 `AuthorizationFilter`，**疊加在既有 RBAC 角色检查之上**（scope 閘門先跑，角色閘門后跑，两者都須通过） |
+
+> **完整资源-scope 授權模型为后续工作**（独立 issue「完整资源-scope 授權模型」）。
+> 當前仅上述最小映射；其餘 `/api/*` 路徑仍仅由既有 RBAC 规則（`rbac_rules`）
+> 把关，不额外要求特定 scope。Scope 匹配为空格分隔 token 的精确匹配
+> （`fulla::drogon::utils::hasScope()`），避免 `openidprofile` 误过
+> `openid`/`profile`。
+
+### 3.y 客户端管理（F-030：admin-only，无 RFC 7592 自管理）
+
+客户端注册与管理**仅**經 admin API `/api/admin/clients/*`（需 admin scope +
+admin 角色）。本服務**不**实作 RFC 7592 動態客户端管理的
+`registration_access_token` 自管理端点 —— 客户端无法自助查看/修改自身注册
+信息。需要變更的客户端須联繫管理員經 admin API 处理。
+
+### 3.z nonce 重放防護（F-026：客户端責任）
+
+OIDC Core §15.5.2 规定 nonce 重放检查为**客户端 MUST**：服務端在 id_token 中
+**回顯**（echo）客户端提交的 nonce，但**不**为其存储或做服務端重放检查。客户端
+必須（1）为每次认证請求生成唯一的 nonce，（2）在收到 id_token 后比对回顯值与
+本地 nonce，并（3）拒絕重複或缺失 nonce 的 id_token。本服務遵循此分工，不
+提供服務端 nonce 重放防護。
+
+---
+
+## 3.1 RP-Initiated Logout 端点 (End Session Endpoint)
+
+OIDC RP-Initiated Logout 1.0 §2 — 終止用户的 server-side session，并（可選）重
+定向到客户端注册的 `post_logout_redirect_uri`。
+
+- **URL**: `/oauth2/end_session`
+- **Method**: `GET`（鏈接式）或 `POST`（表單式）
+- **Access**: 公开（不需 Bearer token）
+
+### 請求參数 (Query/Form)
+
+| 參数名 | 必選 | 描述 |
+|---|---|---|
+| `id_token_hint` | 否* | 此前签发的 id_token，其 `aud` 声明标识客户端用于校验 `post_logout_redirect_uri`（签名强制校验：RS256 + kid 匹配 + iss/exp/sub 策略；验签失败返回 400 AUTH_INVALID_ID_TOKEN_HINT，错误码 4006）。*提供 `post_logout_redirect_uri` 时必需 |
+| `post_logout_redirect_uri` | 否 | 登出后重定向 URI，須为 `id_token_hint` 客户端注册的 redirect_uri，否則 400 |
+| `state` | 否 | 不透明值，原样回顯到重定向 URI |
+
+### 响应
+
+- **200 OK**：未提供 `post_logout_redirect_uri` 时，返回 `{ "message": "Logged out successfully" }`，session 已清除。
+- **302 Found**：提供并校验通过的 `post_logout_redirect_uri`（附 `state`）。
+- **400 Bad Request**：`post_logout_redirect_uri` 未注册 / 缺 `id_token_hint` 无法标识客户端 / `id_token_hint` 验签失败（过期、issuer 不符、签名无效，错误码 4006）。
+
+---
+
+## 4. 辅助接口 (Helper Endpoints)
+
+### 登录提交 (Internal)
+
+- **URL**: `/oauth2/login`
+- **Method**: `POST`
+- **Desc**: 内部使用的表单提交接口，用于 Session 登录并重定向。
+
+### WeChat 登录 (Optional)
+
+- **URL**: `/api/wechat/login`
+- **Method**: `POST`
+- **Desc**: 处理微信小程序/扫码登录（演示用途）。
+
+### Google 登录回调 (Optional)
+
+- **URL**: `/api/google/login`
+- **Method**: `POST`
+- **Desc**: 接收前端传来的 Google Authorization Code，服务端向 Google 换取 Access Token 并调用 UserInfo API，返回过滤后的用户信息（`sub`, `name`, `email`, `picture`）。
+- **请求参数**:
+  - `code` (required): Google 返回的授权码
+- **成功 (200 OK)**:
+  ```json
+  {"sub": "1234567890", "name": "John Doe", "email": "john@gmail.com", "picture": "..."}
+  ```
+- **失败 (400/502)**: code 无效或 Google API 不可达。
+
+### 用户注册
+
+- **URL**: `/api/register`
+- **Method**: `POST`
+- **Content-Type**: `application/x-www-form-urlencoded`
+- **限流**: 每IP每分钟最多 5 次，全局每分钟 5000 次（Hodor 插件）
+
+#### 请求参数 (Form Data)
+
+| 参数名 | 必选 | 描述 |
+|---|---|---|
+| `username` | 是 | 用户名 |
+| `password` | 是 | 密码（明文，服务端 SHA256+Salt 存储）|
+| `email` | 否 | 邮件地址 |
+
+#### 响应
+
+- **成功 (200 OK)**: `User Registered`
+- **失败 (400 Bad Request)**: 缺少用户名或密码
+- **失败 (500 Internal Server Error)**: 用户名已存在等
+
+### 管理员 Dashboard (RBAC Protected)
+
+- **URL**: `/api/admin/dashboard`
+- **Method**: `GET`
+- **Access**: 受保护，需 `admin` 角色（Header: `Authorization: Bearer <token>`）
+
+#### 响应
+
+- **成功 (200 OK)**:
+  ```json
+  {"message": "Welcome to Admin Dashboard", "status": "success"}
+  ```
+- **失败 (401)**: Token 无效或缺失
+- **失败 (403)**: 用户已登录但不具备 `admin` 角色
+
+---
+
+## 5. 通用错误码
+
+> **单一权威来源（single source of truth）**：本章节 5.1 与 5.2 的表格由后端 `ErrorCatalog`（`libs/common/include/fulla/common/error/ErrorCatalog.h`）的 `allEntries()` / `allOAuthEntries()` 生成并由自动化测试校验，请勿手工修改表格行。
+> 任一不一致（缺失/多余条目、HTTP 状态码或 Error_Category 不匹配）都会导致校验测试失败：`fulla-tests -r ErrorCatalogDoc`。
+
+### 5.1 应用错误码 (Application Error Codes)
+
+业务端点（Application_Endpoint）返回统一的 Error Envelope，其 `error.code` 取值属于下表登记的 Error_Code 集合；`numeric_code` 与 `category` 同样取自下表，HTTP 状态码按 Error_Category（NETWORK 类按 numeric_code 区分 502/504）一致映射。少数面向资源语义的 VALIDATION 码通过条目级显式覆盖保留迁移前的 HTTP 状态码（方案 A / 需求 11.4）：`VALIDATION_RESOURCE_NOT_FOUND` → 404，资源已存在/冲突类（`VALIDATION_RESOURCE_CONFLICT`、`VALIDATION_USERNAME_TAKEN`、`VALIDATION_EMAIL_TAKEN`、`VALIDATION_CREDENTIAL_ALREADY_REGISTERED`）→ 409，`VALIDATION_RATE_LIMITED` → 429；其余 VALIDATION 码仍为 400。
+
+| Error_Code | numeric_code | Error_Category | HTTP Status | 默认信息 (Client_Safe_Message) |
+|---|---|---|---|---|
+| `NET_CONNECTION_FAILED` | 1001 | NETWORK | 502 | 上游连接失败 |
+| `NET_TIMEOUT` | 1002 | NETWORK | 504 | 请求超时 |
+| `DB_CONNECTION_ERROR` | 2001 | DATABASE | 500 | 服务暂时不可用 |
+| `DB_QUERY_ERROR` | 2002 | DATABASE | 500 | 服务暂时不可用 |
+| `DB_CONSTRAINT_VIOLATION` | 2003 | DATABASE | 500 | 数据冲突 |
+| `VALIDATION_INVALID_INPUT` | 3001 | VALIDATION | 400 | 输入参数有误 |
+| `VALIDATION_MISSING_REQUIRED_FIELD` | 3002 | VALIDATION | 400 | 缺少必填字段 |
+| `VALIDATION_FORMAT_ERROR` | 3003 | VALIDATION | 400 | 格式不正确 |
+| `VALIDATION_RESOURCE_NOT_FOUND` | 3004 | VALIDATION | 404 | 资源不存在 |
+| `VALIDATION_RESOURCE_CONFLICT` | 3005 | VALIDATION | 409 | 资源已存在或冲突 |
+| `VALIDATION_USERNAME_TAKEN` | 3006 | VALIDATION | 409 | 该用户名已被注册 |
+| `VALIDATION_EMAIL_TAKEN` | 3007 | VALIDATION | 409 | 该邮箱已被注册 |
+| `VALIDATION_CREDENTIAL_ALREADY_REGISTERED` | 3008 | VALIDATION | 409 | 该安全密钥已注册，无需重复添加 |
+| `VALIDATION_RESET_TOKEN_INVALID` | 3009 | VALIDATION | 400 | 重置链接已失效，请重新申请 |
+| `VALIDATION_VERIFICATION_TOKEN_INVALID` | 3010 | VALIDATION | 400 | 验证链接已失效，请重新发送邮件 |
+| `VALIDATION_DEVICE_CODE_INVALID` | 3011 | VALIDATION | 400 | 设备码无效、已过期或已被处理 |
+| `VALIDATION_RATE_LIMITED` | 3012 | VALIDATION | 429 | 请求过于频繁，请稍后重试 |
+| `AUTH_INVALID_CREDENTIALS` | 4001 | AUTHENTICATION | 401 | 用户名或密码错误 |
+| `AUTH_TOKEN_EXPIRED` | 4002 | AUTHENTICATION | 401 | 登录已过期 |
+| `AUTH_TOKEN_INVALID` | 4003 | AUTHENTICATION | 401 | 登录凭证无效 |
+| `AUTH_MFA_CODE_INVALID` | 4004 | AUTHENTICATION | 401 | 验证码不正确 |
+| `AUTH_MFA_NOT_CONFIGURED` | 4005 | AUTHENTICATION | 401 | 尚未设置双重验证，请先完成设置 |
+| `AUTH_INVALID_ID_TOKEN_HINT` | 4006 | AUTHENTICATION | 400 | 登录令牌提示无效 |
+| `AUTHZ_ACCESS_DENIED` | 5001 | AUTHORIZATION | 403 | 没有访问权限 |
+| `AUTHZ_INSUFFICIENT_PERMISSIONS` | 5002 | AUTHORIZATION | 403 | 权限不足 |
+| `INTERNAL_ERROR` | 6001 | INTERNAL | 500 | 服务器内部错误 |
+
+### 5.2 OAuth2 协议错误码 (RFC 6749 §5.2 / RFC 7009 / RFC 8628)
+
+OAuth2 协议端点（OAuth2_Protocol_Endpoint）保持 RFC 6749 §5.2 错误体结构 `{ "error", "error_description", "error_uri" }`，其 `error` 取值与 HTTP 状态码取自下表。
+
+| error | HTTP Status | 默认 error_description |
+|---|---|---|
+| `invalid_request` | 400 | 请求参数缺失或无效 |
+| `invalid_client` | 401 | 客户端认证失败 |
+| `invalid_grant` | 400 | 授权许可无效或已过期 |
+| `unauthorized_client` | 400 | 客户端无权使用该授权类型 |
+| `unsupported_grant_type` | 400 | 不支持的授权类型 |
+| `invalid_scope` | 400 | 请求的 scope 无效 |
+| `server_error` | 500 | 服务器内部错误 |
+| `temporarily_unavailable` | 503 | 服务暂时不可用 |
+| `access_denied` | 403 | 授权请求被拒绝（用户无权或拒绝授权） |
+| `unsupported_token_type` | 400 | 不支持的令牌类型 |
+| `authorization_pending` | 400 | 授权尚未完成，请稍后重试 |
+| `slow_down` | 400 | 轮询过于频繁，请降低频率 |
+| `expired_token` | 400 | 设备码已过期，请重新发起授权 |
+
+### 5.3 HTTP 状态码速查
+
+| HTTP Status | 描述 | 原因示例 |
+|---|---|---|
+| `200` | OK | 请求成功 |
+| `302` | Found | 重定向 (如 OAuth2 授权跳转) |
+| `400` | Bad Request | 参数错误, `invalid_grant`, `unauthorized_client` |
+| `401` | Unauthorized | Token 无效或过期, `invalid_client` |
+| `403` | Forbidden | **RBAC 拦截**: 用户已登录但缺少所需角色, `access_denied` |
+| `429` | Too Many Requests | 触发限流 (Rate Limiting) |
+| `500` | Internal Server Error | 服务器内部错误 |
+
+---
+
+## 6. API 契约维护流程（OpenAPI 治理）
+
+HTTP API 契约的**单一事实源是 [`apps/server/openapi.yaml`](https://github.com/voidvec/fulla/blob/master/apps/server/openapi.yaml)**；本篇是它的导读与补全（含错误码表等 yaml 未承载的内容）。
+
+### 6.1 变更流程
+
+1. 修改端点行为时，同步修改 `apps/server/openapi.yaml`（新端点 / 参数 / 响应）。
+2. Controller 内经 `OpenApiGenerator::addEndpoint()` 登记的元数据保持一致（`fulla-tests -r OpenApiGenerator` 校验登记完整性）。
+3. Swagger UI（`http://localhost:5555/docs/api/`）由服务器托管，用于人工核对。
+
+### 6.2 破坏性变更门（CI）
+
+`OpenAPI Governance` workflow 在 PR 上运行 **oasdiff breaking** 门：对比 PR 与 master 的 `openapi.yaml`，任何破坏性变更（删路径、收紧请求体、收窄响应等）都会使 CI 失败，除非：
+
+- 变更伴随主版本号升级；或
+- 在 `tools/openapi-governance/oasdiff-breaking-ignore.md` 中显式豁免并写明理由。
+
+本地可复现同一命令（见 `.github/workflows/openapi-governance.yml` 头部注释）。
+
+### 6.3 质量标准
+
+*   **必需字段**：`path`, `method`, `summary`, `description`, `tags`, `responses`, `requiresAuth`。
+*   **推荐做法**：为每个响应码提供 `responseExamples`，并详细定义参数的 `type` 和 `location`。
+
+### 6.4 故障排查
+
+*   **Swagger UI 无法访问**：检查静态资源是否随服务器分发，确认静态文件服务已启用。
+*   **登记校验失败**：运行 `fulla-tests -r OpenApiGenerator` 单元测试，查看具体的注册错误。
+*   **治理门误报**：核对 `oasdiff breaking` 输出与豁免清单条目是否对应同一 path/operation。
+

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/multi-tenancy.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/multi-tenancy.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 7
+---
+
+# 多租户（Organizations）
+
+fulla 的多租户目前是一个**组织层**：组织归组用户与客户端、承载品牌字段、
+经管理 API 管理。本页如实记录现状有什么、**没有**什么、以及如何在不过度
+假设隔离的前提下使用它。
+
+> **先读这段**：组织是元数据与归属归组，不是硬隔离边界。授权由 RBAC +
+scope 强制（见 [RBAC 指南](rbac-guide.md)）；今天属于某组织的主体并不会
+自动与其他组织的数据隔离。
+
+## 1. 模型（V017）
+
+```sql
+organizations (
+    id              SERIAL PRIMARY KEY,
+    slug            VARCHAR(50) UNIQUE,   -- 3–50 字符，小写
+    name            VARCHAR(200),
+    logo_uri        VARCHAR(512),         -- 品牌
+    primary_color   VARCHAR(7),           -- 品牌
+    issuer_override VARCHAR(512),         -- 已存储；见 §4 路线图
+    created_at / updated_at
+)
+```
+
+两个可空外键把实体挂到组织上：
+
+| 列 | 所在表 | 语义 |
+|---|---|---|
+| `org_id` | `users` | 用户属于该组织；`NULL` = 未分配（向后兼容） |
+| `org_id` | `oauth2_clients` | 客户端由该组织拥有；`NULL` = 全局/无主 |
+
+两者按设计可空：V017 之前的数据与平台级主体（种子 `admin`、
+`admin-console` 客户端）没有组织。
+
+## 2. 管理 API 面
+
+所有路由要求 admin scope 令牌（`AuthorizationFilter`；`impliedBy: admin`）——
+[API 参考](api-reference.md)客户端管理一节：
+
+| 方法与路径 | 用途 |
+|---|---|
+| `GET /api/admin/organizations` | 列出组织（id、slug、name、品牌字段） |
+| `POST /api/admin/organizations` | 创建（slug：3–50 个小写字符，唯一） |
+| `GET /api/admin/organizations/{slug}` | 查询单个 |
+
+另：
+
+- `POST/PATCH /api/admin/users` 接受 `org_id`——整数分配用户到组织；
+  JSON `null` **清除**归属。
+
+示例：
+
+```bash
+# 创建组织（令牌：admin scope）
+curl -X POST http://localhost:5555/api/admin/organizations \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"slug":"acme","name":"ACME Corp","logo_uri":"https://acme.example/logo.svg","primary_color":"#5b2fd1"}'
+
+# 把用户挂到组织
+curl -X PATCH http://localhost:5555/api/admin/users/42 \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"org_id": 1}'
+```
+
+## 3. 现在能买到什么
+
+- **归属记账**：哪个人属于哪家公司、哪个客户端应用属于哪家公司——管理 API
+  与 SQL（`users.org_id`、`oauth2_clients.org_id`）均可查。
+- **品牌目录**：按组织存 logo 与主色，前端可按租户换肤登录体验。
+- **无迁移断崖**：一切都是可选、增量式的；不关心组织的部署完全不碰它。
+
+## 4. 还没有的（路线图）
+
+对利益相关方要说清楚——以下**未**实现：
+
+1. **`issuer_override` 已存储但未生效**：按组织的 issuer（进发现文档与签发
+   令牌）schema 就绪、运行时未接入。
+2. 用户/客户端列表**无按组织过滤/隔离**；admin 跨组织可见。
+3. **无组织级角色**：角色是全局的（RBAC），不按组织。
+4. 组织**无 update/delete** 端点（只有 create/list/get）。
+5. **无按组织的限流、配额、密钥**。
+
+如果今天就需要硬租户隔离：每租户跑一套 fulla 栈——Docker Compose / Helm
+路径让这很便宜（[部署](../operate/deployment.md)）。
+
+## 5. Schema 参考
+
+权威 DDL 是
+[`V017__multi_tenant.sql`](https://github.com/voidvec/fulla/blob/master/apps/server/migrations/V017__multi_tenant.sql)
+（`users(org_id)`、`oauth2_clients(org_id)`、`organizations(slug)` 上有索引）。
+存储层细节见[数据与持久化](../architecture/data-persistence.md)。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/oidc-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/oidc-guide.md
@@ -1,0 +1,188 @@
+# OpenID Connect (OIDC) 集成指南
+
+本指南介绍如何将本 OAuth2 服务作为 OIDC Provider 集成到你的应用中。
+
+## 1. Discovery 端点
+
+OIDC Discovery 端点提供 Provider 的所有配置信息：
+
+```
+GET /.well-known/openid-configuration
+```
+
+返回示例：
+
+```json
+{
+  "issuer": "https://your-domain.com",
+  "authorization_endpoint": "https://your-domain.com/oauth2/authorize",
+  "token_endpoint": "https://your-domain.com/oauth2/token",
+  "userinfo_endpoint": "https://your-domain.com/oauth2/userinfo",
+  "jwks_uri": "https://your-domain.com/.well-known/jwks.json",
+  "response_types_supported": ["code"],
+  "subject_types_supported": ["public"],
+  "id_token_signing_alg_values_supported": ["RS256"],
+  "scopes_supported": ["openid", "profile", "email"]
+}
+```
+
+## 2. JWKS 端点
+
+JSON Web Key Set 端点提供用于验证 `id_token` 签名的公钥：
+
+```
+GET /.well-known/jwks.json
+```
+
+返回示例：
+
+```json
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "alg": "RS256",
+      "kid": "default-key-id",
+      "n": "<base64url-encoded modulus>",
+      "e": "AQAB"
+    }
+  ]
+}
+```
+
+## 3. id_token 格式
+
+`id_token` 是一个 RS256 签名的 JWT，包含以下标准 claims：
+
+| Claim | 描述 | 示例 |
+|-------|------|------|
+| `iss` | 签发者 (Issuer) | `https://your-domain.com` |
+| `sub` | 用户唯一标识 (UUID public_sub) | `550e8400-e29b-41d4-a716-446655440000` |
+| `aud` | 受众 (Client ID) | `your-client-id` |
+| `exp` | 过期时间 (Unix timestamp) | `1700000000` |
+| `iat` | 签发时间 (Unix timestamp) | `1699996400` |
+| `nonce` | 请求中传入的 nonce 值 | `abc123` |
+
+根据请求的 scope，还可能包含：
+
+- **profile scope**: `name`, `preferred_username`
+- **email scope**: `email`, `email_verified`
+
+## 4. 验证 id_token
+
+### 4.1 验证步骤
+
+1. **解码 JWT Header**：提取 `kid`（Key ID）和 `alg`（应为 RS256）
+2. **获取公钥**：从 JWKS 端点获取对应 `kid` 的公钥
+3. **验证签名**：使用 RSA 公钥验证 JWT 签名
+4. **验证 Claims**：
+   - `iss` 必须匹配你配置的 Issuer URL
+   - `aud` 必须包含你的 Client ID
+   - `exp` 必须大于当前时间
+   - `nonce` 必须匹配你在授权请求中发送的值
+
+### 4.2 安全注意事项
+
+- **始终验证签名**，不要信任未验证的 JWT
+- **缓存 JWKS** 但设置合理的刷新间隔（建议 24 小时或按 Cache-Control 头）
+- **检查 `alg` 头**，拒绝 `none` 算法（防止算法降级攻击）
+
+## 5. 支持的 Scopes 与 Claims
+
+| Scope | 返回的 Claims |
+|-------|---------------|
+| `openid` | `sub` (必需 scope，启用 OIDC) |
+| `profile` | `name`, `preferred_username` |
+| `email` | `email`, `email_verified` |
+
+## 6. 集成示例
+
+### 6.1 使用标准 OIDC 客户端库 (Node.js)
+
+```javascript
+const { Issuer } = require('openid-client');
+
+// 自动发现 Provider 配置
+const issuer = await Issuer.discover('https://your-domain.com');
+
+const client = new issuer.Client({
+  client_id: 'your-client-id',
+  client_secret: 'your-client-secret',
+  redirect_uris: ['http://localhost:3000/callback'],
+  response_types: ['code'],
+});
+
+// 生成授权 URL
+const authUrl = client.authorizationUrl({
+  scope: 'openid profile email',
+  state: 'random-state-value',
+  nonce: 'random-nonce-value',
+});
+
+// 处理回调
+const params = client.callbackParams(req);
+const tokenSet = await client.callback('http://localhost:3000/callback', params, {
+  state: 'random-state-value',
+  nonce: 'random-nonce-value',
+});
+
+console.log('ID Token claims:', tokenSet.claims());
+console.log('Access Token:', tokenSet.access_token);
+```
+
+### 6.2 使用 Python (authlib)
+
+```python
+from authlib.integrations.requests_client import OAuth2Session
+
+client = OAuth2Session(
+    client_id='your-client-id',
+    client_secret='your-client-secret',
+    redirect_uri='http://localhost:8000/callback',
+    scope='openid profile email'
+)
+
+# 获取授权 URL
+uri, state = client.create_authorization_url(
+    'https://your-domain.com/oauth2/authorize'
+)
+
+# 处理回调，换取 Token
+token = client.fetch_token(
+    'https://your-domain.com/oauth2/token',
+    authorization_response=callback_url
+)
+
+# 获取用户信息
+userinfo = client.get('https://your-domain.com/oauth2/userinfo').json()
+```
+
+### 6.3 使用 Go (coreos/go-oidc)
+
+```go
+provider, err := oidc.NewProvider(ctx, "https://your-domain.com")
+
+oauth2Config := oauth2.Config{
+    ClientID:     "your-client-id",
+    ClientSecret: "your-client-secret",
+    RedirectURL:  "http://localhost:8080/callback",
+    Endpoint:     provider.Endpoint(),
+    Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+}
+
+// 验证 id_token
+verifier := provider.Verifier(&oidc.Config{ClientID: "your-client-id"})
+idToken, err := verifier.Verify(ctx, rawIDToken)
+```
+
+## 7. 常见问题
+
+**Q: id_token 的有效期是多久？**
+A: 与 Access Token 一致，默认 1 小时。
+
+**Q: 如何处理密钥轮转？**
+A: 定期从 JWKS 端点刷新公钥。当验证失败时，先尝试刷新 JWKS 再重试验证。
+
+**Q: 是否支持 PKCE？**
+A: 支持。PKCE (RFC 7636) 已实现并默认对 PUBLIC 客户端强制启用（同时支持 `plain` 与 `S256`）。SPA 和移动端客户端应使用 `S256`。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/rbac-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/rbac-guide.md
@@ -1,0 +1,82 @@
+# RBAC 权限控制系统 (Role-Based Access Control)
+
+本文档详细说明了系统的基于角色的访问控制 (RBAC) 设计与使用。
+
+## 1. 核心概念
+
+系统采用标准的 RBAC 模型：
+
+- **User (用户)**: 系统的操作主体。
+- **Role (角色)**: 权限的集合 (e.g., `admin`, `user`)。
+- **Permission (权限)**: 具体的访问能力 (e.g., `user:delete`, `sys:monitor`) - *注: 目前简化为基于角色的 URL 拦截*。
+
+### 关系模型
+
+- `User <-> Role`：多对多（Many-to-Many）
+- `Role <-> Permission`：多对多（Many-to-Many）
+
+## 2. 数据库设计
+
+相关表结构 (PostgreSQL):
+
+```sql
+-- 用户表
+CREATE TABLE users (...);
+
+-- 角色表
+CREATE TABLE roles (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50) UNIQUE NOT NULL, -- e.g. 'admin', 'user'
+    description TEXT
+);
+
+-- 用户-角色关联表
+CREATE TABLE user_roles (
+    user_id INT REFERENCES users(id),
+    role_id INT REFERENCES roles(id),
+    PRIMARY KEY (user_id, role_id)
+);
+```
+
+## 3. 配置规则 (rbac_rules)
+
+在 `config.json` 中配置 URL 路径与所需角色的映射：
+
+```json
+"rbac_rules": {
+    "/api/admin/.*": ["admin"],       // 仅 admin 可访问
+    "/api/user/.*": ["user", "admin"] // user 或 admin 均可访问
+}
+```
+
+- **逻辑**: OR 逻辑 (只要具备列表中任意一个角色即可通过)。
+- **匹配**: 正则表达式匹配 URL Path。
+
+## 4. 认证流程
+
+1. **登录/注册**:
+   - 用户注册时，默认自动分配 `user` 角色。
+   - 用户登录时，系统查询 `user_roles` 表，获取用户所有角色。
+2. **Token 颁发**:
+   - `roles` 列表被包含在 Token 响应中 (JSON body)。
+   - `roles` 已随访问令牌签发进 JWT Claim（TokenService 签发时写入）。
+3. **请求拦截 (AuthorizationFilter)**:
+   - 解析 Access Token 获取 `userId`。
+   - 根据 `userId` 查询缓存/数据库获取当前角色。
+   - 匹配请求 URL 是否命中 `rbac_rules`。
+   - 验证用户是否持有要求角色。
+   - **通过**: 继续处理。
+   - **拒绝**: 返回 `403 Forbidden`。
+
+## 5. 管理接口
+
+- **Dashboard**: `/api/admin/dashboard` (需 `admin` 角色)
+
+## 6. 如何授予 Admin 权限
+
+目前需通过 SQL 手动授予（生产环境通常由 SuperAdmin 界面操作）：
+
+```sql
+-- 假设目标用户 ID 为 5，Admin 角色 ID 为 1
+INSERT INTO user_roles (user_id, role_id) VALUES (5, 1);
+```

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/session-management.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/session-management.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 6
+---
+
+# 会话管理
+
+fulla 有**两个常被混为一谈的生命周期**：浏览器 SSO 会话（cookie 背后的服务端
+会话）与 API 令牌（完全不涉会话）。本页讲清两者、它们如何终结，以及运维上
+最重要的部分——Drogon 会话层在机器流量下的代价与调尺寸。
+
+## 1. 一个系统，两个生命周期
+
+| | SSO 会话 | API 令牌 |
+|---|---|---|
+| 谁拥有 | 走交互式登录/同意流程的浏览器 | 任何调用 token/introspect/userinfo 的客户端——**从不携带 cookie** |
+| 载体 | Drogon 服务端会话（`session_timeout`） | 不透明令牌，落库为哈希（[令牌生命周期](token-lifecycle.md)） |
+| 终结方式 | `end_session` / 登出 / 空闲过期 | 过期、撤销、refresh 家族级联 |
+
+机器流量不触会话存储。但——下面是关键细节——会话开启时它仍会*创建*会话条目。
+
+## 2. 必须了解的 Drogon 会话行为（上游 #278）
+
+`enable_session: true` 时，Drogon 框架层为**每个不带会话 cookie 的请求**创建
+一个 Session 并在 SessionManager 中持有到 `session_timeout` 到期
+（[drogon#278](https://github.com/an-tao/drogon/issues/278)，本仓 2026-08-22
+实测验证）。API 客户端（token / introspect / userinfo / discovery）从不发送
+cookie，因此**每个请求**都付这份代价。
+
+生产 LTO 构建实测（三场 60 秒 c=128 风暴）：
+
+| 量 | 值 |
+|---|---|
+| 每请求留存 | **~750 B**（三场分别 744/755/759 B） |
+| 稳态公式 | `API_QPS × session_timeout × 750 B` |
+| discovery 吞吐税 | **~-54%**（session OFF/ON 交错 6 轮：164.6k → 76.3k QPS） |
+
+该税影响所有端点（会话创建发生在框架层、先于路由）。历史基准数字
+（S1 87–104k）均为**开启**会话的测量值；无会话真天花板 ~165k。
+
+### 尺寸速查表
+
+按公式推算（交互登录写→读间隔为毫秒级，正确性从不依赖 TTL——S4
+登录/authcode 全阶梯已在 120 秒下验证）：
+
+| API QPS（无 cookie） | TTL 3600（默认） | TTL 300 | TTL 120 | TTL 30 |
+|---|---|---|---|---|
+| 100 | ~0.3 GB | ~23 MB | ~9 MB | ~2 MB |
+| 1,000 | **~2.7 GB** | ~225 MB | ~90 MB | ~23 MB |
+| 10,000 | **~27 GB（OOM 区）** | ~2.2 GB | ~0.9 GB | ~225 MB |
+
+**指引**：
+
+- 以交互为主（API 低于 100 QPS）的部署：保持默认 3600 秒——完整 SSO 体验不受影响。
+- API 流量可观的部署：把 `session_timeout`（与 `session_max_age` 同步）调到
+  内存预算可承受的档位。2 分钟空闲窗口对浏览器 SSO 可接受（OIDC 部署常用
+  5–15 分钟）。
+- 基准档采用 30 秒（`config.bench.json`，`QPS × 30 × 750 B` 封顶）。
+- 吞吐税（而非留存）与 TTL 无关、开 session 即存在；结构性修复需上游惰性/
+  按路径建会话——跟踪
+  [drogon#278](https://github.com/an-tao/drogon/issues/278)。
+
+部署侧运维摘要：[生产部署 · 性能调优](../operate/deployment.md)。
+
+## 3. 终结会话
+
+### RP-Initiated Logout（F-027）——`GET/POST /oauth2/end_session`
+
+终结服务端会话并（可选）重定向。规则：
+
+- `post_logout_redirect_uri` **必须**是客户端已注册的 redirect URI 之一；
+  客户端由 `id_token_hint` 的 `aud` 标识。
+- hint 的**签名会被验证**（RS256 + kid + iss/exp/sub 策略）。验证失败 →
+  400 `AUTH_INVALID_ID_TOKEN_HINT`（4006）。
+- 无合法 hint + 已注册 URI → 400。成功：带 `state` 回显 302，未提供重定向
+  URI 时返回 200。
+
+### API 登出——`POST /oauth2/logout`
+
+撤销所提交的令牌**并**调用 `session()->clear()`（F-028），服务端会话与
+access token 一同终结。
+
+### 重新认证语义（F-022）
+
+`prompt=login` 强制重新认证（即使会话存活）；`prompt=none` 禁止 UI
+（`login_required` / `consent_required` 错误重定向回已验证的 redirect URI）；
+`max_age=<秒>` 在会话的 `auth_time` 过老时强制重新认证。`auth_time`、`amr`、
+`acr`（1 = 密码，2 = MFA）随授权码传递并打进 id_token——见
+[配置指南 §6](../operate/configuration-guide.md)。
+
+## 4. 会话不是什么
+
+- 令牌撤销面（按令牌 / 客户端 / 用户撤销）作用于**令牌**而非 SSO 会话——见
+  [令牌生命周期 §6](token-lifecycle.md)。
+- 管理台的令牌浏览器列出的是落库令牌，不暴露在线会话清单。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/social-login.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/social-login.md
@@ -1,0 +1,45 @@
+# 社交登录指南
+
+后端社交登录按"提供方适配器"模式实现；**GitHub 是当前唯一前后端完整接线的提供方**，
+Google 与微信为"后端就绪、前端自接"模式（后端路由与配置已就绪，前端按钮需自行接入）。
+
+## GitHub（已完整接线，主线索）
+
+- 后端路由：`POST /api/github/login`；前端 `frontends/user` 已有"Sign in with GitHub"按钮
+  （OAuth App 的 client id 经 `VITE_GITHUB_CLIENT_ID` 注入）。
+- 账号模型：`oauth2_subject_mappings(provider, subject)` 映射到本地用户；首次登录按
+  `createLinkedUser` 语义创建带默认 `user` 角色的本地账号（用户名冲突时拒绝采用，fail-closed）。
+
+## Google（后端就绪）
+
+1. Google Cloud 侧创建 OAuth 2.0 客户端（Web 应用，回调填 `https://<your-host>/api/google/login`）。
+2. 后端配置（`config.json`）：
+
+```json
+"external_auth": {
+    "google": {
+        "client_id": "<your-client-id>",
+        "client_secret": "<your-client-secret>"
+    }
+}
+```
+
+3. 后端路由 `POST /api/google/login` 接收 `{ code, redirect_uri }` 并完成 code 交换。
+4. **前端按钮需自行接线**（当前 UI 未内置 Google 按钮——验证时用 curl 直接调后端路由）。
+
+## 微信（后端就绪；要求公网回调域名）
+
+1. 微信开放平台创建网站应用（**不支持 localhost 回调**，需备案域名）。
+2. 后端配置同上结构（`external_auth.wechat`：appid / app_secret）。
+3. 后端路由 `POST /api/wechat/login`。
+4. 本地开发三招：hosts 把回调域名指到 127.0.0.1 / Nginx 反代 / 内网穿透。
+
+## 通用安全注意
+
+- 社交回调的 `state` 必须校验（防 CSRF）；提供方返回的 subject 只信任服务端 code 交换结果，
+  绝不信任前端提交的用户信息。
+- 解绑社交账号有"最后一种登录方式"保护与并发解绑竞态的已知限制（见 `docs/history`
+  归档的 social-link 设计与 CHANGELOG #54/#69 修复记录）。
+
+> 合并自已退役的 google-guide.md 与 wechat-guide.md（docs 治理 A2），并修正了 google 指南
+> 中"前端无按钮却让用户点击按钮"的自相矛盾。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/token-lifecycle.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/domains/token-lifecycle.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 5
+---
+
+# 令牌生命周期
+
+fulla 中令牌如何签发、存活与消亡：三类令牌、真正落库的是什么、刷新轮换如何
+检测窃取、以及控制生命周期的每个开关。存储 schema 见
+[数据与持久化](../architecture/data-persistence.md)；HTTP 契约见
+[API 参考](api-reference.md)与 [ADR-0004](../adr/ADR-0004.md)。
+
+## 1. 三类令牌，三种形态
+
+| 令牌 | 形态 | 校验方式 | 默认生命周期 |
+|---|---|---|---|
+| Access token | **不透明随机串**（`generateSecureToken`） | 服务端状态（introspection / userinfo）——不是自包含 JWT | 3600 秒（`access_token_ttl`） |
+| Refresh token | 不透明随机串 + **家族 id** | 服务端状态；每次使用即轮换 | 30 天（可配置） |
+| id_token | **RS256 JWT**，经 JWKS 签名（`kid` 发布于 `/.well-known/jwks.json`） | 客户端侧验签（标准 OIDC） | 与 access token 相同；仅 `openid` scope 时签发 |
+
+设计理由（[ADR-0004](../adr/ADR-0004.md)）：不透明 access token 让服务器保持
+完全控制——撤销即时且有状态，密钥泄露的令牌不会活过服务器端的记录。JWT
+能力保留给协议要求它的 OIDC `id_token`。
+
+一个常见混淆：令牌响应中携带的 **roles** 属于 JSON 信封
+（`"roles": [...]`）与 id_token claims——不透明 access token 本身不携带任何
+需要解码的内容。
+
+## 2. 签发路径
+
+所有授权类型汇合到 `TokenService`（libs/oauth2）：
+
+| 授权类型 | 签发 | 说明 |
+|---|---|---|
+| `authorization_code`（+ PKCE，PUBLIC 客户端强制） | access + refresh（含 `openid` 时加 id_token） | 授权码单次使用、原子消费（见 §5） |
+| `refresh_token` | 新 access + **新** refresh | 旧 refresh 被撤销；家族 id 继承（§4） |
+| `client_credentials` | 仅 access（M2M，无用户） | 仅 CONFIDENTIAL 客户端 |
+| `device_code` | 用户批准后签发 access + refresh | 按 RFC 8628 轮询 |
+
+每个响应中的 `expires_in` 宣告的是**配置的** access-token 生命周期——不是
+硬编码 3600（RFC 6749 §5.1）。
+
+## 3. 落库的是什么（以及不落库什么）
+
+- access 与 refresh token 仅以 **SHA-256 哈希**持久化（写入仓储前经
+  `hashToken()`）——拖库拿不到可用凭据（[ADR-0004](../adr/ADR-0004.md)）。
+- refresh token 行额外存储 `token_family` id、关联的 access-token 哈希、
+  `revoked`/`revoked_at`/`revoked_by`。
+- 过期行由 `OAuth2CleanupService`（`cleanup_interval_seconds`，默认 3600 秒）
+  清理——Postgres 定期 DELETE、Redis 历史上靠 TTL、memory 定期扫描。
+
+## 4. 刷新轮换、重用检测与家族撤销
+
+每次刷新签发**新的** refresh token 并继承同一 `token_family`（V008）。若已被
+撤销的 refresh token 再次被提交，视为窃取：服务器**级联撤销该家族全部令牌**
+——攻击者与合法用户都需重新认证。完整威胁模型推演（含时序图）见
+[安全架构 §7](../architecture/security-architecture.md)。
+
+## 5. 授权码单次使用
+
+`consumeAuthCode` 在各后端均原子：Postgres 用
+`UPDATE ... WHERE consumed = false ... RETURNING`、Redis 历史上用 Lua 脚本、
+memory 用互斥锁——竞态中被重放的窃取授权码必然失败。该契约由
+`GrantRepositoryContractTest`（`ctest -L Contract`）跨三实现强制守护。
+
+## 6. 撤销面
+
+| 面 | 粒度 |
+|---|---|
+| `POST /oauth2/revoke`（RFC 7009） | 被提交的令牌 |
+| 管理 API `DELETE /api/admin/tokens/{prefix}` | 按令牌前缀 |
+| 管理令牌面 | 按**客户端**或按**用户**撤销——清掉该主体的全部令牌 |
+
+撤销是有状态且即时的：下一次携带已撤销令牌的 introspection 或 userinfo 调用
+即返回 `{"active": false}` / 401。
+
+## 7. 与缓存的联动
+
+启用 Redis L2 缓存（`cache.enabled`）后，token 与 client 读路径先命中
+`fulla:cache:*` 再回源 Postgres。每条写路径（签发、刷新、撤销）经**延迟双删**
+失效（立即 DEL + 约 200ms 后二次 DEL，
+`cache.invalidation_double_delete_delay_ms`），封住并发读者在写与首删之间回填
+旧值的竞态。二次删除失败计入
+`fulla_cache_invalidation_failures_total`——见[可观测性](../operate/observability.md)。
+细节见[数据与持久化 · 缓存一致性](../architecture/data-persistence.md)。
+
+## 8. 配置参考
+
+| 键 | 默认 | 含义 |
+|---|---|---|
+| `access_token_ttl` | 3600 | access-token 生命周期（秒）；在 `expires_in` 中宣告 |
+| refresh-token TTL | 30 天 | refresh-token 生命周期 |
+| `cleanup_interval_seconds` | 3600 | `OAuth2CleanupService` 清理过期行的周期 |
+| `cache.enabled` / `cache.ttl_seconds` | false / — | token/client 读的 L2 缓存（[配置指南](../operate/configuration-guide.md)） |

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/intro.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/intro.md
@@ -1,0 +1,24 @@
+---
+sidebar_position: 0
+---
+
+# 开始
+
+**Fulla** 是以 C++17 构建的高性能开源身份与访问管理（IAM）核心：生产级 OAuth2/OIDC
+授权服务器，完整覆盖用户认证、MFA、WebAuthn、RBAC 与多租户——既可作为**开箱即用的
+产品**（Docker/Helm）部署，也可作为**可嵌入的 C++ SDK**（`find_package(fulla-*)`）集成。
+
+快速入口：
+
+| 你想… | 去 |
+|---|---|
+| 五分钟了解架构 | [架构总览](architecture/architecture-overview) |
+| 跑起来试试 | [Docker 部署](operate/docker-deployment) · README 的 [Quick Start](https://github.com/voidvec/fulla#quick-start) |
+| 把 OAuth2 引擎嵌进你的 C++ 项目 | [SDK 集成指南](sdk/sdk-integration-guide) |
+| 用任意语言调 HTTP API | [API 参考](domains/api-reference) · [OIDC 集成](domains/oidc-guide) |
+| 部署到生产 | [生产部署](operate/deployment) · [配置指南](operate/configuration-guide) |
+| 理解某个设计为什么是这样 | [ADR 决策记录](adr/ADR-0001.md) |
+| 给项目贡献 | [贡献区](contribute/testing-guide) |
+
+本站内容直接来自[仓库的 docs/ 目录](https://github.com/voidvec/fulla/tree/master/docs)
+（单一事实源，零拷贝）；发现错误请提 PR 修改仓库文档，站点随 master 自动重建。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/account-lockout.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/account-lockout.md
@@ -1,0 +1,237 @@
+# 账号锁定机制说明
+
+## 问题描述
+
+OAuth2 系统实现了账号锁定机制以防止暴力破解攻击。当用户多次登录失败时，账号会被临时锁定。
+
+## 锁定规则
+
+根据 `AuthService.cc` 中的实现，锁定规则如下：
+
+| 失败次数 | 锁定时长 |
+|---------|---------|
+| 5-9次   | 1分钟   |
+| 10-14次 | 5分钟   |
+| 15-19次 | 30分钟  |
+| 20次以上 | 1小时   |
+
+## 常见场景
+
+### 场景1：测试脚本重复执行导致锁定
+
+**症状**：
+- 第一次运行测试脚本成功
+- 第二次运行时所有测试失败
+- 后端日志显示：`Account locked for user: admin until 1779441748`
+
+**原因**：
+测试脚本中某个测试用例登录失败（例如使用了错误的凭证），累积失败次数达到阈值。
+
+**解决方案**：
+测试脚本已自动在结束时重置账号锁定状态。如果仍然遇到问题，可以手动重置。
+
+## 手动重置账号锁定
+
+### 方法1：使用重置脚本（推荐）
+
+#### 本地PostgreSQL数据库
+
+```powershell
+# 默认使用config.json中的配置（fulla_user/fulla_db/123456）
+.\scripts\backend\reset-account-lockout.ps1
+
+# 重置特定用户
+.\scripts\backend\reset-account-lockout.ps1 -Username admin
+
+# 自定义数据库连接
+.\scripts\backend\reset-account-lockout.ps1 -DbHost localhost -DbUser fulla_user -DbPassword 123456
+```
+
+#### Docker数据库
+
+```powershell
+# 脚本会自动检测Docker容器
+.\scripts\backend\reset-account-lockout.ps1
+
+# 重置特定用户
+.\scripts\backend\reset-account-lockout.ps1 -Username admin
+```
+
+### 方法2：重置admin密码
+
+如果admin账号密码被意外修改或升级为PBKDF2后无法登录，使用此脚本重置为默认密码：
+
+```powershell
+# 重置admin密码为默认值 'admin'
+.\scripts\backend\reset-admin-password.ps1
+```
+
+**注意**：此脚本会将admin密码重置为SHA-256格式的默认密码（开发环境用）。首次登录后，系统会自动升级为PBKDF2格式。
+
+### 方法3：直接使用SQL
+
+#### 本地PostgreSQL
+
+```powershell
+# Windows PowerShell - 重置锁定状态
+$env:PGPASSWORD = "123456"
+psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET failed_login_count = 0, locked_until = 0 WHERE username='admin';"
+$env:PGPASSWORD = $null
+
+# 如果密码也需要重置（重置为默认密码 'admin'）
+$env:PGPASSWORD = "123456"
+psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET password_hash = '892738161086b314334f88d661aa6e7bab7c825c34bf55222811dad46cdbf724', salt = 'admin_salt', failed_login_count = 0, locked_until = 0 WHERE username = 'admin';"
+$env:PGPASSWORD = $null
+```
+
+```bash
+# Linux/Mac - 重置锁定状态
+PGPASSWORD=123456 psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET failed_login_count = 0, locked_until = 0 WHERE username='admin';"
+
+# 如果密码也需要重置
+PGPASSWORD=123456 psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET password_hash = '892738161086b314334f88d661aa6e7bab7c825c34bf55222811dad46cdbf724', salt = 'admin_salt', failed_login_count = 0, locked_until = 0 WHERE username = 'admin';"
+```
+
+#### Docker数据库
+
+```bash
+# 重置锁定状态
+docker exec <container_name> psql -U fulla_user -d fulla_db -c "UPDATE users SET failed_login_count = 0, locked_until = 0 WHERE username='admin';"
+
+# 如果密码也需要重置
+docker exec <container_name> psql -U fulla_user -d fulla_db -c "UPDATE users SET password_hash = '892738161086b314334f88d661aa6e7bab7c825c34bf55222811dad46cdbf724', salt = 'admin_salt', failed_login_count = 0, locked_until = 0 WHERE username = 'admin';"
+```
+
+### 方法4：查看锁定状态
+
+```sql
+-- 查看所有用户的锁定状态
+SELECT 
+    username, 
+    failed_login_count, 
+    locked_until,
+    CASE 
+        WHEN locked_until > EXTRACT(EPOCH FROM NOW()) THEN 'LOCKED'
+        ELSE 'UNLOCKED'
+    END as status,
+    CASE 
+        WHEN locked_until > EXTRACT(EPOCH FROM NOW()) 
+        THEN TO_TIMESTAMP(locked_until) - NOW()
+        ELSE INTERVAL '0'
+    END as remaining_time
+FROM users
+ORDER BY username;
+```
+
+## 测试脚本自动清理
+
+`test-admin-endpoints.ps1` 已经在测试结束时自动重置admin账号的锁定状态：
+
+```powershell
+# 测试脚本会在结束时执行：
+# 1. 尝试连接Docker容器
+# 2. 如果没有Docker，尝试连接本地PostgreSQL
+# 3. 重置admin账号的 failed_login_count 和 locked_until
+```
+
+**注意**：如果使用本地PostgreSQL，需要在脚本中配置数据库密码：
+
+```powershell
+# 编辑 test-admin-endpoints.ps1，找到这一行：
+$env:PGPASSWORD = "your_password"  # 修改为你的数据库密码
+```
+
+## 预防措施
+
+### 1. 测试环境使用专用账号
+
+不要在测试中使用生产环境的admin账号。创建专门的测试账号：
+
+```sql
+INSERT INTO users (username, password_hash, salt, email, email_verified)
+VALUES ('test_admin', '<hash>', '', 'test@example.com', true);
+
+INSERT INTO user_roles (user_id, role_id)
+SELECT u.id, r.id FROM users u, roles r 
+WHERE u.username = 'test_admin' AND r.name = 'admin';
+```
+
+### 2. 测试后自动清理
+
+在所有测试脚本的末尾添加清理代码：
+
+```powershell
+# Cleanup
+try {
+    # 重置测试账号
+    psql -U fulla_user -d fulla_db -h localhost -c "UPDATE users SET failed_login_count = 0, locked_until = 0 WHERE username='test_admin';"
+} catch {
+    Write-Host "Warning: Failed to reset test account" -ForegroundColor Yellow
+}
+```
+
+### 3. 使用正确的凭证
+
+确保测试脚本中使用的用户名和密码与数据库中的一致：
+
+```powershell
+# 检查数据库中的用户
+psql -U fulla_user -d fulla_db -h localhost -c "SELECT username FROM users;"
+
+# 如果需要重置密码（使用PBKDF2）
+# 需要通过应用程序的注册接口或直接调用PasswordHasher
+```
+
+## 生产环境建议
+
+### 1. 监控锁定事件
+
+在生产环境中监控账号锁定事件：
+
+```sql
+-- 查找最近被锁定的账号
+SELECT 
+    username, 
+    failed_login_count,
+    TO_TIMESTAMP(locked_until) as locked_until_time,
+    TO_TIMESTAMP(last_failed_login) as last_failed_time
+FROM users
+WHERE locked_until > EXTRACT(EPOCH FROM NOW())
+ORDER BY locked_until DESC;
+```
+
+### 2. 设置告警
+
+当关键账号（如admin）被锁定时发送告警：
+
+```sql
+-- 可以通过定时任务检查
+SELECT COUNT(*) FROM users 
+WHERE username IN ('admin', 'superuser') 
+AND locked_until > EXTRACT(EPOCH FROM NOW());
+```
+
+### 3. 审计日志
+
+后端日志会记录所有锁定事件：
+
+```
+WARN  Account locked for user: admin until 1779441748
+INFO  [METRIC] oauth2_login_failures_total reason=bad_credentials
+```
+
+建议将这些日志发送到集中式日志系统（如ELK、Grafana Loki）进行分析。
+
+## 安全注意事项
+
+1. **不要禁用锁定机制**：这是防止暴力破解的重要安全措施
+2. **不要在代码中硬编码数据库密码**：使用环境变量或密钥管理系统
+3. **限制重置权限**：只有管理员应该能够重置账号锁定状态
+4. **记录重置操作**：在生产环境中，所有重置操作都应该被审计
+
+## 相关文件
+
+- `libs/drogon/src/AuthService.cc` - 账号锁定逻辑实现
+- `scripts/backend/test-admin-endpoints.ps1` - 测试脚本（含自动清理）
+- `scripts/backend/reset-account-lockout.ps1` - 手动重置脚本
+- 数据库表：`users` (字段: `failed_login_count`, `locked_until`, `last_failed_login`)

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/configuration-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/configuration-guide.md
@@ -1,0 +1,184 @@
+# 配置指南
+
+## 1. 环境变量注入
+
+应用支持用环境变量覆盖关键配置项。这在 Docker/Kubernetes 环境下尤为重要——
+敏感信息不应硬编码在 `config.json` 中。
+
+### 支持的环境变量
+
+| 变量名 | 说明 | 覆盖的配置路径 | 示例 |
+|---|---|---|---|
+| `FULLA_DB_HOST` | 数据库主机名 | `db_clients[0].host` | `postgres` |
+| `FULLA_DB_NAME` | 数据库名 | `db_clients[0].dbname` | `fulla_db` |
+| `FULLA_DB_PASSWORD` | 数据库密码 | `db_clients[0].passwd` | `secret` |
+| `FULLA_REDIS_HOST` | Redis 主机名 | `redis_clients[0].host` | `redis` |
+| `FULLA_REDIS_PASSWORD` | Redis 密码 | `redis_clients[0].passwd` | `secret` |
+| `FULLA_VUE_CLIENT_SECRET` | Vue 客户端密钥 | `plugins[OAuth2Plugin].config.clients.vue-client.secret` | `...` |
+
+> 生产部署的完整环境变量清单（30+ 项）见[生产部署](deployment.md)的变量表；本表只列注入机制的六个核心项。
+
+### 工作机制
+
+1. **加载钩子**：启动时 `main.cc` 的 `loadConfiguration()` 先调用 `common::config::ConfigManager::load()`，再调用 `ConfigManager::validate()`。
+2. **解析**：把基础 `config.json` 读入 `Json::Value` 对象。
+3. **注入**：检查上述环境变量是否存在；存在则就地更新 `Json::Value` 中对应节点。
+4. **加载**：Drogon 通过 `drogon::app().loadConfigJson(config)` 直接加载修改后的配置对象，磁盘上不产生临时文件。
+
+### 验证
+
+专用测试 `EnvInjectionVerify`（`EnvConfigTest.cc`）保证该逻辑正确。
+
+## 2. Docker 部署
+
+仓库内置 `docker-compose.yml` 编排全栈（详解见 [Docker 部署](docker-deployment.md)）。
+
+### 服务栈
+
+- **fulla-frontend**：Vue SPA + Nginx（构建自 `deploy/docker/Dockerfile` 的 `frontend-runtime`）。
+- **fulla-admin**：管理后台前端（构建自 `frontends/admin/Dockerfile`）。
+- **fulla-backend**：Drogon 后端（构建自 `deploy/docker/Dockerfile` 的 `backend-runtime`）。
+- **fulla-postgres**：PostgreSQL 17（后端启动时经 `FULLA_AUTO_MIGRATE=true` 应用 `apps/server/migrations/` 下的 schema）。
+- **fulla-redis**：带密码保护的 Redis 7。
+- **fulla-prometheus**：指标采集。
+
+### 快速开始
+
+```bash
+# 构建并启动（在仓库根目录执行）
+docker compose -f deploy/docker/docker-compose.yml up -d --build
+
+# 查看日志
+docker compose -f deploy/docker/docker-compose.yml logs -f fulla-backend
+
+# 停止
+docker compose -f deploy/docker/docker-compose.yml down
+```
+
+### Docker 下的配置处理
+
+`docker-compose.yml` 将 `apps/server/config/config.json` 只读挂载进容器；
+`environment` 段注入环境变量（见 §1），运行时经 `ConfigManager::load()` +
+环境注入覆盖文件默认值。
+
+## 3. 存储后端选择
+
+OAuth2 插件的 `config.storage_type` 决定持久化后端：
+
+| `storage_type` | 状态 | 说明 |
+|---|---|---|
+| `postgres` | **支持（唯一生产后端）** | 完整令牌持久化、refresh token 轮换与重用检测。 |
+| `redis` | **已弃用** | 历史上从未持久化 refresh token（`saveRefreshToken`/`getRefreshToken` 为空操作），轮换与重用检测静默失效。该模式仍可启动（兼容考虑，启动时打 ERROR 日志），但 `refresh_token` 授权会以 `unsupported_grant_type` 被拒绝。新部署不要使用。 |
+| `memory` | 仅测试 | 面向单元/集成测试，不用于生产。 |
+
+目标架构：**Postgres 作为存储层，前置一个在线 Redis L2 缓存**（键空间
+`fulla:cache:*`，经 `config.json` 的 `cache` 块配置 `enabled` /
+`ttl_seconds` / `invalidation_double_delete_delay_ms`；失效采用延迟双删，
+见 `DelayedDoubleDelete`）。不存在独立 Redis 存储模式。
+
+## 4. Issuer 配置
+
+`config.metadata.issuer`（custom config）是服务器 issuer URL 的唯一事实源。
+`OAuth2Plugin` 启动时读取一次，一致地用于：
+
+- 签发 access token 时打上的 `iss` 声明（authorization_code / refresh_token / client_credentials / device_code 授权）；
+- 内省响应的 `iss`（存储行未携带时以配置值回填）；
+- 发现文档（`/.well-known/openid-configuration`、`/.well-known/oauth-authorization-server`）。
+
+约束：
+
+- 末尾斜杠会被自动规范化掉，不要依赖它。
+- 未设置时默认 `http://localhost:5555`，此时打 `LOG_WARN`。
+- 生产部署**必须**配置 `https://` issuer；非回环主机上使用明文 http issuer 会有启动告警。
+- 内省 `iss` 与发现文档 `issuer` 保证逐字节一致（OIDC Discovery §3 要求）。
+
+## 5. 客户端令牌端点认证方式（F-017）
+
+每个客户端通过 `oauth2_clients.token_endpoint_auth_method` 列声明其在
+`/oauth2/token`、`/oauth2/introspect`、`/oauth2/revoke` 的认证方式：
+
+| 取值 | 语义 |
+|---|---|
+| `client_secret_basic` | 密钥**必须**走 `Authorization: Basic` 头；body 携带 `client_secret` 会被拒绝。 |
+| `client_secret_post` | 密钥**必须**走 POST body；Basic 头会被拒绝。 |
+| `none` | PUBLIC 客户端；携带任何 `client_secret` 都会被拒绝。 |
+| NULL / 空 | 旧版宽松回退：接受 Basic 头，也接受 body 密钥（Basic→body 回退）。 |
+
+注册/管理端创建时若省略该字段，按以下默认值落库：
+
+- `PUBLIC` 客户端 → `none`（本就没有密钥）。
+- `CONFIDENTIAL` 客户端 → `client_secret_basic`。
+
+种子客户端均显式声明：`vue-client` 与 `admin-console` → `none`；
+`backend-svc` → `client_secret_basic`。已有 NULL 值的客户端保持升级前的
+行为，升级不破坏存量部署。
+
+## 6. OIDC prompt / max_age / auth_time（F-022）
+
+授权端点支持 OIDC Core §3.1.2.1 的 `prompt` 与 `max_age` 参数：
+
+- **`prompt=none`**：禁止任何 UI。无会话 → 302 `error=login_required`；
+  需要同意 → `error=consent_required`。错误会带着回显的 `state` 重定向回
+  已验证的 `redirect_uri`。`none` 与其他值组合（如 `none login`）自相矛盾，
+  直接返回 400。
+- **`prompt=login`**：即使已有会话也强制重新认证。
+- **`prompt=consent`**：即使既有同意已覆盖所请求的 scope，也强制显示同意页。
+- **`max_age=<秒>`**：若会话的 `auth_time`（登录 / MFA 验证时设置）早于
+  `max_age`，强制重新认证。
+
+`auth_time` 与 `amr` 随授权码持久化，并在换票时打进 id_token：`auth_time`
+（大于 0 时）、`amr`（设置时为 JSON 数组）、`acr`（`1` = 仅密码，`2` = MFA）。
+发现文档宣告 `prompt_values_supported`、`acr_values_supported` 与相关 claims。
+
+## 7. RP-Initiated Logout（F-027）与会话失效（F-028）
+
+`/oauth2/end_session`（GET + POST）终结服务端会话。要在登出后重定向，
+客户端须提供 `post_logout_redirect_uri`，且它**必须**是该客户端已注册的
+redirect URI 之一；客户端由 `id_token_hint` 的 `aud` 声明识别。hint 的
+签名**会**被验证（RS256 + kid + iss/exp/sub 策略，issue #78），验证失败以
+400 `AUTH_INVALID_ID_TOKEN_HINT` 拒绝。没有合法 hint + 已注册 URI 时请求
+被 400 拒绝；成功时带 `state` 回显 302 重定向，未提供重定向 URI 时返回 200。
+
+`POST /oauth2/logout`（既有的 API 登出）额外调用 `session()->clear()`
+（F-028），因此服务端会话随 access token 撤销一并终结。
+
+## 8. 认证失败限流（F-018）
+
+token / introspect / revoke / device-code 轮询四个端点共享一个进程内
+滑动窗口限流器，按 `(client_ip, client_id)` 分桶。滚动窗口
+（默认 60s）内**失败**计数达 `max_failures`（默认 30）后，后续请求返回
+**HTTP 429**，带 `Retry-After` 头与 OAuth2 风格的
+`{error, error_description}` 响应体。只计**失败**；一次成功即清零，因此
+正常负载（以及大量连续成功请求的集成测试套件）不会被限流。
+
+经 `custom_config.auth.rate_limit` 配置（所有 `config*.json` 都显式携带默认值）：
+
+```json
+"custom_config": {
+  "auth": {
+    "require_pkce_for_public": true,
+    "allow_http_redirect_uri": true,
+    "rate_limit": {
+      "max_failures": 30,
+      "window_seconds": 60
+    }
+  }
+}
+```
+
+两个键均可省略；`rate_limit` 对象缺失时使用内置默认（30 / 60）。限流器是
+函数局部单例（`libs/common/include/fulla/common/utils/RateLimiter.h` 的
+`RateLimiter::instance()`），四个受保护端点在同一进程内共享一份计数表。
+这是最小化的暴力破解/令牌探测防护；多实例部署需要共享存储（Redis），
+为后续工作。
+
+## 9. JWKS 密钥轮换（F-029 —— 运维待办）
+
+JWKS 端点（`/.well-known/jwks.json`）当前只服务**单个静态 `kid`**，在插件
+启动时由配置的 JWK 物料初始化一次（`OAuth2Plugin::initAndStart()` →
+`JwkManager::init()`）。**轮换尚未实现**：没有轮换周期、没有 kid 滚动窗口、
+没有双密钥发布。当前密钥签发的令牌在其整个生命周期内有效；轮换密钥会使
+前任密钥签发的所有存量令牌失效。
+
+生产轮换已登记为运维待办。在此之前，将密钥泄露纳入威胁模型的运维者应
+以新 JWK 物料重启服务器（并接受此前签发的全部令牌失效）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/deployment-windows-docker-desktop.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/deployment-windows-docker-desktop.md
@@ -1,0 +1,836 @@
+# Windows Docker Desktop 部署验证指南
+
+本指南说明如何在 Windows Docker Desktop 上验证 fulla 全栈系统的部署，**除了域名和 SSL 外，其他所有功能与 Linux 生产环境完全一致**。
+
+---
+
+## 为什么使用 Windows Docker Desktop 验证？
+
+✓ **完全模拟生产环境**：使用相同的 Docker Compose 配置、相同的容器镜像、相同的网络拓扑  
+✓ **快速反馈循环**：本地修改代码 → 立即验证 → 确认无误后再推送到 Linux 服务器  
+✓ **节省时间**：避免每次"推送 → 服务器拉取 → 重启服务 → 发现问题"的漫长循环  
+✓ **核心功能全覆盖**：数据库迁移、API 端点、前端路由、OAuth2 流程全部可测试  
+
+**与 Linux 生产环境的差异**：
+| 功能 | Windows Docker Desktop | Linux 生产环境 |
+|------|------------------------|----------------|
+| PostgreSQL | ✓ 完全相同 | ✓ |
+| Redis | ✓ 完全相同 | ✓ |
+| 后端 API | ✓ 完全相同 | ✓ |
+| 前端 | ✓ 完全相同 | ✓ |
+| 管理后台 | ✓ 完全相同 | ✓ |
+| Nginx 反向代理 | ⚠ 简化配置（无 TLS） | ✓ |
+| 域名访问 | ✗ 使用 localhost | ✓ |
+| SSL/TLS | ✗ 不启用 | ✓ |
+
+---
+
+## 前置条件
+
+### 软件要求
+
+1. **Windows 10/11 专业版或企业版**（家庭版需要 WSL2 手动配置）
+2. **Docker Desktop for Windows**（最新稳定版）
+   - 下载：https://www.docker.com/products/docker-desktop/
+   - 安装时启用 WSL2 后端（推荐）或 Hyper-V
+3. **Git**（用于克隆项目）
+   - 下载：https://git-scm.com/download/win
+4. **OpenSSL**（用于生成 JWT 密钥，可选）
+   - Windows: 下载 https://slproweb.com/products/Win32OpenSSL.html
+   - 或使用 Git Bash 自带的 OpenSSL
+
+### 验证 Docker Desktop 安装
+
+打开 PowerShell 或 Windows Terminal：
+
+```powershell
+# 检查 Docker 版本（要求 20.10+）
+docker --version
+
+# 检查 Docker Compose 版本（要求 v2+）
+docker compose version
+
+# 检查 Docker 是否正常运行
+docker ps
+```
+
+预期输出示例：
+```
+Docker version 24.0.7, build afdd53b
+Docker Compose version v2.23.0
+CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
+```
+
+---
+
+## 快速开始（5 步）
+
+### 1. 克隆项目
+
+```powershell
+# 克隆仓库（替换为实际地址）
+git clone <repo-url>
+cd fulla
+
+# 检查分支
+git branch
+```
+
+### 2. 生成 JWT 密钥
+
+**方法 A：使用 Git Bash（推荐）**
+
+```bash
+# 在项目根目录执行
+cd /path/to/repo-root
+
+# 生成 JWT 签名密钥
+chmod +x scripts/generate-jwt-keys.sh
+./scripts/generate-jwt-keys.sh
+
+# 验证密钥生成
+ls -la deploy/keys/
+# 应该看到 signing.pem 和 signing.pub
+```
+
+**方法 B：使用 PowerShell + OpenSSL**
+
+```powershell
+# 安装 OpenSSL for Windows 后
+openssl genrsa -out deploy\keys\signing.pem 2048
+openssl rsa -in deploy\keys\signing.pem -pubout -out deploy\keys\signing.pub
+
+# 验证
+dir deploy\keys
+```
+
+**方法 C：跳过密钥生成（仅用于测试）**
+
+如果只是验证部署流程，可以暂时跳过此步，后端会使用内置测试密钥（⚠ 生产环境必须生成真实密钥）。
+
+### 3. 配置环境变量
+
+```powershell
+# 复制环境变量模板
+Copy deploy\env\docker.env.example .env.docker
+
+# 编辑文件（使用 VS Code 或记事本）
+notepad .env.docker
+```
+
+**编辑 `.env.docker`，设置本地测试密码**：
+
+```env
+# PostgreSQL
+POSTGRES_USER=fulla_user
+POSTGRES_PASSWORD=WinDockerTest2024!
+POSTGRES_DB=fulla_db
+
+# Redis
+REDIS_PASSWORD=WinDockerTest2024!
+
+# OAuth2 Backend
+FULLA_DB_HOST=fulla-postgres
+FULLA_DB_NAME=fulla_db
+FULLA_DB_PASSWORD=WinDockerTest2024!
+FULLA_REDIS_HOST=fulla-redis
+FULLA_REDIS_PASSWORD=WinDockerTest2024!
+FULLA_FRONTEND_URL=http://localhost:8080
+
+# 域名（本地测试忽略）
+DOMAIN=localhost
+```
+
+> **注意**：Windows 环境变量文件使用 CRLF 换行符，Docker Compose 会自动处理。
+
+#### 邮件服务配置（可选）
+
+后端邮件服务有两种模式（由 [EmailService.cc](https://github.com/voidvec/fulla/blob/master/libs/drogon/src/utils/EmailService.cc) 的 `getEmailService()` 决定）：
+
+| 模式 | 触发条件 | 行为 |
+|------|---------|------|
+| **Console 模式**（默认） | 未设置 `FULLA_SMTP_*` | 验证邮件只输出到后端日志，不真正发送 |
+| **SMTP 模式** | 设置 `FULLA_SMTP_HOST` + `FULLA_SMTP_USER` + `FULLA_SMTP_PASSWORD` | 通过 SMTP 真正发送邮件 |
+
+**默认 Console 模式（本地验证推荐）**：
+
+无需任何配置。点击"发送邮箱验证"后，邮件内容（含验证链接）会打到后端日志，可从中复制链接验证：
+
+```bash
+docker logs fulla-backend --tail 50 2>&1 | grep -A 5 -iE "verify|email"
+```
+
+**启用真实 SMTP 发送（163 邮箱示例）**：
+
+在 `.env.docker` 末尾追加：
+
+```env
+# Email / SMTP
+FULLA_SMTP_HOST=smtp.163.com
+FULLA_SMTP_PORT=465
+FULLA_SMTP_USER=your-email@163.com
+FULLA_SMTP_PASSWORD=your-authorization-code   # 163 授权码，非登录密码
+FULLA_SMTP_FROM_NAME=OAuth2 Platform
+FULLA_SMTP_SSL=true                            # 465 端口必须 SSL
+```
+
+> **获取 163 授权码**：登录 163 邮箱网页版 → 设置 → POP3/SMTP/IMAP → 开启 SMTP 服务 → 生成授权码。
+
+修改后重启后端使配置生效：
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d fulla-backend
+
+# 验证已切换到 SMTP 模式（应看到 "Email service: SMTP (smtp.163.com:465)"）
+docker logs fulla-backend 2>&1 | grep -i "Email service"
+```
+
+> **注意**：邮件里的验证链接使用 `FULLA_FRONTEND_URL`（本地为 `http://localhost:8080`），从其他机器点开会失效——这是本地部署的预期限制。
+
+### 4. 修改 Docker Compose 配置
+
+由于本地环境不需要 HTTPS，我们创建一个简化的 Compose 文件：
+
+**选项 A：使用现有的开发配置（推荐）**
+
+```powershell
+# 直接使用 docker-compose.yml（已配置好本地端口）
+docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d --build
+```
+
+**选项 B：创建自定义配置**
+
+如果需要更多控制，创建 `deploy/docker/docker-compose.windows.yml`：
+
+```yaml
+# 基于 docker-compose.yml，移除外部认证和 TLS 相关配置
+services:
+  fulla-backend:
+    environment:
+      - FULLA_DB_HOST=fulla-postgres
+      - FULLA_DB_NAME=fulla_db
+      - FULLA_DB_PASSWORD=${POSTGRES_PASSWORD}
+      - FULLA_REDIS_HOST=fulla-redis
+      - FULLA_REDIS_PASSWORD=${REDIS_PASSWORD}
+      - FULLA_AUTO_MIGRATE=true
+      - FULLA_FRONTEND_URL=http://localhost:8080
+    volumes:
+      - ../../deploy/keys:/app/keys:ro  # JWT 密钥
+      - ../../apps/server/migrations:/app/sql/migrations:ro
+      - ../../apps/server/seed:/app/sql/seed:ro
+
+  # 其他服务保持不变...
+```
+
+### 5. 启动服务
+
+```powershell
+# 启动所有服务
+docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d --build
+
+# 查看启动日志
+docker compose -f deploy/docker/docker-compose.yml logs -f
+```
+
+预期输出（服务启动成功）：
+```
+[+] Running 8/8
+ [+] Network oauth2-net          Created                 0.1s
+ [+] Volume "oauth2_plugin_postgres_prod" Created
+ [+] Container fulla-postgres    Started                 2.3s
+ [+] Container fulla-redis      Started                 1.8s
+ [+] Container fulla-backend    Started                 5.2s
+ [+] Container fulla-frontend    Started                 3.1s
+ [+] Container fulla-admin      Started                 2.9s
+ [+] Container fulla-prometheus Started                 1.5s
+```
+
+---
+
+## 验证部署
+
+### 1. 检查容器状态
+
+```powershell
+docker compose -f deploy/docker/docker-compose.yml ps
+```
+
+预期所有容器状态为 `Up`：
+
+```
+NAME                STATUS          PORTS
+fulla-admin        Up              0.0.0.0:8081->80/tcp
+fulla-backend      Up              0.0.0.0:5555->5555/tcp
+fulla-frontend     Up              0.0.0.0:8080->80/tcp
+fulla-postgres     Up              0.0.0.0:5433->5432/tcp
+fulla-prometheus   Up              0.0.0.0:9090->9090/tcp
+fulla-redis        Up              0.0.0.0:6380->6379/tcp
+```
+
+### 2. 验证后端健康
+
+```powershell
+curl http://localhost:5555/health
+```
+
+预期返回：
+```json
+{"status":"healthy","timestamp":"2024-06-23T10:30:00Z"}
+```
+
+### 3. 验证数据库迁移
+
+```powershell
+# 进入 postgres 容器
+docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "\dt"
+
+# 预期看到 OAuth2 相关表
+# clients, users, tokens, authorization_codes, etc.
+```
+
+### 4. 验证前端访问
+
+在浏览器中打开：
+- **用户前端**：http://localhost:8080
+- **管理后台**：http://localhost:8081/admin/
+- **Prometheus**：http://localhost:9090
+
+### 5. 创建管理员账号
+
+```Git Bash
+# 执行 seed 脚本
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_user.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_console_client.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_vue_client.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_backend_client.sql
+```
+
+```powershell
+# 执行管理员用户 seed
+Get-Content apps\server\seed\dev_admin_user.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
+
+# 执行管理后台客户端 seed
+Get-Content apps\server\seed\dev_admin_console_client.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
+
+# 执行 Vue 客户端 seed
+Get-Content apps\server\seed\dev_vue_client.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
+
+# 执行 backend-svc 客户端 seed
+Get-Content apps\server\seed\dev_backend_client.sql | docker exec -i fulla-postgres psql -U fulla_user -d fulla_db
+```
+
+验证管理员账号：
+
+**方法 1：使用 Git Bash（推荐）**
+```bash
+docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT username, email FROM users WHERE username = 'admin';"
+```
+
+**方法 2：使用 PowerShell**
+```powershell
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT username, email FROM users WHERE username = 'admin';"
+```
+
+**预期输出**：
+```
+ username |       email       
+----------+-------------------
+ admin    | admin@example.com
+```
+
+**验证管理员角色**：
+```bash
+docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT u.username, u.email, r.name FROM users u LEFT JOIN user_roles ur ON u.id = ur.user_id LEFT JOIN roles r ON ur.role_id = r.id WHERE u.username = 'admin';"
+```
+
+**预期输出**：
+```
+ username |       email       | name  
+----------+-------------------+-------
+ admin    | admin@example.com | admin
+```
+
+---
+
+## 执行端点测试
+
+项目包含完整的端点测试套件，用于验证 OAuth2 核心功能和管理后台 API。
+
+### 推荐方式：Git Bash
+
+**优势**：原生支持 shell 脚本、路径处理正确、与 Linux 环境一致
+
+#### 1. 执行 OAuth2 核心端点测试
+
+```bash
+# 进入项目目录
+cd /path/to/repo-root
+
+# 确保测试脚本有执行权限
+chmod +x scripts/backend/test-oauth2-endpoints.sh
+
+# 执行测试（55个测试）
+./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
+```
+
+**测试覆盖**：
+- 健康检查、JWKS 端点
+- OAuth2 登录、令牌交换、刷新令牌
+- 令牌内省、撤销
+- 用户注册、登录、个人资料
+- 密码重置、修改
+- MFA 设置、验证、禁用
+- 动态客户端注册（RFC 7591）
+- WebAuthn 认证
+- 设备授权流程
+- 外部认证（GitHub、Google、微信）
+
+#### 2. 执行管理后台 API 测试
+
+```bash
+chmod +x scripts/backend/test-admin-endpoints.sh
+./scripts/backend/test-admin-endpoints.sh http://localhost:5555
+```
+
+**测试覆盖**：
+- 管理员登录、仪表板统计
+- 用户管理（CRUD 操作）
+- 客户端应用管理
+- Scope 管理
+- Token 管理
+- 授权用户管理
+- 角色权限管理
+
+### 备选方式：WSL2 Ubuntu
+
+```bash
+# 1. 启动 WSL2
+wsl
+
+# 2. 进入项目目录（注意路径转换）
+cd /path/to/repo-root
+
+# 3. 执行测试
+./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
+./scripts/backend/test-admin-endpoints.sh http://localhost:5555
+```
+
+### PowerShell 混合方式
+
+```powershell
+# 在 PowerShell 中调用 Git Bash 执行测试
+bash ./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
+bash ./scripts/backend/test-admin-endpoints.sh http://localhost:5555
+```
+
+### 测试结果解读
+
+#### 预期输出
+
+```bash
+========================================
+OAuth2 Endpoints Tests (59 tests)
+========================================
+Base URL: http://localhost:5555
+
+[Test 1/59] Test 1: Health Check
+    Status: ok
+    [+] PASS (0.1s)
+
+[Test 10/59] Test 10: Client Credentials
+    AT: eyJhbGciOiJSUzI1Ni..., Scope: read
+    [+] PASS (0.2s)
+
+...
+
+========================================
+Test Results: 59/59 passed, 0 failed
+========================================
+```
+
+#### 失败排查
+
+**端点测试应全部通过（当前口径：OAuth2 侧 59、Admin 侧 52）**。若出现失败，按以下已知环境依赖排查：
+
+1. **Test 10 失败**：`no access_token`
+   - **原因**：缺少测试客户端 `backend-svc`
+   - **解决**：执行 `dev_backend_client.sql` 创建测试客户端
+
+2. **Test 20/20b 失败**：`missing field: .client_id` 或 `Expected HTTP 400, got 403`
+   - **原因**：RBAC 权限控制正确工作，动态客户端注册需要特殊配置
+   - **影响**：无（这是预期行为）
+
+3. **连锁失败**：`skipped: no token`
+   - **原因**：前序测试撤销令牌导致后续测试无令牌可用
+   - **影响**：无（测试脚本设计如此）
+
+#### 成功标准
+
+**59/52 全部通过才算部署验证成功**。个别失败若出现，先核对是否为上述已知的脚本环境依赖（数据库重置、种子数据、端口占用）；不要把『部分通过』当作部署成功标准。
+
+### 测试前准备
+
+#### 1. 确保数据库种子数据
+
+```bash
+# 执行必需的 seed 脚本
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_user.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_console_client.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_vue_client.sql
+
+# 可选：创建测试客户端（提高测试通过率）
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_backend_client.sql
+```
+
+#### 2. 验证基础服务
+
+```bash
+# 检查容器状态
+docker ps
+
+# 检查后端健康
+curl http://localhost:5555/health
+
+# 检查数据库连接
+docker exec fulla-postgres pg_isready -U fulla_user
+```
+
+### 快速验证命令
+
+```bash
+# 一键执行所有测试
+cd /path/to/repo-root && \
+chmod +x scripts/backend/*.sh && \
+echo "[+] 执行 OAuth2 核心测试..." && \
+./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555 && \
+echo "" && \
+echo "[+] 执行管理后台 API 测试..." && \
+./scripts/backend/test-admin-endpoints.sh http://localhost:5555
+```
+
+---
+
+## 功能测试清单
+
+### 核心 OAuth2 流程
+
+| 测试项 | 测试方法 | 预期结果 |
+|--------|---------|---------|
+| 用户注册 | 前端注册页面 | 注册成功，可登录 |
+| 用户登录 | POST /oauth2/login（授权码 + PKCE 流程第一步） | 返回授权码 code |
+| 刷新令牌 | POST /oauth2/token (refresh_token grant) | 返回新的 access_token |
+| 令牌校验 | POST /oauth2/introspect | 返回 token 有效信息 |
+| 令牌撤销 | POST /oauth2/revoke | 返回 200 OK |
+| 授权码流程 | /oauth2/authorize → /callback | 完整 OAuth2 流程 |
+| 客户端管理 | Admin Console 创建/删除客户端 | 操作成功 |
+
+### API 端点测试
+
+#### 方法 1：使用现有测试脚本（推荐）
+
+项目包含完整的端点测试脚本，推荐使用 Git Bash 执行：
+
+**执行 OAuth2 核心端点测试（59 个测试）**：
+```bash
+# 1. 进入项目目录（Git Bash）
+cd /path/to/repo-root
+
+# 2. 确保测试脚本有执行权限
+chmod +x scripts/backend/test-oauth2-endpoints.sh
+
+# 3. 执行测试
+./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
+```
+
+**执行管理后台 API 测试（52 个测试）**：
+```bash
+chmod +x scripts/backend/test-admin-endpoints.sh
+./scripts/backend/test-admin-endpoints.sh http://localhost:5555
+```
+
+**预期输出示例**：
+```bash
+========================================
+OAuth2 Endpoints Tests (59 tests)
+========================================
+Base URL: http://localhost:5555
+
+[Test 1/59] Test 1: Health Check
+    Status: ok
+    [+] PASS (0.1s)
+
+...
+
+========================================
+Test Results: 59/59 passed, 0 failed
+========================================
+```
+
+**成功标准**：全部通过（59/52）。个别失败先按上文「失败排查」核对环境依赖；不要把『部分通过』当作部署成功标准。
+
+#### 方法 2：使用 PowerShell 脚本测试
+
+`admin-console` 是 PUBLIC 客户端（PKCE 强制、无 secret、无 password grant），手工构造令牌流程较繁琐，推荐直接使用仓库自带的 PowerShell 测试脚本（内部已实现 PKCE 登录）：
+
+```powershell
+# 执行管理后台端点测试（含 PKCE 登录 + 52 项断言）
+.\scripts\backend\test-admin-endpoints.ps1 -BaseUrl "http://localhost:5555"
+
+# 若已从其他途径拿到 access_token，可直接手工调用受保护 API 验证：
+$headers = @{ Authorization = "Bearer <access_token>" }
+Invoke-RestMethod -Uri "http://localhost:5555/api/admin/users" -Headers $headers
+# 预期：用户列表 JSON
+```
+
+#### 方法 3：使用 WSL2 Ubuntu（推荐）
+
+```bash
+# 1. 启动 WSL2
+wsl
+
+# 2. 进入项目目录
+cd /path/to/repo-root
+
+# 3. 执行测试
+./scripts/backend/test-oauth2-endpoints.sh http://localhost:5555
+./scripts/backend/test-admin-endpoints.sh http://localhost:5555
+```
+
+### 前端路由测试
+
+| 路径 | 预期页面 |
+|------|---------|
+| http://localhost:8080/ | 用户登录页 |
+| http://localhost:8080/register | 用户注册页 |
+| http://localhost:8080/profile | 个人资料页（需登录） |
+| http://localhost:8080/callback | OAuth2 回调页 |
+| http://localhost:8081/admin/ | 管理后台（需登录） |
+| http://localhost:8081/admin/apps | 应用管理页 |
+
+---
+
+## 常见问题排查
+
+### Docker Desktop 启动失败
+
+**症状**：`docker ps` 报错 "Cannot connect to the Docker daemon"
+
+**解决**：
+1. 检查 Docker Desktop 是否正在运行（系统托盘图标）
+2. 重启 Docker Desktop
+3. 检查 Hyper-V 或 WSL2 是否启用：
+   ```powershell
+   # WSL2
+   wsl --list --verbose
+   
+   # Hyper-V
+   dism /Online /Get-FeatureInformation /FeatureName:Microsoft-Hyper-V
+   ```
+
+### 端口冲突
+
+**症状**：容器启动失败，日志显示 "port is already allocated"
+
+**检查占用端口的进程**：
+```powershell
+# 检查 8080 端口
+netstat -ano | findstr :8080
+
+# 检查 5433 端口
+netstat -ano | findstr :5433
+```
+
+**解决**：
+1. 停止冲突的服务
+2. 或修改 `docker-compose.yml` 中的端口映射（如改为 `8082:80`）
+
+### 数据库连接失败
+
+**症状**：后端日志显示 "Connection refused" 或 "Host unreachable"
+
+**排查**：
+```powershell
+# 1. 检查 postgres 容器状态
+docker ps | findstr fulla-postgres
+
+# 2. 检查 postgres 日志
+docker logs fulla-postgres
+
+# 3. 测试数据库连接
+docker exec fulla-postgres pg_isready -U fulla_user
+
+# 4. 从后端容器测试网络连通性
+docker exec fulla-backend curl -s http://fulla-postgres:5432 2>&1
+docker exec fulla-backend curl -s http://fulla-redis:6379 2>&1
+```
+
+### 构建失败
+
+**症状**：`docker compose build` 报错 "failed to solve"
+
+**解决**：
+```powershell
+# 清理构建缓存
+docker builder prune -a
+
+# 重新构建
+docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker build --no-cache
+
+# 如果仍失败，检查磁盘空间
+docker system df
+```
+
+### Windows 路径问题
+
+**症状**：卷挂载失败，错误 "invalid mount config"
+
+**原因**：Windows 路径转换问题（`C:\` → `/c/`）
+
+**解决**：
+1. 使用 Git Bash 执行 Docker 命令（自动转换路径）
+2. 或使用 WSL2 执行：
+   ```powershell
+   wsl docker compose -f deploy/docker/docker-compose.yml up -d
+   ```
+
+---
+
+## 与 Linux 生产部署的映射关系
+
+### 配置文件映射
+
+| Windows 本地 | Linux 生产 | 说明 |
+|-------------|-----------|------|
+| `.env.docker` | `/root/fulla/.env.docker` | 环境变量完全相同 |
+| `deploy/keys/signing.pem` | `/root/fulla/deploy/keys/signing.pem` | JWT 密钥 |
+| `docker-compose.yml` | `docker-compose.prod.yml` | 端口和 TLS 配置差异 |
+
+### 部署命令映射
+
+| 操作 | Windows Docker Desktop | Linux 生产 |
+|------|----------------------|-----------|
+| 启动 | `docker compose --env-file .env.docker up -d` | `docker compose --env-file .env.docker -f docker-compose.prod.yml up -d` |
+| 查看日志 | `docker compose logs -f` | `docker compose -f docker-compose.prod.yml logs -f` |
+| 重建 | `docker compose up -d --build` | `docker compose -f docker-compose.prod.yml up -d --build` |
+| 停止 | `docker compose down` | `docker compose -f docker-compose.prod.yml down` |
+
+### 访问地址映射
+
+| 服务 | Windows 本地 | Linux 生产 |
+|------|-------------|-----------|
+| 用户前端 | http://localhost:8080 | https://your-domain.com/ |
+| 管理后台 | http://localhost:8081 | https://your-domain.com/admin/ |
+| 后端 API | http://localhost:5555 | https://your-domain.com/api/ |
+| Prometheus | http://localhost:9090 | http://your-server:9090 |
+
+---
+
+## 从本地验证到生产部署
+
+### 验证通过后部署到 Linux
+
+1. **确保本地验证成功**：
+   ```powershell
+   # 运行完整测试
+   .\scripts\backend\test-oauth2-endpoints.ps1
+   .\scripts\backend\test-admin-endpoints.ps1
+   ```
+
+2. **提交代码**：
+   ```powershell
+   git add .
+   git commit -m "feat: XXX (tested on Windows Docker Desktop)"
+   git push
+   ```
+
+3. **在 Linux 服务器上部署**：
+   ```bash
+   # 拉取代码
+   git pull
+
+   # 复制环境变量（只复制一次）
+   cp deploy/env/docker.env.example .env.docker
+   # 编辑 .env.docker 设置生产密码
+
+   # 使用生产配置启动
+   docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker up -d --build
+   ```
+
+4. **配置 TLS**（Linux 唯一额外步骤）：
+   ```bash
+   # 使用 Let's Encrypt
+   sudo certbot certonly --standalone -d your-domain.com
+   cp /etc/letsencrypt/live/your-domain.com/fullchain.pem deploy/nginx/ssl/
+   cp /etc/letsencrypt/live/your-domain.com/privkey.pem deploy/nginx/ssl/
+   docker compose -f deploy/docker/docker-compose.prod.yml restart nginx
+   ```
+
+---
+
+## 性能对比
+
+| 指标 | Windows Docker Desktop | Linux 生产服务器 |
+|------|----------------------|----------------|
+| 启动时间 | ~45 秒（6 个容器） | ~30 秒（相同配置） |
+| 内存占用 | ~2.5 GB | ~1.8 GB |
+| API 响应时间 | ~50ms | ~40ms |
+| 数据库查询 | ~10ms | ~8ms |
+
+> 差异主要来自 Windows 系统开销和 WSL2 虚拟化层，但功能完全一致。
+
+---
+
+## 下一步
+
+1. **完成本地验证**：确保所有核心功能正常
+2. **记录测试结果**：在项目文档中标记"Windows Docker Desktop 已验证"
+3. **推送到 Linux**：一次性部署成功
+4. **配置监控**：设置 Prometheus + Grafana
+
+---
+
+## 附录：完整端口映射
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Windows 宿主机                             │
+├─────────────────────────────────────────────────────────────┤
+│  Port 8080 ──→ fulla-frontend:80 (Vue 用户前端)              │
+│  Port 8081 ──→ fulla-admin:80 (Vue 管理后台)                 │
+│  Port 5555 ──→ fulla-backend:5555 (C++ API)                │
+│  Port 5433 ──→ fulla-postgres:5432 (PostgreSQL)            │
+│  Port 6380 ──→ fulla-redis:6379 (Redis)                    │
+│  Port 9090 ──→ fulla-prometheus:9090 (监控)                │
+└─────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Docker 内部网络 (oauth2-net)                 │
+│                                                               │
+│  所有容器通过内部 DNS 互相访问：                              │
+│  - fulla-backend → fulla-postgres:5432                     │
+│  - fulla-backend → fulla-redis:6379                        │
+│  - fulla-frontend → fulla-backend:5555                     │
+│  - fulla-admin → fulla-backend:5555                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 总结
+
+✓ **可行**：Windows Docker Desktop 可以完全验证部署流程（除域名和 SSL）  
+✓ **推荐**：本地验证 → 推送代码 → Linux 部署，大幅减少调试时间  
+✓ **一致性**：数据库模式、API 接口、前端逻辑与生产环境 100% 一致  
+
+**适用场景**：
+- ✓ 验证代码更改
+- ✓ 测试数据库迁移
+- ✓ 调试 API 端点
+- ✓ 验证前端路由
+- ✓ 测试 OAuth2 流程
+
+**不适用场景**：
+- ✗ TLS/SSL 测试（使用自签名证书可部分替代）
+- ✗ 性能压测（使用 Linux 服务器）
+- ✗ 高可用配置（需要多台服务器）

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/deployment.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/deployment.md
@@ -1,0 +1,809 @@
+# 生产化部署指南
+
+本指南说明如何将 OAuth2 全栈系统（用户前端 + 管理后台 + 后端 API）部署到生产环境。
+
+---
+
+## 架构概览
+
+```
+                    Internet
+                       │
+                ┌──────┴──────┐
+                │   Nginx     │  :80 → :443 (TLS)
+                │  (反向代理)  │
+                └──────┬──────┘
+          ┌────────────┼────────────┐
+          │            │            │
+    ┌─────┴─────┐ ┌────┴────┐ ┌────┴────┐
+    │ Frontend  │ │  Admin  │ │ Backend │
+    │ (Vue SPA) │ │ (Vue)   │ │ (C++)   │
+    │  :80      │ │  :80    │ │  :5555  │
+    └───────────┘ └─────────┘ └────┬────┘
+                                   │
+                         ┌─────────┼─────────┐
+                         │                   │
+                   ┌─────┴─────┐     ┌───────┴───────┐
+                   │ PostgreSQL│     │     Redis     │
+                   │   :5432   │     │    :6379      │
+                   └───────────┘     └───────────────┘
+```
+
+**路由规则（Nginx）**：
+- `/api/*`, `/oauth2/*`, `/.well-known/*`, `/health` → Backend
+- `/admin/*` → Admin Console
+- `/*` (其他) → User Frontend
+
+---
+
+## 前置条件
+
+### 硬件要求
+- **CPU**: 2 核心以上
+- **内存**: 4GB 以上（推荐 8GB）
+- **磁盘**: 20GB 以上可用空间
+- **网络**: 公网 IP，域名已解析到服务器
+
+### 操作系统支持
+
+- Ubuntu 20.04 / 22.04 / 24.04 LTS
+- Debian 11 / 12
+- CentOS Stream 8 / 9
+- Rocky Linux 8 / 9
+
+### 软件依赖安装
+
+#### 1. 安装 Docker
+
+**Ubuntu/Debian**:
+```bash
+# 更新包索引
+sudo apt update
+
+# 安装必要依赖
+sudo apt install -y ca-certificates curl gnupg lsb-release
+
+# 添加 Docker 官方 GPG 密钥
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+# 设置 Docker 仓库
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# 安装 Docker Engine
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# 启动 Docker 服务
+sudo systemctl start docker
+sudo systemctl enable docker
+
+# 验证安装
+docker --version
+docker compose version
+```
+
+**CentOS/Rocky Linux**:
+```bash
+# 安装必要依赖
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+
+# 添加 Docker 仓库
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+# 安装 Docker
+sudo yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# 启动 Docker 服务
+sudo systemctl start docker
+sudo systemctl enable docker
+
+# 验证安装
+docker --version
+docker compose version
+```
+
+#### 2. 配置 Docker 用户组（可选但推荐）
+
+```bash
+# 创建 docker 组（如果不存在）
+sudo groupadd docker
+
+# 将当前用户添加到 docker 组
+sudo usermod -aG docker $USER
+
+# 重新登录或运行以下命令使组权限生效
+newgrp docker
+
+# 验证：无需 sudo 运行 docker
+docker ps
+```
+
+#### 2.5. 配置 Docker 镜像加速器（中国大陆必需）
+
+由于 Docker Hub 在中国大陆访问不稳定，拉取镜像会超时（典型错误：`dial tcp registry-1.docker.io:443: i/o timeout`），必须配置镜像加速器。
+
+以下加速器地址经实测（2026-06）在阿里云服务器上验证可用：
+
+**创建或修改 Docker 配置文件**:
+
+```bash
+sudo mkdir -p /etc/docker
+sudo tee /etc/docker/daemon.json > /dev/null << 'EOF'
+{
+  "registry-mirrors": [
+    "https://docker.1panel.live",
+    "https://docker.awsl9527.cn",
+    "https://docker.xuanyuan.me"
+  ],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m",
+    "max-file": "3"
+  }
+}
+EOF
+```
+
+> 说明：配置多个加速器，Docker 会按顺序尝试，任一可用即拉取成功。
+
+**重启 Docker 服务使配置生效**:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+sudo systemctl status docker
+```
+
+**验证镜像加速器配置**:
+
+```bash
+# 检查配置是否被加载（应显示上述 registry-mirrors 列表）
+docker info | grep -A 5 "Registry Mirrors"
+
+# 测试拉取镜像（本项目需要的全部镜像）
+docker pull postgres:17-alpine
+docker pull redis:7-alpine
+docker pull nginx:stable-alpine
+docker pull prom/prometheus:latest
+docker pull ubuntu:22.04
+```
+
+如果某个加速器报错（如 `502` 或 `i/o timeout`），Docker 会自动尝试下一个；若全部失败，参考下方故障排除。
+
+**故障排除**:
+
+1. **所有加速器均失败**：访问 [dongyubin/DockerHub](https://github.com/dongyubin/DockerHub) 获取最新可用列表，替换 `daemon.json` 中的地址后重启 Docker。
+
+2. **使用阿里云专属加速器**（需要阿里云账号，最稳定）:
+   - 登录 [阿里云容器镜像服务](https://cr.console.aliyun.com/) → 镜像工具 → 镜像加速器
+   - 获取专属加速地址（形如 `https://<your_code>.mirror.aliyuncs.com`）
+   - 将该地址置于 `daemon.json` 的 `registry-mirrors` 数组首位
+
+3. **使用代理拉取**（如果有可用的代理服务器）:
+
+   ```bash
+   # 为 Docker 守护进程配置代理
+   sudo mkdir -p /etc/systemd/system/docker.service.d
+   sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf > /dev/null << EOF
+   [Service]
+   Environment="HTTP_PROXY=http://your-proxy:port"
+   Environment="HTTPS_PROXY=http://your-proxy:port"
+   Environment="NO_PROXY=localhost,127.0.0.1"
+   EOF
+
+   sudo systemctl daemon-reload
+   sudo systemctl restart docker
+   ```
+
+#### 3. 安装 Git
+
+**Ubuntu/Debian**:
+```bash
+sudo apt install -y git
+```
+
+**CentOS/Rocky Linux**:
+```bash
+sudo yum install -y git
+```
+
+#### 4. 安装 OpenSSL（用于生成密钥）
+
+**Ubuntu/Debian**:
+```bash
+sudo apt install -y openssl
+```
+
+**CentOS/Rocky Linux**:
+```bash
+sudo yum install -y openssl
+```
+
+#### 5. 安装 Certbot（用于获取 Let's Encrypt 证书）
+
+**Ubuntu/Debian**:
+```bash
+sudo apt install -y certbot
+```
+
+**CentOS/Rocky Linux**:
+```bash
+sudo yum install -y certbot
+```
+
+### 验证依赖安装
+
+```bash
+# 检查 Docker 版本（要求 24+）
+docker --version
+
+# 检查 Docker Compose 版本（要求 v2）
+docker compose version
+
+# 检查 Git
+git --version
+
+# 检查 OpenSSL
+openssl version
+
+# 检查 Certbot
+certbot --version
+```
+
+### 域名和 DNS 配置
+
+1. **域名解析**：确保您的域名（如 `your-domain.example.com`）的 A 记录指向服务器公网 IP
+2. **DNS 传播验证**：
+   ```bash
+   # 检查域名是否正确解析
+   dig +short your-domain.example.com
+   nslookup your-domain.example.com
+   ```
+3. **防火墙配置**：确保以下端口可访问：
+   - `80/tcp` (HTTP)
+   - `443/tcp` (HTTPS)
+
+### 防火墙配置
+
+**Ubuntu (UFW)**:
+```bash
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+```
+
+**CentOS/Rocky Linux (firewalld)**:
+```bash
+sudo firewall-cmd --permanent --add-service=http
+sudo firewall-cmd --permanent --add-service=https
+sudo firewall-cmd --reload
+```
+
+---
+
+## 快速部署（5 步）
+
+### 1. 克隆项目
+
+```bash
+git clone <repo-url>
+cd fulla
+```
+
+### 2. 生成密钥
+
+```bash
+# 生成 JWT 签名密钥
+chmod +x scripts/generate-jwt-keys.sh
+./scripts/generate-jwt-keys.sh
+
+# 生成 TLS 证书（开发用自签名，生产用 Let's Encrypt）
+chmod +x scripts/generate-certs.sh
+./scripts/generate-certs.sh
+```
+
+**生产环境使用 Let's Encrypt**：
+```bash
+# 安装 certbot
+sudo apt install certbot
+
+# 创建 SSL 证书目录
+mkdir -p deploy/nginx/ssl/
+
+# 获取证书（先停止 nginx）
+sudo certbot certonly --standalone -d your-domain.com
+
+# 复制证书
+cp /etc/letsencrypt/live/your-domain.com/fullchain.pem deploy/nginx/ssl/
+cp /etc/letsencrypt/live/your-domain.com/privkey.pem deploy/nginx/ssl/
+```
+
+### 3. 配置环境变量
+
+```bash
+# 检查模板文件是否存在
+[ -f deploy/env/docker.env.example ] && echo "模板文件存在" || echo "错误：模板文件不存在"
+
+cp deploy/env/docker.env.example .env.docker
+```
+
+编辑 `.env.docker`，设置强密码与 HTTPS 域名相关配置：
+
+```env
+# 运行模式（生产强制校验 HTTPS issuer / 强密码；须配合 FULLA_ISSUER=https://）
+FULLA_ENV=production
+FULLA_ISSUER=https://your-domain.com
+
+# JWT 签名密钥（生产必填；不设则每次重启 token 失效）
+FULLA_JWT_KEY_PATH=/app/keys/signing.pem
+
+POSTGRES_USER=fulla_user
+POSTGRES_PASSWORD=<生成强密码>
+POSTGRES_DB=fulla_db
+
+REDIS_PASSWORD=<生成强密码>
+
+FULLA_DB_HOST=fulla-postgres
+FULLA_DB_PORT=5432
+FULLA_DB_NAME=fulla_db
+FULLA_DB_USER=fulla_user
+FULLA_DB_PASSWORD=<与 POSTGRES_PASSWORD 相同>
+FULLA_REDIS_HOST=fulla-redis
+FULLA_REDIS_PORT=6379
+FULLA_REDIS_PASSWORD=<与 REDIS_PASSWORD 相同>
+
+# CORS / OAuth 回调（HTTPS 域名必填，否则浏览器请求被拦截）
+FULLA_FRONTEND_URL=https://your-domain.com
+FULLA_CORS_ALLOW_ORIGINS=https://your-domain.com
+FULLA_VUE_REDIRECT_URI=https://your-domain.com/callback
+FULLA_VUE_CLIENT_SECRET=<生成强密码>
+FULLA_GOOGLE_REDIRECT_URI=https://your-domain.com/callback
+
+# 错误详细度（生产建议 false，不暴露字段级校验错误）
+DETAILED_VALIDATION_ERRORS=false
+
+# 邮件服务（SMTP）— 生产环境必须配置
+FULLA_SMTP_HOST=smtp.example.com
+FULLA_SMTP_PORT=465
+FULLA_SMTP_USER=noreply@example.com
+FULLA_SMTP_PASSWORD=<SMTP 授权码，非邮箱登录密码>
+FULLA_SMTP_FROM_NAME=OAuth2 Platform
+FULLA_SMTP_SSL=true
+
+# 前端构建变量（Vite 构建期注入）
+# VITE_API_BASE_URL 生产必须留空 → SPA 走相对路径（nginx 同源反代）
+VITE_API_BASE_URL=
+VITE_CLIENT_ID=vue-client
+VITE_REDIRECT_URI=https://your-domain.com/callback
+VITE_GITHUB_CLIENT_ID=
+
+DOMAIN=your-domain.com
+```
+
+> **重要耦合**：`FULLA_ENV=production` 与 `FULLA_ISSUER=https://...` 必须同时设置。仅设 production 而不配 HTTPS issuer 会导致后端启动校验失败（`ConfigManager` 的 prod-mode 校验拒绝非 https issuer）。同理 DB/Redis 密码不能是默认的 `123456` / `password`，否则 prod 校验也会拒绝启动。
+
+生成强密码：
+```bash
+openssl rand -base64 32
+```
+
+#### 邮件服务（SMTP）配置说明
+
+后端邮件服务有两种模式（由 `getEmailService()` 根据环境变量自动选择）：
+
+| 模式 | 触发条件 | 行为 |
+|------|---------|------|
+| **Console 模式** | 未设置 `FULLA_SMTP_HOST` / `USER` / `PASSWORD` | 邮件内容只输出到后端日志，**不真正发送** |
+| **SMTP 模式** | 上述三个变量均已设置且非空 | 通过 SMTP 真正发送邮件 |
+
+> **生产环境必须配置 SMTP**，否则邮箱验证、密码重置等功能的邮件不会真正发送给用户（只在服务器日志里）。
+
+**常见邮箱服务商配置参考**：
+
+| 服务商 | SMTP 主机 | 端口 | SSL | 凭据说明 |
+|--------|----------|------|-----|---------|
+| 163 邮箱 | `smtp.163.com` | 465 | true | 授权码（非登录密码） |
+| QQ 邮箱 | `smtp.qq.com` | 465 | true | 授权码 |
+| Gmail | `smtp.gmail.com` | 465 | true | 应用专用密码（需开两步验证） |
+| 腾讯企业邮 | `smtp.exmail.qq.com` | 465 | true | 邮箱密码 |
+| 阿里云企业邮 | `smtp.qiye.aliyun.com` | 465 | true | 邮箱密码 |
+| SendGrid | `smtp.sendgrid.net` | 587 | false | 用户名 `apikey`，密码为 API Key |
+
+**获取授权码（以 163 为例）**：
+1. 登录 163 邮箱网页版
+2. 设置 → POP3/SMTP/IMAP
+3. 开启 SMTP 服务
+4. 按提示生成授权码（16 位字符串）
+
+配置完成后重启后端生效：
+
+```bash
+docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker up -d fulla-backend
+
+# 验证已切换到 SMTP 模式（应输出 "Email service: SMTP (...)"）
+docker compose -f deploy/docker/docker-compose.prod.yml logs fulla-backend | grep "Email service"
+```
+
+### 4. 启动服务
+
+```bash
+docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker up -d
+```
+
+### 5. 验证部署
+
+```bash
+# 检查所有容器状态
+docker compose -f deploy/docker/docker-compose.prod.yml ps
+
+# 检查后端健康
+curl -k https://localhost/health
+
+# 检查前端
+curl -k https://localhost/
+
+# 检查管理后台
+curl -k https://localhost/admin/
+```
+
+---
+
+## 服务详情
+
+### 用户前端 (OAuth2Frontend)
+
+| 项目 | 值 |
+|------|-----|
+| 容器名 | fulla-frontend |
+| 构建 | Dockerfile (target: frontend-runtime) |
+| 基础镜像 | nginx:stable-alpine |
+| 内部端口 | 80 |
+| 访问路径 | `https://your-domain.com/` |
+| 功能 | 登录、注册、个人资料、安全设置、OAuth2 授权 |
+
+### 管理后台 (OAuth2Admin)
+
+| 项目 | 值 |
+|------|-----|
+| 容器名 | fulla-admin |
+| 构建 | frontends/admin/Dockerfile |
+| 基础镜像 | nginx:alpine |
+| 内部端口 | 80 |
+| 访问路径 | `https://your-domain.com/admin/` |
+| 功能 | 应用管理、用户管理、角色/Scope/Token 管理 |
+
+### 后端 API (fulla-server)
+
+| 项目 | 值 |
+|------|-----|
+| 容器名 | fulla-backend |
+| 构建 | Dockerfile (target: backend-runtime) |
+| 基础镜像 | ubuntu:22.04 (minimal) |
+| 内部端口 | 5555 |
+| 访问路径 | `https://your-domain.com/api/*`, `/oauth2/*` |
+| 数据库迁移 | 启动时自动执行（FULLA_AUTO_MIGRATE=true） |
+
+### 基础设施
+
+| 服务 | 镜像 | 用途 |
+|------|------|------|
+| fulla-postgres | postgres:17-alpine | 主数据库 |
+| fulla-redis | redis:7-alpine | Token 缓存 |
+| oauth2-nginx | nginx:stable-alpine | TLS 终止 + 反向代理 |
+| fulla-prometheus | prom/prometheus | 监控指标采集 |
+
+---
+
+## 配置说明
+
+### 后端配置 (config.prod.json)
+
+后端通过环境变量覆盖配置文件中的值（优先级：`.env` 文件 > 系统环境变量 > `config.prod.json` 默认值）：
+
+| 环境变量 | 用途 | 默认值 |
+|----------|------|--------|
+| `FULLA_ENV` | 运行模式（`production` 启用 HTTPS issuer + 强密码严格校验） | development |
+| `FULLA_ISSUER` | JWT issuer（生产必须 `https://`） | http://localhost:5555 |
+| `FULLA_JWT_KEY_PATH` | JWT 签名密钥文件路径 | /app/keys/signing.pem |
+| `FULLA_SIGNING_KEY` | JWT 密钥 PEM 内容（与 `JWT_KEY_PATH` 二选一） | (可选) |
+| `FULLA_DB_HOST` | PostgreSQL 主机 | postgres |
+| `FULLA_DB_PORT` | PostgreSQL 端口 | 5432 |
+| `FULLA_DB_NAME` | 数据库名 | fulla_db_prod |
+| `FULLA_DB_USER` | 数据库用户 | fulla_user |
+| `FULLA_DB_PASSWORD` | 数据库密码 | (必须设置) |
+| `FULLA_REDIS_HOST` | Redis 主机 | redis |
+| `FULLA_REDIS_PORT` | Redis 端口 | 6379 |
+| `FULLA_REDIS_PASSWORD` | Redis 密码 | (必须设置) |
+| `FULLA_LISTEN_PORT` | 后端监听端口 | 5555 |
+| `FULLA_FRONTEND_URL` | 前端 URL（用于重定向等） | http://localhost:5173 |
+| `FULLA_CORS_ALLOW_ORIGINS` | CORS 允许的源（逗号分隔，覆盖 JSON 数组） | config 中的 localhost 列表 |
+| `FULLA_VUE_REDIRECT_URI` | vue-client OAuth 回调 URI | config 中的 localhost 值 |
+| `FULLA_GOOGLE_REDIRECT_URI` | Google OAuth 回调 URI | config 中的 localhost 值 |
+| `FULLA_VUE_CLIENT_SECRET` | vue-client 密钥 | 123456 |
+| `FULLA_AUTO_MIGRATE` | 自动执行数据库迁移 | true |
+| `DETAILED_VALIDATION_ERRORS` | 是否返回字段级校验错误（生产建议 false） | false |
+| `FULLA_GITHUB_CLIENT_ID` / `FULLA_GITHUB_CLIENT_SECRET` | GitHub OAuth（可选） | (空) |
+| `FULLA_GOOGLE_CLIENT_ID` / `FULLA_GOOGLE_CLIENT_SECRET` | Google OAuth（可选） | (空) |
+| `FULLA_SMTP_HOST` | SMTP 服务器主机（未设置则邮件走 Console 模式） | (可选) |
+| `FULLA_SMTP_PORT` | SMTP 端口 | 465 |
+| `FULLA_SMTP_USER` | SMTP 用户名（完整邮箱地址） | (可选) |
+| `FULLA_SMTP_PASSWORD` | SMTP 授权码（非邮箱登录密码） | (可选) |
+| `FULLA_SMTP_FROM_NAME` | 发件人显示名称 | OAuth2 Platform |
+| `FULLA_SMTP_SSL` | 是否启用 SSL | true |
+
+> **邮件模式说明**：仅当 `FULLA_SMTP_HOST` + `FULLA_SMTP_USER` + `FULLA_SMTP_PASSWORD` 三项均非空时启用真实 SMTP 发送；否则邮件只输出到后端日志。详见上文"邮件服务（SMTP）配置说明"。
+>
+> **CORS 数组覆盖**：`FULLA_CORS_ALLOW_ORIGINS` 是逗号分隔的字符串（如 `https://a.com,https://b.com`），后端启动时自动分割成 JSON 数组覆盖 `config.prod.json` 的 `custom_config.cors.allow_origins`。CORS 校验代码要求该字段是数组，因此**必须**用逗号分隔形式，不要写成 JSON 数组字面量。
+
+### Nginx 配置
+
+`deploy/nginx/nginx.conf` 包含：
+- HTTP → HTTPS 自动重定向
+- TLS 1.2/1.3 配置
+- 限流规则（登录 5次/分钟/IP，API 30次/秒/IP）
+- `/metrics` 端点限制内网访问
+- HSTS 头
+
+### 前端配置
+
+前端（用户端 OAuth2Frontend）通过 Vite 环境变量配置，**在镜像构建时注入**到 SPA bundle（不是运行时读取）。`docker-compose.prod.yml` 的 `fulla-frontend.build.args` 从 `.env.docker` 透传这些变量，`Dockerfile` 的 `frontend-builder` 阶段用 `ARG`/`ENV` 暴露给 Vite。
+
+| 变量 | 用途 | 生产值 |
+|------|------|--------|
+| `VITE_API_BASE_URL` | API 基础 URL | **(空)** — SPA 同域走相对路径，填值会破坏 nginx 反代路由 |
+| `VITE_CLIENT_ID` | OAuth2 Client ID | vue-client |
+| `VITE_REDIRECT_URI` | OAuth2 回调 URI | https://your-domain.com/callback |
+| `VITE_GITHUB_CLIENT_ID` | GitHub "Sign in with GitHub" 按钮（可选） | (空则不显示按钮) |
+
+> **管理后台（OAuth2Admin）无需配置**：源码不读取任何 `import.meta.env`，所有 API 调用走相对路径 `/api/admin/*`，由 nginx 反代到后端。改域名时只需保证 nginx `/admin/` 路由正确，无需重建 admin 镜像。
+>
+> **改域名需重建前端镜像**：由于 VITE 变量在构建期固化，更换域名后必须 `docker compose ... up -d --build fulla-frontend`（管理后台不受影响）。
+
+---
+
+## 数据库初始化
+
+首次部署时，后端会自动执行数据库迁移（`FULLA_AUTO_MIGRATE=true`）。
+
+如需手动初始化：
+
+```bash
+# 进入 postgres 容器
+docker exec -it fulla-postgres psql -U fulla_user -d fulla_db
+
+# 或从宿主机执行迁移
+docker exec -it fulla-postgres sh -c '
+  for f in /docker-entrypoint-initdb.d/migrations/V*.sql; do
+    psql -U fulla_user -d fulla_db -f "$f"
+  done
+'
+```
+
+### 创建管理员账号
+
+首次部署后，执行 seed 脚本创建默认管理员：
+
+```bash
+# 验证 seed 文件存在
+ls apps/server/seed/dev_*.sql || echo "错误：Seed 文件缺失，请检查项目结构"
+
+# 创建管理员账号
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_user.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_admin_console_client.sql
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < apps/server/seed/dev_vue_client.sql
+```
+
+**重要**：生产环境部署后立即修改 admin 密码！
+
+---
+
+## 性能调优（推荐配置）
+
+> 本节是官方推荐的生产性能基线（分析依据为维护者基准档案，关键结论与实测
+> 数据已直接收录本节）。
+> 基准测试以本节配置为准——写进本节的配置即"官方配置"。
+
+### 1. 开启 Redis L2 缓存（吞吐档推荐，须配套扩容 Redis 连接池）
+
+读路径（introspect / userinfo 的 token 查询、client 查询）命中 Redis，不再落到
+PostgreSQL。`config.prod.json` 出厂保持关闭（`cache.enabled: false`）——开启前
+**必须**同步扩容 `redis_clients[0].number_of_connections`（见下方实测数据）：
+
+```json
+"cache": {
+    "enabled": true,
+    "redis_client_name": "default",
+    "ttl_seconds": {
+        "client": 300,
+        "access_token_max": 60
+    }
+}
+```
+
+语义说明：token 缓存 TTL 不超过 60s 且吊销即时失效（含负缓存）；client
+缓存 TTL 300s。要求部署内 Redis 可用（生产 compose 已含 fulla-redis）。
+多实例部署注意：写路径失效的 Redis DEL 对全实例即时生效，但 userinfo 的
+进程内 piggyback memo（2s 一次性）只在处理写请求的那台实例被同步清除，
+其它实例最长滞后 2s（TTL 自兜底，可接受）。
+
+**实测（2026-08-18 基准环境，10s 快测）**：cache on + Redis 池 20 时 S6 反而
+-18%（池排队）；Redis 池扩到 64 后 S2 +39%、S3 +59%、S6 +6%。结论：**cache
+收益以 Redis 池 ≥ 预期并发为前提**，出厂默认关闭 + 本节指引是安全姿势。
+另注意：introspect 的正向缓存受 N2 判别器约束（仅在 token 走过发放/校验
+路径后才回填），S3 的收益主要来自 client 缓存与 PG 调优。
+
+### 2. PostgreSQL 实例调优
+
+出厂默认（`shared_buffers=128MB`、`checkpoint_timeout=5min`、
+`max_wal_size=1GB`）面向小内存机器，在高频写入下产生周期性 checkpoint
+刷盘尖峰。为 16GB / 8 vCPU 主机推荐的调优（按内存等比缩放
+`shared_buffers` ≈ 25% RAM）：
+
+```yaml
+  fulla-postgres:
+    command:
+      - postgres
+      - -c
+      - shared_buffers=4GB
+      - -c
+      - effective_cache_size=12GB
+      - -c
+      - work_mem=16MB
+      - -c
+      - checkpoint_timeout=15min
+      - -c
+      - max_wal_size=4GB
+      - -c
+      - min_wal_size=1GB
+      - -c
+      - wal_compression=on
+      - -c
+      - checkpoint_completion_target=0.9
+      - -c
+      - autovacuum_vacuum_insert_scale_factor=0.02
+      - -c
+      - autovacuum_vacuum_scale_factor=0.02
+```
+
+该配置为基准环境实测采用的形态，完整可运行示例见
+`benchmarks/fulla/docker-compose.bench.yml`（bench overlay，叠加在
+`deploy/docker/docker-compose.yml` 之上）。纯 conf 调优对现有数据卷无
+兼容性影响，可随时启用/回退。**注**：bench overlay 已将 `shared_buffers`
+调至 1GB（2026-08-22 三臂 A/B 验证与 4GB 等效）；上表 4GB 仍为 16GB 主机的
+PG 官方推荐起点。
+
+**版本与升级注记**：deploy compose 自 2026-08-18 起使用 `postgres:17-alpine`
+（与客户端 libpq 17.x 对齐，基准在 17 上实测）。**存量 15 版数据卷不能直接
+在 17 上启动**（大版本数据目录不兼容）——升级前先 `pg_dump`/`pg_restore`
+或用 `pg_upgrade`；全新部署无此步骤。
+
+### 3. 会话留存（session_timeout）——按 API 流量调尺寸
+
+**要点**：`enable_session: true` 时，Drogon 框架层为每个不带会话 cookie 的
+请求创建 Session 并持有到 `session_timeout` 到期（上游
+[drogon#278](https://github.com/an-tao/drogon/issues/278) 行为，本仓 2026-08-22
+实测验证）。API 流量（从不带 cookie）按请求付费：**每请求约留存 750 B**
+（`API_QPS × session_timeout × 750 B`），且对所有端点存在约 -54% 的吞吐税。
+
+**留存公式、尺寸速查表与分档指引**（交互型低于 100 QPS 保持默认 3600s；API
+型按表调低；基准档 30s）的完整版见
+[会话管理 · 尺寸速查](../domains/session-management.md)——该文档是此主题的
+单一出处，本节只保留运维要点。
+
+### 4. Docker 网络拓扑（原生引擎可选；Docker Desktop 下不可用）
+
+若使用**原生 Docker Engine**（Linux 服务器直装），可将 backend + PG + redis
+置于 `network_mode: host`：backend↔PG/Redis 走 loopback，省去每包 veth 穿越。
+
+**Docker Desktop（WSL2 集成）下不要使用**（2026-08-18 实测）：`host` 是引擎
+VM 的 netns 而非发行版的 netns，host 模式监听端口对发行版完全不可达
+（127.0.0.1、共享 eth0 IP、host.docker.internal 均超时；仅发布端口被转发）。
+基准环境因此保持 bridge + 发布端口拓扑，四产品一致（公平性不受影响）。
+
+跨机部署（nginx 前置、独立 DB）不受此项影响。
+
+---
+
+## 运维操作
+
+### 查看日志
+
+```bash
+# 所有服务
+docker compose -f deploy/docker/docker-compose.prod.yml logs -f
+
+# 单个服务
+docker compose -f deploy/docker/docker-compose.prod.yml logs -f fulla-backend
+docker compose -f deploy/docker/docker-compose.prod.yml logs -f nginx
+```
+
+### 重启服务
+
+```bash
+# 重启单个服务
+docker compose -f deploy/docker/docker-compose.prod.yml restart fulla-backend
+
+# 重建并重启（代码更新后）
+docker compose -f deploy/docker/docker-compose.prod.yml up -d --build fulla-backend
+docker compose -f deploy/docker/docker-compose.prod.yml up -d --build fulla-frontend
+docker compose -f deploy/docker/docker-compose.prod.yml up -d --build fulla-admin
+```
+
+### 更新部署
+
+```bash
+git pull
+docker compose -f deploy/docker/docker-compose.prod.yml up -d --build
+```
+
+### 数据库备份
+
+```bash
+# 备份
+docker exec fulla-postgres pg_dump -U fulla_user fulla_db > backup_$(date +%Y%m%d).sql
+
+# 恢复
+docker exec -i fulla-postgres psql -U fulla_user -d fulla_db < backup_20260526.sql
+```
+
+### 监控
+
+- Prometheus: `http://your-server:9090`
+- 后端指标: `https://your-domain.com/metrics`（仅内网可访问）
+- 健康检查: `https://your-domain.com/health`
+
+---
+
+## 故障排除
+
+### 容器启动失败
+
+```bash
+# 查看容器状态
+docker compose -f deploy/docker/docker-compose.prod.yml ps
+
+# 查看失败容器日志
+docker compose -f deploy/docker/docker-compose.prod.yml logs fulla-backend
+```
+
+### 数据库连接失败
+
+```bash
+# 检查 postgres 是否就绪
+docker exec fulla-postgres pg_isready -U fulla_user
+
+# 检查网络连通性
+docker exec fulla-backend curl -s http://fulla-postgres:5432 || echo "Cannot reach postgres"
+```
+
+### 证书问题
+
+```bash
+# 检查证书是否存在
+ls -la deploy/nginx/ssl/
+
+# 检查证书有效期
+openssl x509 -in deploy/nginx/ssl/fullchain.pem -noout -dates
+```
+
+### 前端 404
+
+如果前端页面刷新后 404，检查 nginx.conf 中的 SPA fallback 配置：
+- OAuth2Frontend: `try_files $uri $uri/ /index.html`
+- OAuth2Admin: `try_files $uri $uri/ /admin/index.html`
+
+---
+
+## 安全清单
+
+- [ ] 所有密码使用强随机值（`openssl rand -base64 32`）
+- [ ] TLS 证书有效且自动续期
+- [ ] `.env.docker` 文件权限设为 600
+- [ ] `deploy/keys/signing.pem` 权限设为 600
+- [ ] 首次部署后修改 admin 默认密码
+- [ ] Prometheus 端口 9090 不对外暴露（或加认证）
+- [ ] 定期备份数据库
+- [ ] 监控磁盘空间（日志、数据库）

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/docker-deployment.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/docker-deployment.md
@@ -1,0 +1,243 @@
+# Docker 部署与容器编排指南 (Docker Deployment)
+
+本文档详细说明如何使用 Docker Compose 在本地或生产环境部署完整的 OAuth2 服务栈。
+
+---
+
+## 1. 服务栈架构
+
+`docker-compose.yml` 编排以下 6 个服务：
+
+```
+Internet
+    │
+    │ :8080 / :8081
+    ▼
+┌────────────────────────┐   ┌────────────────────────┐
+│  fulla-frontend        │   │  fulla-admin           │
+│  Vue 用户前端 (Nginx)  │   │  管理后台前端 (Nginx)  │
+│  Port: 8080            │   │  Port: 8081            │
+└───────────┬────────────┘   └───────────┬────────────┘
+            │         内网               │
+            └────────────┬───────────────┘
+                         ▼
+            ┌────────────────────────┐
+            │  fulla-backend         │
+            │  Drogon 后端 :5555     │
+            │  → postgres → redis    │
+            └───────────┬────────────┘
+                   ┌────┴─────┐
+                   ▼          ▼
+              postgres      redis
+              (5433:5432)   (6380:6379)
+
+              prometheus (9090:9090)
+```
+
+| 服务 | 镜像/构建 | 对外端口 | 说明 |
+|---|---|---|---|
+| `fulla-frontend` | `deploy/docker/Dockerfile` (`frontend-runtime`) | `8080:80` | Vue SPA (用户端) + Nginx |
+| `fulla-admin` | `frontends/admin/Dockerfile` | `8081:80` | 管理后台前端 |
+| `fulla-backend` | `deploy/docker/Dockerfile` (`backend-runtime`) | `5555:5555` | Drogon C++ 后端 |
+| `fulla-postgres` | `postgres:17-alpine` | `5433:5432` | PostgreSQL（宿主机 5433，避开本地冲突）|
+| `fulla-redis` | `redis:7-alpine` | `6380:6379` | Redis（宿主机 6380，避开本地冲突）|
+| `fulla-prometheus` | `prom/prometheus:latest` | `9090:9090` | 指标采集 |
+
+---
+
+## 2. 快速启动
+
+详见 [Docker 容器和镜像规范指南](#镜像--容器--网络命名规范)。
+
+```bash
+# 第一次或代码变更后：重新构建并启动（在项目根目录执行）
+docker-compose -f deploy/docker/docker-compose.yml up -d --build
+
+# 后续启动（无代码变更）
+docker-compose -f deploy/docker/docker-compose.yml up -d
+
+# 查看服务状态
+docker-compose -f deploy/docker/docker-compose.yml ps
+
+# 实时查看后端日志
+docker-compose -f deploy/docker/docker-compose.yml logs -f fulla-backend
+
+# 停止所有服务
+docker-compose -f deploy/docker/docker-compose.yml down
+
+# 停止并删除数据卷（数据库会被清空）
+docker-compose -f deploy/docker/docker-compose.yml down -v
+```
+
+---
+
+## 3. 环境变量与密钥注入
+
+`fulla-backend` 在 `docker-compose.yml` 的 `environment` 节中通过环境变量注入敏感配置，**完全覆盖 `config.json` 中的默认值**。开发环境默认值（仅用于本地评估）如下：
+
+```yaml
+environment:
+  - FULLA_DB_HOST=fulla-postgres         # 指向 Docker 内网的 postgres 服务名
+  - FULLA_DB_NAME=fulla_db
+  - FULLA_DB_PASSWORD=123456
+  - FULLA_REDIS_HOST=fulla-redis
+  - FULLA_REDIS_PASSWORD=redis_secret_pass
+  - FULLA_VUE_CLIENT_SECRET=123456
+  - FULLA_AUTO_MIGRATE=true               # 启动时自动执行 apps/server/migrations
+  - FULLA_FRONTEND_URL=http://localhost:8080
+  # SMTP 配置经 ${FULLA_SMTP_*:-} 占位从 .env.docker 注入；留空则回退到控制台模式
+  - FULLA_SMTP_HOST=${FULLA_SMTP_HOST:-}
+  ...
+```
+
+> **WARNING** **生产环境安全提示**：
+> - **禁止**将真实密码直接写在 `docker-compose.yml` 中并提交到 Git。
+> - 推荐使用 **Docker Secrets** 或外部密钥管理（Vault、AWS Secrets Manager）。
+> - 最低要求：使用 `.env` 文件，并将其加入 `.gitignore`。
+
+### 使用 `.env` 文件（推荐）
+
+仓库提供了示例文件 `deploy/env/docker.env.example`（以及 `deploy/env/server.env.example`）。复制为 `.env.docker`（已在 `.gitignore` 中排除）并填入生产值：
+
+```env
+FULLA_DB_PASSWORD=your_strong_password
+FULLA_REDIS_PASSWORD=your_redis_password
+FULLA_VUE_CLIENT_SECRET=your_client_secret
+# SMTP（留空则后端回退到控制台模式）
+FULLA_SMTP_HOST=
+FULLA_SMTP_PORT=465
+...
+```
+
+然后 `docker-compose.yml` 中通过 `${VAR_NAME:-default}` 引用即可。
+
+---
+
+## 4. 数据持久化
+
+通过命名 Volume 实现数据持久化，容器重启不丢数据：
+
+```yaml
+volumes:
+  pgdata:    # PostgreSQL 数据文件
+  redisdata: # Redis RDB / AOF 文件
+```
+
+数据库初始化由后端在启动时自动完成（`FULLA_AUTO_MIGRATE=true`，按文件名顺序执行 `apps/server/migrations/V*.sql`，再执行 `apps/server/seed/*.sql`）。`docker-compose.yml` 同时把迁移与种子脚本挂进 postgres 容器的子目录：
+
+```yaml
+volumes:
+  - ../../apps/server/migrations:/docker-entrypoint-initdb.d/migrations:ro
+  - ../../apps/server/seed:/docker-entrypoint-initdb.d/seed:ro
+```
+
+> **WARNING** **注意**：postgres entrypoint **不会**递归进入 `/docker-entrypoint-initdb.d` 的子目录，因此这两个挂载对首次初始化是 **no-op**，真正的 schema 初始化由后端的 `FULLA_AUTO_MIGRATE` 完成。
+
+---
+
+## 5. Prometheus 监控配置
+
+`prometheus.yml` 配置 Prometheus 采集 `fulla-backend` 的 `/metrics` 端点：
+
+```yaml
+scrape_configs:
+  - job_name: "fulla-backend"
+    static_configs:
+      - targets: ["fulla-backend:5555"]
+```
+
+Prometheus 与 fulla-backend 位于同一 Docker 网络 `oauth2-net`，使用服务名直接访问（无需暴露宿主机端口）。
+
+访问 `http://localhost:9090` 即可查看 Prometheus UI。
+
+---
+
+## 6. 生产部署建议
+
+### 6.1 在 Nginx 前端服务添加 SSL 终结
+
+前端 `fulla-frontend` 的 Nginx 负责静态文件托管，应在其前面增加一层带 SSL 的 Nginx/Traefik：
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name your-domain.com;
+
+    ssl_certificate     /etc/ssl/certs/cert.pem;
+    ssl_certificate_key /etc/ssl/private/key.pem;
+
+    location / {
+        proxy_pass http://fulla-frontend:80;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location /api/ {
+        proxy_pass http://fulla-backend:5555;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+> **重要**：转发 `X-Forwarded-For` 头，确保后端的 Hodor 插件能正确获取真实客户端 IP。
+
+### 6.2 屏蔽 `/metrics` 端点
+
+Prometheus `/metrics` 端点不应暴露到公网，在 Nginx 中添加：
+
+```nginx
+location /metrics {
+    deny all;
+}
+```
+
+或通过 Docker 不对外暴露 `fulla-backend:5555`，仅允许 Prometheus 内网访问。
+
+### 6.3 数据库连接池调优
+
+生产环境建议将 `config.prod.json` 的 `number_of_connections` 从 `4` 调整为 `10-50`，根据实际并发量测试确定。
+
+---
+
+## 7. 健康检查与故障排查
+
+```bash
+# 检查所有容器状态
+docker-compose ps
+
+# 检查后端服务是否可达
+curl http://localhost:5555/metrics
+
+# 查看数据库是否已初始化
+docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "\dt"
+
+# 查看 Redis 连接
+docker exec -it fulla-redis redis-cli -a redis_secret_pass ping
+
+# 清理并重建（数据会丢失）
+docker-compose down -v
+docker-compose up -d --build
+```
+
+## 镜像 / 容器 / 网络命名规范
+
+| 镜像用途 | 名称 | 构建目标 | 说明 |
+|---------|------|--------------------|------|
+| 生产后端 | `fulla-backend` | `backend-runtime` | 仅运行时，体积小；GHCR 多架构发布 |
+| 调试后端 | `fulla-backend-debug` | `backend-dev` | 含完整编译工具链 |
+| 生产前端 | `fulla-frontend` | `frontend-runtime` | Nginx + 静态资源 |
+
+容器命名：`fulla-{service}[-debug]`（backend/frontend/postgres/redis）；网络：Release 为 `oauth2-net`，Debug 为 `fulla-debug-net`（历史保留名见 compose 文件）。三份 compose 矩阵：`docker-compose.yml`（开发，6 服务）、`docker-compose.debug.yml`（调试，3 服务）、`docker-compose.prod.yml`（生产，8 服务含 Nginx 与 migrate 作业）。**所有 compose 命令在仓库根目录执行并带 `-f deploy/docker/...`**。
+
+## 调试环境（挂载源码 / GDB）
+
+```bash
+docker build -f deploy/docker/Dockerfile --target backend-dev -t fulla-backend-debug:v1.0.0 .
+docker compose -f deploy/docker/docker-compose.debug.yml up -d
+docker compose -f deploy/docker/docker-compose.debug.yml run --rm debug-env bash
+```
+
+## 自动化验证
+
+- `deploy/docker/docker-quick-verify-debug.sh`（容器内全流程：依赖检查 → 等 PG/Redis 就绪 → 建库 → 并行编译 → 单测）；
+- `scripts/backend/full_test_docker.bat`（宿主一键：起容器 → 初始化 → ORM 重生成 → 编译 → 测试 → 起服 → OAuth2/Admin 端点测试 → 清理）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/observability.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/observability.md
@@ -1,0 +1,99 @@
+# OAuth2 可观测性设计文档 (Observability)
+
+本系统集成了完整的 Prometheus 监控指标与结构化上下文日志，支持生产环境的实时监控与问题排查。
+
+## 1. Prometheus Metrics
+
+系统通过 Exporter 暴露标准的 Prometheus 指标。
+
+### 1.1 指标列表
+
+| 指标名称 | 类型 | 标签 (Labels) | 说明 |
+|----------|------|--------------|------|
+| `oauth2_requests_total` | Counter | `endpoint`, `status` | OAuth2 请求总数 |
+| `oauth2_login_failures_total` | Counter | `reason` | 登录失败次数 |
+| `oauth2_introspect_requests_total` | Counter | `client_id` | Token Introspection 请求总数 |
+| `oauth2_introspect_errors_total` | Counter | `client_id`, `error` | Introspection 错误次数 |
+| `oauth2_revocation_requests_total` | Counter | `client_id` | Token Revocation 请求总数 |
+| `oauth2_revocation_errors_total` | Counter | `client_id`, `error` | Revocation 错误次数 |
+| `oauth2_latency_seconds` | Histogram | `operation`, `storage` | 关键步骤（含存储后端）耗时分布 |
+| `oauth2_active_tokens` | Gauge | — | 当前活跃（未过期）Token 估算值 |
+
+> 指标由 `libs/drogon/src/observability/Metrics.cc` 与 `libs/drogon/src/adapters/DrogonMetrics.cc` 统一发射（经 `LOG_INFO` 的 `[METRIC]` 结构化日志，供 PromExporter/日志采集端消费），定义见 `libs/drogon/include/fulla/drogon/observability/Metrics.h`。
+
+### 1.2 监控面板示例 (Grafana)
+
+建议配置以下面板：
+
+- **QPS & Error Rate**: `rate(oauth2_requests_total[1m])` vs `rate(oauth2_login_failures_total[1m])`
+- **P99 Latency**: `histogram_quantile(0.99, rate(oauth2_latency_seconds_bucket[1m]))`
+- **Business**: Active Tokens trend.
+
+## 2. Structured Logging (结构化日志)
+
+系统采用上下文感知的结构化日志，便于 Splunk/ELK 收集分析。
+
+### 2.1 Audit Logs (审计日志)
+
+关键安全操作（如颁发 Token）会输出带有 `[AUDIT]` 标记的日志。
+
+**格式**:
+`[AUDIT] Action={Action} User={UserId} Client={ClientId} Success={True/False} IP={RemoteAddr}`
+
+**示例**:
+
+```
+2026-01-18 10:00:00 INFO [AUDIT] Action=IssueToken User=admin Client=vue-client Success=True
+2026-01-18 10:05:00 WARN [AUDIT] Action=ExchangeCode User=admin Client=vue-client Success=False Reason="Replay Detected"
+```
+
+### 2.2 Contextual Logs (上下文日志)
+
+在请求处理链路中，所有日志自动附带 `RequestId`，用于关联分布式追踪。
+
+```cpp
+LOG_INFO << "Processing request"; // 输出: [ReqId: abc-123] Processing request
+```
+
+## 3. 配置与集成
+
+### 3.1 开启 Metrics
+
+默认情况下，Metrics Exporter 监听 `/metrics` 端点（需在 Drogon 配置文件中开启 Exporter）。
+
+### 3.2 日志级别
+
+系统统一使用六级日志，等级与 Drogon/Trantor 的内置级别一一对应（trace < debug < info < warn < error < fatal）：
+
+| 等级 | 含义 | 典型场景 |
+|------|------|----------|
+| `trace` | 最细粒度追踪 | 函数入参 / 出参、循环迭代、逐行执行轨迹，用于深度调试定位 |
+| `debug` | 调试信息 | 变量值、分支走向、内部状态变化，开发阶段排查问题用 |
+| `info` | 常规信息 | 服务启动 / 停止、关键流程节点、用户登录、任务完成等正常业务事件 |
+| `warn` | 警告 | 可恢复的异常、降级处理、配置使用默认值、资源接近阈值等，系统仍能正常运行 |
+| `error` | 错误 | 功能失败、请求异常、数据库连接失败等，影响单次操作但服务整体可用 |
+| `fatal` | 致命错误 | 导致服务崩溃、无法继续运行的严重故障，需立即告警并人工介入 |
+
+**约定**：
+
+- 生产环境默认开启 `info` 及以上级别；`trace`/`debug` 按需动态开启。
+- 等级越高输出越少，`fatal` 应极少出现。
+- `apps/server/config/config.prod.json` 默认为 `INFO`，`config.dev.json` 默认为 `DEBUG`，`config.json`/`config.ci.json` 默认为 `DEBUG`。
+
+**动态调整**：修改配置文件 `app.log.log_level` 字段即可，可选值为 `TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`（不区分大小写）：
+
+```json
+"app": {
+    "log": {
+        "log_level": "INFO"
+    }
+}
+```
+
+**代码约定**：
+
+- Domain 层（`libs/common`、`libs/oauth2`、`libs/identity`）**不得**直接使用 Drogon 的 `LOG_*` 宏，必须经 `fulla::common::ports::ILogger` 端口，以便单元测试可用 `FakeLogger` 捕获并断言。
+- Adapter / 基础设施层（`libs/drogon`、`libs/storage-*`、`apps/server`）可直接使用 `LOG_*` 宏。
+- 六级对应关系：`LogLevel::Trace`→`LOG_TRACE`、`Debug`→`LOG_DEBUG`、`Info`→`LOG_INFO`、`Warn`→`LOG_WARN`、`Error`→`LOG_ERROR`、`Fatal`→`LOG_FATAL`。
+
+> 关于测试输出的最小化策略（ctest 默认仅打印失败用例与汇总），见 [testing-guide.md](../contribute/testing-guide.md)。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/postgresql-major-upgrade.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/postgresql-major-upgrade.md
@@ -1,0 +1,133 @@
+# PostgreSQL 大版本升级 Runbook（15 → 17）
+
+> 适用范围：使用本仓库 `deploy/docker/docker-compose.prod.yml`（或 Helm chart）
+> 且带**持久数据卷**的存量部署。PG 大版本**拒绝挂载**旧版本的数据目录——
+> 直接 `docker compose up`（镜像已升到 `postgres:17-alpine`）会导致数据库容器
+> 循环重启，数据不会损坏但服务不可用。升级前必须走本 runbook。
+>
+> 全新部署无此问题（17 数据目录由初始化直接生成）。
+>
+> Fulla 自身在 PG 15 vs 17 的基准差异在噪声带内（2026-08-18 A/B 实测），
+> 升级动机是与服务端 libpq 17.x 客户端对齐及基准环境一致性，**没有吞吐诉求**。
+> 不急于升级的部署可以继续用 15 跑（把 compose 里的镜像 tag 钉回
+> `postgres:15-alpine` 即可，与应用兼容）。
+
+## 路线选择
+
+| 路线 | 停机窗口 | 适用 |
+|---|---|---|
+| A. dump/restore（推荐） | 与数据量成正比（GB 级通常分钟级） | 中小数据量；操作简单、可交叉验证 |
+| B. pg_upgrade（原地） | 通常 &lt;1 分钟 | 大数据量（数十 GB+）不想长停机 |
+
+两条路线都要求：**升级前完成一次全量备份并保留旧数据卷**，验证通过后再清理。
+
+## 路线 A：dump/restore（推荐）
+
+以 prod compose 为例（凭据来自 `.env`：`POSTGRES_USER`/`POSTGRES_PASSWORD`/
+`POSTGRES_DB`；compose project 名以实际为准，下同）。
+
+### 1. 停应用、留旧库
+
+```bash
+cd deploy/docker
+docker compose -f docker-compose.prod.yml stop fulla-backend
+# 旧 PG（15）保持运行，用它导出
+```
+
+### 2. 全量导出
+
+```bash
+docker compose -f docker-compose.prod.yml exec -T fulla-postgres \
+  pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --no-owner --no-privileges \
+  > backup_pg15_$(date +%Y%m%d).sql
+# 校验导出文件非空且含表结构
+grep -c "CREATE TABLE" backup_pg15_*.sql
+```
+
+### 3. 切换数据卷
+
+```bash
+docker compose -f docker-compose.prod.yml down
+# 重命名旧卷留底（project 名按实际替换；默认 project 名 = 目录名）
+docker volume rm <project>_pgdata 2>/dev/null || true
+# 更稳妥：先改名留底而不是删除
+#   docker run --rm -v <project>_pgdata:/src -v /var/backups:/dst alpine \
+#     cp -a /src /dst/pgdata_pg15_backup
+```
+
+> 简化写法：也可以直接 `docker volume rm` 旧卷——前提是步骤 2 的 dump 文件
+> 已安全存放在宿主机并校验过。留底副本是给"验证失败回滚"用的保险。
+
+### 4. 启动 17 并导入
+
+```bash
+docker compose -f docker-compose.prod.yml up -d fulla-postgres
+# 等健康检查通过后导入
+docker compose -f docker-compose.prod.yml exec -T fulla-postgres \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+  < backup_pg15_$(date +%Y%m%d).sql 2>&1 | grep -i "error\|fatal" || echo "IMPORT CLEAN"
+```
+
+> 服务端配置了启动自动迁移（`FULLA_AUTO_MIGRATE=true` 时），导入旧 schema 后
+> 首次启动会自动补齐新增迁移（V025 分区等，幂等）。
+
+### 5. 验证后放流量
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+curl -fsS http://<backend>/health/ready
+```
+
+按 [verification-checklist.md](../operate/verification-checklist) 走一遍核心路径
+（登录 → 授权码 → token → introspect → userinfo）。通过后保留 dump 文件与
+旧卷留底至少一个回归周期，再清理。
+
+## 路线 B：pg_upgrade（原地，大数据量）
+
+pg_upgrade 需要同时存在新旧两套 binary 与数据目录。容器化下的最省事做法是
+官方 `postgres:17` 镜像内置的 `/usr/local/bin/pg_upgrade`（alpine 镜像不含，
+需用非 alpine tag 或自行挂载工具镜像）：
+
+```bash
+# 1) 停应用与旧库
+docker compose -f docker-compose.prod.yml stop fulla-backend fulla-postgres
+
+# 2) 复制旧数据卷到新卷（pg_upgrade --link 可省空间但有损坏回滚风险，不默认）
+docker run --rm -v <project>_pgdata:/old -v <project>_pgdata17:/new alpine \
+  cp -a /old /new
+
+# 3) 用 17 镜像对新副本执行 pg_upgrade（旧目录只读挂载）
+docker run --rm \
+  -v <project>_pgdata:/var/lib/postgresql/15 \
+  -v <project>_pgdata17:/var/lib/postgresql/17 \
+  -e POSTGRES_USER=$POSTGRES_USER postgres:17 \
+  bash -c 'install -d /var/lib/postgresql/17.tmp && gosu postgres pg_upgrade \
+    -b /usr/lib/postgresql/15/bin -B /usr/local/bin \
+    -d /var/lib/postgresql/15 -D /var/lib/postgresql/17 \
+    -U "$POSTGRES_USER"'
+# 注：postgres:17 非 alpine 镜像内含 15 的 binary（多版本包），命令按镜像实际
+# 路径调整；上述为骨架，执行前先在测试环境演练一遍。
+
+# 4) 把 compose 的 pgdata 卷指向升级后的卷（或交换卷名），up -d，验证同路线 A。
+```
+
+pg_upgrade 成功后按提示执行 `vacuumdb --all --analyze`（或等自动 analyze）。
+
+## Helm 部署
+
+Chart 内置 PostgreSQL 的镜像 tag 在 `deploy/helm/fulla/values.yaml`
+（`postgresql.image`）。有状态集的 PVC 同样是大版本绑定的数据目录：
+
+1. `kubectl scale deploy/fulla --replicas=0`（停应用）；
+2. 按上面任一路线导出/升级 PVC 中的数据；
+3. 更新 values 后 `helm upgrade`，验证就绪后恢复副本。
+
+外接数据库（自管 PG / RDS 类）的部署不涉及本仓库配置，走云厂商或 DBA 的
+大版本升级流程即可。
+
+## 回滚
+
+- 路线 A：`down` → 恢复旧卷留底（或恢复 `postgres:15-alpine` tag + 原卷）→
+  `up -d`。应用镜像与 PG 15 兼容（libpq 17 客户端连 15 服务端没有问题）。
+- 路线 B：旧卷未被修改（只读挂载），换回即可。
+- 已在新库写入新数据后回滚会丢这部分数据——回滚决策要在放流量验证之前做。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/verification-checklist.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/verification-checklist.md
@@ -1,0 +1,1001 @@
+# 部署验证清单
+
+本文档提供完整的部署验证步骤，确保 fulla 全栈系统在 Windows Docker Desktop 或 Linux 生产环境上正确运行。
+
+---
+
+## 快速验证（5 分钟）
+
+### 1. 检查所有容器状态
+
+```powershell
+# Windows
+docker compose -f deploy/docker/docker-compose.yml ps
+
+# Linux
+docker compose -f deploy/docker/docker-compose.prod.yml --env-file .env.docker ps
+```
+
+**预期结果**：所有容器状态为 `Up` 或 `Up (healthy)`
+
+| 容器名 | 状态 | 端口映射 |
+|--------|------|---------|
+| fulla-frontend | Up | 8080:80 |
+| fulla-admin | Up | 8081:80 |
+| fulla-backend | Up (healthy) | 5555:5555 |
+| fulla-postgres | Up (healthy) | 5433:5432 |
+| fulla-redis | Up | 6380:6379 |
+| fulla-prometheus | Up | 9090:9090 |
+
+### 2. 健康检查
+
+```powershell
+# 后端健康端点
+curl http://localhost:5555/health
+
+# 预期输出
+{"status":"healthy","timestamp":"2026-08-26T10:30:00Z"}
+```
+
+### 3. 数据库连接测试
+
+```powershell
+# 进入 postgres 容器
+docker exec -it fulla-postgres psql -U fulla_user -d fulla_db -c "\dt"
+
+# 预期输出：OAuth2 相关表列表
+# oauth2_clients, oauth2_codes, oauth2_access_tokens, oauth2_refresh_tokens,
+# oauth2_scopes, users, roles, user_roles, organizations, audit_logs 等（V026 后共 21 张）
+```
+
+### 4. 前端访问测试
+
+在浏览器中打开：
+- **用户前端**：http://localhost:8080 或 https://your-domain.com
+- **管理后台**：http://localhost:8081 或 https://your-domain.com/admin
+
+**预期结果**：页面正常加载，无 404 或 502 错误
+
+---
+
+## 完整验证（30 分钟）
+
+## 阶段一：基础设施验证
+
+### 1.1 PostgreSQL 验证
+
+```powershell
+# 连接测试
+docker exec fulla-postgres pg_isready -U fulla_user
+
+# 预期输出：/var/run/postgresql:5432 - accepting connections
+
+# 表结构检查
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = 'public' 
+ORDER BY table_name;
+"
+
+# 预期表列表（V002-V026 实际 schema，均带 oauth2_ 前缀）：
+# - oauth2_access_tokens, oauth2_refresh_tokens, oauth2_codes
+# - oauth2_clients, oauth2_scopes, oauth2_client_scopes
+# - oauth2_user_consents, oauth2_subject_mappings, oauth2_device_codes
+# - users, roles, permissions, user_roles, role_permissions
+# - organizations, audit_logs, webauthn_credentials 等
+
+# 数据库版本检查
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "SELECT version();"
+
+# 预期：PostgreSQL 17.x（deploy compose 默认 postgres:17-alpine；
+#       显式钉回 15 的存量部署此处应为 15.x，见 docs/operate/postgresql-major-upgrade.md）
+```
+
+### 1.2 Redis 验证
+
+```powershell
+# 进入 redis 容器
+docker exec -it fulla-redis redis-cli -a redis_secret_pass ping
+
+# 预期输出：PONG
+
+# 测试读写
+docker exec fulla-redis redis-cli -a redis_secret_pass SET test_key "hello"
+docker exec fulla-redis redis-cli -a redis_secret_pass GET test_key
+
+# 预期输出："hello"
+
+# 检查内存使用
+docker exec fulla-redis redis-cli -a redis_secret_pass INFO memory
+
+# 预期：used_memory_human 显示合理的内存占用
+```
+
+### 1.3 网络连通性验证
+
+```powershell
+# 从后端容器测试数据库连接
+docker exec fulla-backend ping -c 3 fulla-postgres
+
+# 预期：3 packets transmitted, 3 received, 0% packet loss
+
+# 从后端容器测试 Redis 连接
+docker exec fulla-backend ping -c 3 fulla-redis
+
+# 预期：3 packets transmitted, 3 received, 0% packet loss
+
+# 检查 DNS 解析
+docker exec fulla-backend nslookup fulla-postgres
+
+# 预期：返回 fulla-postgres 的容器 IP 地址（如 172.x.x.x）
+```
+
+---
+
+## 阶段二：数据库初始化验证
+
+### 2.1 检查 Seed 数据
+
+```powershell
+# 检查管理员用户（角色经 user_roles 关联，users 表本身没有 role 列）
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT u.username, u.email, r.name AS role, u.created_at
+FROM users u
+LEFT JOIN user_roles ur ON ur.user_id = u.id
+LEFT JOIN roles r ON r.id = ur.role_id
+WHERE u.username = 'admin';
+"
+
+# 预期输出：
+# username |       email       | role  |         created_at
+# ----------+-------------------+-------+----------------------------
+# admin    | admin@example.com | admin | 2026-xx-xx xx:xx:xx
+
+# 检查默认客户端（表名带 oauth2_ 前缀；名称列是 name）
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT client_id, name, client_type, token_endpoint_auth_method
+FROM oauth2_clients
+WHERE client_id IN ('admin-console', 'vue-client');
+"
+
+# 预期输出：admin-console 与 vue-client 均为 PUBLIC（token_endpoint_auth_method = none）
+
+# 检查默认 Scopes（scope 名称列是 name）
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT name, description
+FROM oauth2_scopes
+LIMIT 5;
+"
+
+# 预期输出：openid, profile, email, admin 等标准 scope
+```
+
+### 2.2 验证数据库迁移
+
+```powershell
+# 检查 migrations 表（如果有的话）
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "\d schema_migrations"
+
+# 或检查表结构完整性
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT COUNT(*) AS table_count 
+FROM information_schema.tables 
+WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
+"
+
+# 预期：table_count >= 15（V026 后实测 21 张 public 表）
+```
+
+---
+
+## 阶段三：后端 API 验证
+
+### 3.1 获取管理员令牌
+
+`admin-console` 是 **PUBLIC 客户端**（`token_endpoint_auth_method=none`，无 client_secret，不支持 password grant），令牌必须走 **授权码 + PKCE** 两步流程（F-011：PUBLIC 客户端强制 PKCE）。以下等价于 `scripts/backend/test-admin-endpoints.sh` 的 setup 步骤：
+
+```bash
+# 1) 登录换取授权码（表单编码；code_challenge = BASE64URL(SHA256(code_verifier))）
+CODE_VERIFIER=$(head -c 32 /dev/urandom | basenc --base64url | tr -d '=' | tr -d '+/' | head -c 43)
+CODE_CHALLENGE=$(printf '%s' "$CODE_VERIFIER" | openssl dgst -sha256 -binary | basenc --base64url | tr -d '=')
+
+LOGIN_RESP=$(curl -s -X POST http://localhost:5555/oauth2/login \
+  -d "username=admin&password=admin" \
+  -d "client_id=admin-console&redirect_uri=http://localhost:5174/admin/callback" \
+  -d "scope=openid+profile+admin&state=verify-state" \
+  -d "code_challenge=$CODE_CHALLENGE&code_challenge_method=S256&json=true")
+CODE=$(echo "$LOGIN_RESP" | jq -r '.code')
+
+# 2) 授权码换令牌（表单编码；PUBLIC 客户端只带 client_id，不能携带任何 secret）
+curl -s -X POST http://localhost:5555/oauth2/token \
+  -d "grant_type=authorization_code&code=$CODE" \
+  -d "redirect_uri=http://localhost:5174/admin/callback" \
+  -d "client_id=admin-console&code_verifier=$CODE_VERIFIER"
+
+# 预期响应（保存 access_token）：
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "tGzv3JH7xN1yQ9X2...",
+  "scope": "openid profile admin"
+}
+
+# 设置环境变量（后续测试使用）
+export TOKEN="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+```
+
+> Windows 下可使用仓库自带的 `scripts/backend/test-admin-endpoints.ps1` 完成同样的登录+令牌流程。
+
+### 3.2 验证令牌内省（Token Introspection）
+
+```bash
+# 内省令牌（RFC 7662，表单编码）
+curl -s -X POST http://localhost:5555/oauth2/introspect \
+  -d "token=$TOKEN" \
+  -d "token_type_hint=access_token" \
+  -d "client_id=admin-console"
+
+# 预期响应：
+{
+  "active": true,
+  "client_id": "admin-console",
+  "username": "admin",
+  "scope": "openid profile admin",
+  "exp": 1719123456,
+  "iat": 1719119856,
+  "sub": "admin",
+  "iss": "http://localhost:5555"
+}
+
+# 测试无效令牌
+curl -s -X POST http://localhost:5555/oauth2/introspect \
+  -d "token=invalid_token" \
+  -d "token_type_hint=access_token" \
+  -d "client_id=admin-console"
+
+# 预期响应：{"active": false}
+```
+
+### 3.3 刷新令牌（Refresh Token）
+
+```bash
+# 使用 refresh_token 获取新的 access_token（表单编码；
+# PUBLIC 客户端只带 client_id —— 携带 client_secret 反而会被 F-017 拒绝）
+curl -s -X POST http://localhost:5555/oauth2/token \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=tGzv3JH7xN1yQ9X2..." \
+  -d "client_id=admin-console"
+
+# 预期响应：返回新的 access_token 和 refresh_token
+{
+  "access_token": "新的 access token...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "新的 refresh token...",
+  "scope": "openid profile admin"
+}
+```
+
+### 3.4 撤销令牌（Token Revocation）
+
+```bash
+# 撤销令牌（RFC 7009，表单编码；客户端认证方式须与注册的
+# token_endpoint_auth_method 一致 —— PUBLIC 客户端仅 client_id）
+curl -s -X POST http://localhost:5555/oauth2/revoke \
+  -d "token=$TOKEN" \
+  -d "token_type_hint=access_token" \
+  -d "client_id=admin-console"
+
+# 预期响应：HTTP 200 OK（空响应体）
+
+# 验证令牌已被撤销
+curl -s -X POST http://localhost:5555/oauth2/introspect \
+  -d "token=$TOKEN" \
+  -d "token_type_hint=access_token" \
+  -d "client_id=admin-console"
+
+# 预期响应：{"active": false}
+```
+
+---
+
+## 阶段四：管理后台 API 验证
+
+### 4.1 用户管理 API
+
+```powershell
+# 获取用户列表
+curl -X GET http://localhost:5555/api/admin/users \
+  -H "Authorization: Bearer $TOKEN"
+
+# 预期响应：用户列表 JSON
+{
+  "users": [
+    {
+      "user_id": 1,
+      "username": "admin",
+      "email": "admin@example.com",
+      "role": "admin",
+      "created_at": "2026-08-26T10:00:00Z",
+      "updated_at": "2026-08-26T10:00:00Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "per_page": 20
+}
+
+# 创建新用户
+curl -X POST http://localhost:5555/api/admin/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "testuser",
+    "email": "test@example.com",
+    "password": "TestPassword123!",
+    "role": "user"
+  }'
+
+# 预期响应：HTTP 201 Created
+{
+  "user_id": 2,
+  "username": "testuser",
+  "email": "test@example.com",
+  "role": "user",
+  "created_at": "2026-08-26T10:30:00Z"
+}
+
+# 获取单个用户详情
+curl -X GET http://localhost:5555/api/admin/users/2 \
+  -H "Authorization: Bearer $TOKEN"
+
+# 预期响应：显示 testuser 的详细信息
+```
+
+### 4.2 客户端管理 API
+
+```powershell
+# 获取客户端列表
+curl -X GET http://localhost:5555/api/admin/clients \
+  -H "Authorization: Bearer $TOKEN"
+
+# 预期响应：客户端列表（客户端 secret 一律不回显；哈希仅存于库中）
+{
+  "clients": [
+    {
+      "client_id": "admin-console",
+      "name": "Admin Console",
+      "client_type": "PUBLIC",
+      "token_endpoint_auth_method": "none",
+      "redirect_uris": ["http://localhost:5174/admin/callback"],
+      "allowed_grant_types": ["authorization_code", "refresh_token"],
+      "scopes": ["openid", "profile", "admin"]
+    }
+  ],
+  "total": 1
+}
+
+# 创建新客户端
+curl -X POST http://localhost:5555/api/admin/clients \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_id": "test-client",
+    "name": "Test Client",
+    "client_type": "CONFIDENTIAL",
+    "client_secret": "test-secret",
+    "redirect_uris": ["http://localhost:8080/callback"],
+    "allowed_grant_types": ["authorization_code", "refresh_token"],
+    "scopes": ["openid", "profile", "email"]
+  }'
+
+# 预期响应：HTTP 201 Created（响应含新生成客户端的元数据；secret 不回显）
+```
+
+### 4.3 Scope 管理 API
+
+```powershell
+# 获取所有 scopes
+curl -X GET http://localhost:5555/api/admin/scopes \
+  -H "Authorization: Bearer $TOKEN"
+
+# 预期响应：scope 列表（scope 名称字段为 name，与 oauth2_scopes 表一致）
+{
+  "scopes": [
+    {"name": "openid", "description": "OpenID Connect"},
+    {"name": "profile", "description": "User profile"},
+    {"name": "email", "description": "User email"},
+    {"name": "admin", "description": "Administrative access"}
+  ]
+}
+
+# 创建新 scope
+curl -X POST http://localhost:5555/api/admin/scopes \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "read",
+    "description": "Read access to user resources"
+  }'
+
+# 预期响应：HTTP 201 Created
+```
+
+---
+
+## 阶段五：前端功能验证
+
+### 5.1 用户前端验证
+
+| 测试项 | 操作步骤 | 预期结果 |
+|--------|---------|---------|
+| 访问首页 | 打开 http://localhost:8080 | 显示登录页面 |
+| 用户注册 | 填写注册表单（用户名、邮箱、密码） | 注册成功，跳转到登录页 |
+| 用户登录 | 使用刚注册的账号登录 | 登录成功，跳转到个人资料页 |
+| 访问个人资料 | 点击"个人资料"菜单 | 显示用户信息（用户名、邮箱） |
+| 修改密码 | 输入旧密码和新密码 | 密码修改成功，需要重新登录 |
+| 退出登录 | 点击"退出"按钮 | 退出成功，跳转到登录页 |
+
+### 5.2 管理后台验证
+
+| 测试项 | 操作步骤 | 预期结果 |
+|--------|---------|---------|
+| 访问管理后台 | 打开 http://localhost:8081/admin | 显示管理后台登录页 |
+| 管理员登录 | 使用 admin/admin 登录 | 登录成功，显示仪表板 |
+| 应用管理 | 点击"应用"菜单 | 显示客户端列表（至少有 admin-console） |
+| 创建应用 | 点击"新建应用"，填写表单 | 应用创建成功，出现在列表中 |
+| 用户管理 | 点击"用户"菜单 | 显示用户列表（至少有 admin 和刚注册的用户） |
+| Token 管理 | 点击"Token"菜单 | 显示 active tokens 列表 |
+
+### 5.3 OAuth2 授权码流程验证
+
+```bash
+# 步骤 1：构建授权 URL（在浏览器中访问）
+# 注意：redirect_uri 必须与客户端注册值精确匹配（vue-client 种子注册的是
+#       http://127.0.0.1:8080/callback —— 用 localhost 会被拒绝）
+# http://localhost:5555/oauth2/authorize?
+#   response_type=code&
+#   client_id=vue-client&
+#   redirect_uri=http://127.0.0.1:8080/callback&
+#   scope=openid profile email&
+#   state=random_state_value
+
+# 预期：重定向到登录页面
+
+# 步骤 2：用户登录
+# 使用测试账号登录（如 testuser）
+
+# 预期：显示授权确认页面
+
+# 步骤 3：用户授权
+# 点击"授权"按钮
+
+# 预期：重定向到 redirect_uri，携带 authorization code
+# http://127.0.0.1:8080/callback?code=xxx&state=random_state_value
+
+# 步骤 4：交换令牌（vue-client 是 PUBLIC 客户端 → 必须带 PKCE code_verifier，
+#          且不能携带 client_secret）
+curl -s -X POST http://localhost:5555/oauth2/token \
+  -d "grant_type=authorization_code" \
+  -d "code=从回调中获取的code" \
+  -d "redirect_uri=http://127.0.0.1:8080/callback" \
+  -d "client_id=vue-client" \
+  -d "code_verifier=登录时使用的PKCE_verifier"
+
+# 预期响应：返回 access_token 和 refresh_token
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "xxx",
+  "scope": "openid profile email"
+}
+```
+
+---
+
+## 阶段五·补充：邮件服务验证
+
+邮件服务有两种模式，由后端 `getEmailService()` 根据 `FULLA_SMTP_*` 环境变量决定。
+
+### 5.4 确认邮件服务模式
+
+```powershell
+# 查看后端启动日志中的邮件服务模式
+docker logs fulla-backend 2>&1 | grep -i "Email service"
+```
+
+**预期输出（二选一）**：
+
+- Console 模式（未配置 SMTP）：`Email service: Console (set FULLA_SMTP_* env vars to enable SMTP)`
+- SMTP 模式（已配置）：`Email service: SMTP (smtp.163.com:465)`
+
+### 5.5 邮箱验证邮件
+
+**操作**：登录用户前端 → Profile 页面 → 点击"发送邮箱验证"
+
+| 模式 | 验证方式 |
+|------|---------|
+| Console 模式 | 邮件内容打到后端日志，从中复制验证链接 |
+| SMTP 模式 | 收件箱应收到真实邮件 |
+
+**Console 模式下查看验证链接**：
+
+```powershell
+docker logs fulla-backend --tail 50 2>&1 | grep -A 5 -iE "verify|email"
+# 预期：含 "verify-email?token=xxx" 的链接
+```
+
+**SMTP 模式下验证邮件发送**：
+
+```powershell
+# 触发发送后，检查后端是否有 SMTP 错误
+docker logs fulla-backend --tail 50 2>&1 | grep -iE "smtp|email|curl"
+# 预期：无 ERROR 级别日志；收件箱收到 "Verify Your Email" 邮件
+```
+
+### 5.6 密码重置邮件
+
+**操作**：前端"忘记密码"页面 → 输入邮箱 → 提交
+
+- **预期响应**（防枚举）：无论邮箱是否存在，统一返回 `If the email exists, a reset link has been sent`
+- Console 模式下，重置链接同样打到后端日志
+
+### 5.7 启用真实 SMTP（可选，详见部署指南）
+
+如需真实邮件发送，在 `.env.docker` 设置 `FULLA_SMTP_HOST` / `FULLA_SMTP_USER` / `FULLA_SMTP_PASSWORD` 三项后重启后端：
+
+```powershell
+docker compose -f deploy/docker/docker-compose.yml --env-file .env.docker up -d fulla-backend
+docker logs fulla-backend 2>&1 | grep -i "Email service"
+# 预期：Email service: SMTP (...)
+```
+
+> **注意**：邮件验证链接使用 `FULLA_FRONTEND_URL`。本地部署为 `http://localhost:8080`，从其他机器点击会失效。
+
+---
+
+## 阶段六：安全性验证
+
+### 6.1 错误响应验证
+
+```bash
+# 测试无效客户端 ID（token 端点，表单编码）
+curl -s -X POST http://localhost:5555/oauth2/token \
+  -d "grant_type=authorization_code&code=x" \
+  -d "client_id=invalid-client&code_verifier=x"
+
+# 预期响应：HTTP 401 Unauthorized
+{
+  "error": "invalid_client",
+  "error_description": "Client authentication failed"
+}
+
+# 测试错误密码（登录端点 —— 注意：失败计数会触发 F-018 限流，别连刷超过阈值）
+curl -s -X POST http://localhost:5555/oauth2/login \
+  -d "username=admin&password=wrong-password" \
+  -d "client_id=admin-console&redirect_uri=http://localhost:5174/admin/callback" \
+  -d "scope=openid&state=t&code_challenge=x&code_challenge_method=S256"
+
+# 预期响应：HTTP 401 Unauthorized（错误码经 ErrorCatalog，防枚举口径统一）
+{
+  "error": "invalid_grant",
+  "error_description": "Invalid username or password"
+}
+
+# 测试缺少必需参数
+curl -s -X POST http://localhost:5555/oauth2/token \
+  -d "grant_type=authorization_code"
+
+# 预期响应：HTTP 400 Bad Request
+{
+  "error": "invalid_request",
+  "error_description": "Missing required parameter: client_id"
+}
+```
+
+### 6.2 令牌过期验证
+
+```powershell
+# 等待令牌过期（3600 秒），或修改后端配置为较短的过期时间进行测试
+
+# 或使用已撤销的令牌
+curl -X GET http://localhost:5555/api/admin/users \
+  -H "Authorization: Bearer revoked_token"
+
+# 预期响应：HTTP 401 Unauthorized
+{
+  "error": "invalid_token",
+  "error_description": "The access token expired or has been revoked"
+}
+```
+
+### 6.3 Scope 授权验证
+
+```powershell
+# 请求超出授权范围的资源（如果实现了 scope-based access control）
+curl -X GET http://localhost:5555/api/admin/users \
+  -H "Authorization: Bearer $token_with_limited_scope"
+
+# 预期响应：HTTP 403 Forbidden
+{
+  "error": "insufficient_scope",
+  "error_description": "The request requires higher privileges than provided by the access token"
+}
+```
+
+---
+
+## 阶段七：性能和监控验证
+
+### 7.1 Prometheus 指标验证
+
+```powershell
+# 访问 Prometheus UI
+# 打开浏览器：http://localhost:9090
+
+# 查询示例指标（权威清单见 docs/operate/observability.md）：
+# - oauth2_requests_total：总请求数（按 endpoint/status 维度）
+# - oauth2_latency_seconds：关键步骤耗时直方图
+# - oauth2_active_tokens：当前活跃令牌数
+# - oauth2_login_failures_total：登录失败次数
+
+# 预期：指标正常采集，有数据
+```
+
+### 7.2 日志验证
+
+```powershell
+# 查看后端日志
+docker logs fulla-backend --tail 50
+
+# 预期：无 ERROR 级别日志，正常的 INFO/DEBUG 日志
+
+# 查看 nginx 日志（Linux 生产环境）
+docker logs oauth2-nginx --tail 50
+
+# 预期：正常的访问日志，无 5xx 错误
+
+# 实时跟踪日志
+docker compose -f deploy/docker/docker-compose.yml logs -f fulla-backend
+```
+
+### 7.3 数据库性能验证
+
+```powershell
+# 检查数据库连接数
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT count(*) AS connections 
+FROM pg_stat_activity 
+WHERE datname = 'fulla_db';
+"
+
+# 预期：connections 为合理值（通常 < 20）
+
+# 检查慢查询（如果有 pg_stat_statements 扩展）
+docker exec fulla-postgres psql -U fulla_user -d fulla_db -c "
+SELECT query, calls, total_time, mean_time 
+FROM pg_stat_statements 
+ORDER BY mean_time DESC 
+LIMIT 5;
+"
+
+# 预期：无明显的慢查询（mean_time < 100ms）
+```
+
+---
+
+## 故障排除检查点
+
+### 问题 1：容器无法启动
+
+**检查步骤**：
+
+```powershell
+# 查看容器状态
+docker compose -f deploy/docker/docker-compose.yml ps
+
+# 查看失败容器的日志
+docker logs fulla-backend
+
+# 检查资源占用
+docker stats
+
+# 验证配置文件
+docker compose -f deploy/docker/docker-compose.yml config
+```
+
+### 问题 2：数据库连接失败
+
+**检查步骤**：
+
+```powershell
+# 验证 postgres 容器健康状态
+docker exec fulla-postgres pg_isready -U fulla_user
+
+# 检查网络连通性
+docker exec fulla-backend ping fulla-postgres
+
+# 验证环境变量
+docker exec fulla-backend env | grep FULLA_DB
+
+# 查看数据库日志
+docker logs fulla-postgres
+```
+
+### 问题 3：前端无法访问后端 API
+
+**检查步骤**：
+
+```powershell
+# 从前端容器测试后端连接
+docker exec fulla-frontend curl -s http://fulla-backend:5555/health
+
+# 检查 nginx 配置（生产环境）
+docker exec oauth2-nginx nginx -t
+
+# 查看后端 CORS 配置
+docker logs fulla-backend | grep -i cors
+```
+
+### 问题 4：令牌验证失败
+
+**检查步骤**：
+
+```powershell
+# 验证 JWT 密钥存在
+docker exec fulla-backend ls -la /app/keys/
+
+# 检查令牌签名
+# 复制 access_token 到 https://jwt.io 解码验证
+
+# 查看后端日志中的认证错误
+docker logs fulla-backend | grep -i "auth\|token"
+```
+
+---
+
+## 自动化验证脚本
+
+### 完整验证脚本（PowerShell）
+
+保存为 `verify-deployment.ps1`：
+
+```powershell
+# fulla 部署验证脚本
+param(
+    [string]$BackendUrl = "http://localhost:5555",
+    [string]$FrontendUrl = "http://localhost:8080",
+    [string]$AdminUrl = "http://localhost:8081",
+    [switch]$Verbose
+}
+
+function Test-ContainerStatus {
+    Write-Host "`n[1/8] 检查容器状态..." -ForegroundColor Cyan
+    $containers = docker compose -f deploy/docker/docker-compose.yml ps
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "[+] 所有容器运行正常" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] 容器状态异常" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-BackendHealth {
+    Write-Host "`n[2/8] 检查后端健康..." -ForegroundColor Cyan
+    try {
+        $response = Invoke-RestMethod -Uri "$BackendUrl/health" -Method Get
+        if ($response.status -eq "healthy") {
+            Write-Host "[+] 后端健康检查通过" -ForegroundColor Green
+            return $true
+        }
+    } catch {
+        Write-Host "[-] 后端健康检查失败: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-DatabaseConnection {
+    Write-Host "`n[3/8] 检查数据库连接..." -ForegroundColor Cyan
+    $result = docker exec fulla-postgres pg_isready -U fulla_user 2>&1
+    if ($LASTEXITCODE -eq 0 -and $result -match "accepting connections") {
+        Write-Host "[+] 数据库连接正常" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] 数据库连接失败" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-DatabaseTables {
+    Write-Host "`n[4/8] 检查数据库表结构..." -ForegroundColor Cyan
+    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
+        SELECT COUNT(*) FROM information_schema.tables 
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
+    " 2>&1
+    
+    $tableCount = [int]$result.Trim()
+    if ($tableCount -ge 20) {
+        Write-Host "[+] 数据库表结构完整 ($tableCount 张表)" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] 数据库表结构不完整 (仅 $tableCount 张表)" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-SeedData {
+    Write-Host "`n[5/8] 检查种子数据..." -ForegroundColor Cyan
+    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
+        SELECT COUNT(*) FROM users WHERE username = 'admin';
+    " 2>&1
+    
+    $count = [int]$result.Trim()
+    if ($count -eq 1) {
+        Write-Host "[+] 管理员账号已创建" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] 管理员账号未创建" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-RedisConnection {
+    Write-Host "`n[6/8] 检查 Redis 连接..." -ForegroundColor Cyan
+    $result = docker exec fulla-redis redis-cli -a redis_secret_pass ping 2>&1
+    if ($result -match "PONG") {
+        Write-Host "[+] Redis 连接正常" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] Redis 连接失败" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-DiscoveryEndpoint {
+    Write-Host "`n[7/8] 测试 OIDC 发现端点..." -ForegroundColor Cyan
+    # 完整登录流程（PKCE）见上文阶段三；脚本化部署检查用发现端点验证
+    # 后端 OAuth2 栈已就绪，且不依赖具体凭证。
+    try {
+        $response = Invoke-RestMethod -Uri "$BackendUrl/.well-known/openid-configuration" -Method Get
+        if ($response.issuer -and $response.token_endpoint) {
+            Write-Host "[+] OIDC 发现端点正常 (issuer: $($response.issuer))" -ForegroundColor Green
+            return $true
+        }
+    } catch {
+        Write-Host "[-] OIDC 发现端点失败: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-FrontendAccess {
+    Write-Host "`n[8/8] 检查前端访问..." -ForegroundColor Cyan
+    try {
+        $response = Invoke-WebRequest -Uri $FrontendUrl -Method Get -UseBasicParsing
+        if ($response.StatusCode -eq 200) {
+            Write-Host "[+] 前端页面可访问" -ForegroundColor Green
+            return $true
+        }
+    } catch {
+        Write-Host "[-] 前端页面访问失败: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+# 执行所有测试
+$results = @()
+$results += Test-ContainerStatus
+$results += Test-BackendHealth
+$results += Test-DatabaseConnection
+$results += Test-DatabaseTables
+$results += Test-SeedData
+$results += Test-RedisConnection
+$results += Test-DiscoveryEndpoint
+$results += Test-FrontendAccess
+
+# 汇总结果
+$passed = ($results | Where-Object { $_ -eq $true }).Count
+$total = $results.Count
+
+Write-Host "`n" -NoNewline
+Write-Host ("=" * 60) -ForegroundColor DarkGray
+Write-Host "验证结果: $passed / $total 通过" -ForegroundColor $(if ($passed -eq $total) { "Green" } else { "Yellow" })
+Write-Host ("=" * 60) -ForegroundColor DarkGray
+
+if ($passed -eq $total) {
+    Write-Host "`n[+] 部署验证完全通过！系统可以投入使用。" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "`n[-] 部署验证失败，请检查上述错误项。" -ForegroundColor Red
+    exit 1
+}
+```
+
+**使用方法**：
+
+```powershell
+# 基本验证
+.\verify-deployment.ps1
+
+# 详细模式
+.\verify-deployment.ps1 -Verbose
+
+# 自定义端点
+.\verify-deployment.ps1 -BackendUrl "https://your-domain.com" -FrontendUrl "https://your-domain.com"
+```
+
+---
+
+## 验证报告模板
+
+完成验证后，建议填写以下报告模板：
+
+```markdown
+## fulla 部署验证报告
+
+**验证日期**：YYYY-MM-DD
+**验证环境**：Windows Docker Desktop / Linux 生产服务器
+**验证人员**：[姓名]
+
+### 验证结果汇总
+
+| 阶段 | 状态 | 备注 |
+|------|------|------|
+| 基础设施验证 | 通过 | 所有容器正常运行 |
+| 数据库初始化验证 | 通过 | 21 张表（V026），管理员账号已创建 |
+| 后端 API 验证 | 通过 | 令牌端点、内省、撤销功能正常 |
+| 管理后台 API 验证 | 通过 | 用户、客户端、Scope 管理正常 |
+| 前端功能验证 | 通过 | 用户登录、注册、个人资料功能正常 |
+| 安全性验证 | 通过 | 错误处理、令牌验证正常 |
+| 性能和监控验证 | 部分通过 | Prometheus 正常，需要优化慢查询 |
+
+### 发现的问题
+
+1. **问题描述**：[具体问题]
+   - **影响范围**：[哪些功能受影响]
+   - **解决方案**：[如何解决]
+   - **状态**：[待解决 | 已解决]
+
+### 优化建议
+
+1. [建议 1]
+2. [建议 2]
+
+### 下一步行动
+
+- [ ] 部署到生产环境
+- [ ] 配置 Let's Encrypt 证书
+- [ ] 设置监控告警
+- [ ] 执行性能压测
+
+### 签名确认
+
+验证人员：__________  日期：__________
+审核人员：__________  日期：__________
+```
+
+---
+
+## 总结
+
+本验证清单涵盖了 fulla 系统的所有核心功能：
+
+- **基础设施**：Docker 容器、网络、存储卷
+- **数据层**：PostgreSQL 数据库、Redis 缓存
+- **业务层**：OAuth2 核心流程、管理后台 API
+- **表现层**：Vue.js 用户前端、管理后台
+- **安全性**：认证、授权、令牌管理
+- **可观测性**：日志、指标、健康检查
+
+**验证通过标准**：
+- 所有容器状态为 `Up`
+- 后端健康检查通过
+- 数据库表结构完整（V026 后共 21 张 public 表）
+- 管理员账号可用
+- OAuth2 核心流程（授权、令牌、内省、撤销）正常
+- 前端页面可访问并完成基本操作
+
+完成本清单验证后，系统即可投入生产使用。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/sdk-integration-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/sdk-integration-guide.md
@@ -1,0 +1,169 @@
+# SDK 集成指南（发布产物消费）
+
+如何获取并集成 Fulla 的发布产物：SDK 二进制包（库 + 头 +
+`fulla-*Config.cmake`）与 GHCR 容器镜像。运行时行为承诺（线程 / ABI /
+异常 / 日志 / 插件注册）见 [SDK Runtime Contract](sdk-runtime-contract)，
+本文只讲"怎么拿、怎么接"。发布流水线为
+`.github/workflows/release.yml`（严格 SemVer tag `vX.Y.Z` 触发）。
+
+> 非 C++ 消费者：官方维护的 **Python**（PyPI [`fulla-oauth2`](https://pypi.org/project/fulla-oauth2/)）与
+> **Go**（`github.com/voidvec/fulla/clients/go`）HTTP 客户端开箱即用，
+> 见 [clients/](https://github.com/voidvec/fulla/tree/master/clients)。
+
+---
+
+## 1. 发布产物清单
+
+| 产物 | 位置 | 说明 |
+|------|------|------|
+| SDK 包 `fulla-sdk-<ver>-linux-x86_64.tar.gz` | GitHub Release 附件 | 8 个静态库 + `include/fulla/**` 头 + `lib/cmake/fulla-*/{Config,ConfigVersion,Targets}.cmake`（附 `.sha256`） |
+| 后端镜像 | `ghcr.io/voidvec/fulla-backend:<ver>` | 多架构（amd64 + arm64），入口 `:5555`，`/health` 探活 |
+| 用户前端镜像 | `ghcr.io/voidvec/fulla-frontend:<ver>` | nginx 静态托管，`:80` |
+| 管理台镜像 | `ghcr.io/voidvec/fulla-admin:<ver>` | nginx 静态托管 `/admin`，`:80` |
+
+镜像另有 `latest` 标签；`<ver>-amd64` / `<ver>-arm64` 为单架构中间标签。
+服务器可执行文件**不在** SDK 包内——产品部署走镜像通道。
+
+## 2. SDK 包前置条件（先读）
+
+- **v1.x 只承诺源码级 SemVer，不承诺二进制 ABI**（契约 §2）。发布的
+  `linux-x86_64` 静态库按 Release 流水线的工具链编译（ubuntu-24.04 /
+  gcc / libstdc++ / C++17 / Conan 锁定依赖）；工具链不匹配时**请改用源码
+  集成**（`add_subdirectory` 或自行 `cmake --install`，同一 SDK 面）。
+- 第三方依赖（Drogon / OpenSSL / jsoncpp 等）**不在包内**。消费方用仓库根
+  的 `conanfile.py` + `conan.lock` 解析同版本依赖，保证 `find_dependency`
+  闭包与库编译时一致。
+
+## 3. find_package 集成步骤
+
+```bash
+# 1) 解包
+tar xzf fulla-sdk-1.0.0-linux-x86_64.tar.gz   # -> fulla-sdk-1.0.0-linux-x86_64/
+
+# 2) 用仓库的 conanfile.py 解析依赖（生成 toolchain + 各依赖的 CMake config）
+conan install <fulla-repo> --output-folder=deps --build=missing \
+  -s build_type=Release -s compiler.cppstd=17
+
+# 3) 配置消费工程：toolchain 供依赖解析，PREFIX_PATH 指向解包目录
+cmake -S . -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE=$PWD/deps/conan_toolchain.cmake \
+  -DCMAKE_PREFIX_PATH=$PWD/fulla-sdk-1.0.0-linux-x86_64
+cmake --build build -j
+```
+
+CMakeLists 侧：
+
+```cmake
+# 全栈宿主：一个包拉全闭包（common/oauth2/identity/storage-*/Drogon/OpenSSL/CURL）
+find_package(fulla-drogon CONFIG REQUIRED)
+target_link_libraries(my-host PRIVATE fulla::drogon)
+
+# 或只取引擎面（无 Drogon 依赖）：
+find_package(fulla-oauth2 CONFIG REQUIRED)
+find_package(fulla-storage-memory CONFIG REQUIRED)
+target_link_libraries(my-engine PRIVATE fulla::oauth2 fulla::storage::memory)
+```
+
+可用包与导出目标：`fulla-common`→`fulla::common`（另含
+`fulla::common::testing`）、`fulla-oauth2`→`fulla::oauth2`、
+`fulla-identity`→`fulla::identity`、
+`fulla-storage-{memory,redis,postgres}`→`fulla::storage::{memory,redis,postgres}`、
+`fulla-drogon`→`fulla::drogon`。版本兼容为 SameMajorVersion
+（`find_package(fulla-drogon 1.0 CONFIG REQUIRED)` 可锁 major）。
+
+参考消费方（随仓库 CI 持续验证）：
+
+- `examples/full-stack-host/`：完整 HTTP 宿主，`find_package(fulla-drogon)`
+  复用产品 controllers / OAuth2Plugin / views。Release 流水线用它对**安装
+  前缀**做消费冒烟（`ctest -L SdkSmoke` 则对 build-tree 做同样验证）。
+- `examples/third-party-host/`：最小引擎消费方，只链 Domain 层四个包。
+
+## 4. 插件注册与 whole-archive（H1/F1/H5 口径）
+
+- 插件本体当前以 **OBJECT 库**链入宿主，目标文件逐个直接链接，自注册符号
+  不会被裁剪——**当前不需要 whole-archive**。
+- 发布的 SDK 包中 `fulla::drogon` 是常规静态库，但插件注册走
+  `config.json` `plugins[].name = "OAuth2Plugin"` 反射 + 显式
+  `registerAllControllers()`（见 full-stack-host 的 main.cc），同样不依赖
+  链接器保留未引用符号。若消费方自建**依赖静态初始化自注册**的封装，须
+  自行 `-Wl,--whole-archive` 包裹对应库。
+- 类名 / config schema 稳定性承诺见契约 §6。
+
+## 5. 镜像使用
+
+```bash
+docker pull ghcr.io/voidvec/fulla-backend:1.0.0
+```
+
+三镜像与 `deploy/docker/docker-compose.yml` 的构建目标一一对应
+（`backend-runtime` / `frontend-runtime` / `frontends/admin/Dockerfile`），
+环境变量与挂载约定直接照搬 compose 文件的 `fulla-backend` 段
+（`FULLA_DB_HOST` / `FULLA_REDIS_HOST` / `FULLA_AUTO_MIGRATE` 等）。
+
+## 6. 发布流程（维护者）
+
+1. 确认三源版本一致（`cmake/Version.cmake` 为单一事实源；api-diff 在 CI
+   强制其与根 `CMakeLists.txt`、`conanfile.py` 一致）且 API 基线已按
+   SemVer 规则更新（`tools/api-diff/`）。
+2. （可选）本地刷新 CHANGELOG.md：
+   `git cliff --unreleased --tag vX.Y.Z --prepend CHANGELOG.md`
+   （配置见根目录 `cliff.toml`；发布工作流只生成 Release notes，
+   不会从 tag ref 回推提交）。
+3. 打严格 SemVer tag：`git tag v1.0.1 && git push origin v1.0.1`。带后缀
+   的 tag（如 `v1.0.0-rc1`）**不会**触发发布。
+4. `release.yml` 自动执行：tag/版本一致性校验 → SDK 打包 + 安装树消费
+   冒烟 → amd64/arm64 原生构建三镜像 → 多架构 manifest（`<ver>` +
+   `latest`）→ cosign keyless 按 digest 签名三镜像 + syft 生成 SPDX
+   SBOM（三镜像 + 源码树）→ GitHub Release（git-cliff 生成 notes，
+   挂 SDK 附件与全部 SBOM）。
+5. `workflow_dispatch` 手动触发 = 干跑（全量构建但不推送、不发 Release）。
+
+### 验证发布产物（消费方）
+
+```sh
+# 镜像签名（keyless：身份 = release.yml 工作流，无需公钥分发）
+cosign verify ghcr.io/voidvec/fulla-backend:<ver> \
+  --certificate-identity-regexp \
+    'https://github.com/voidvec/[^/]+/.github/workflows/release.yml.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# SDK tarball 校验和（Release 附件）
+sha256sum -c fulla-sdk-<ver>-linux-x86_64.tar.gz.sha256
+```
+
+
+## Quickstart：嵌入你自己的 Drogon 宿主
+
+除 `find_package` 外只需两步（详见上文第 3 节的包引入）：
+
+**1. 在宿主 `config.json` 激活插件**（自动注册协议路由与 Filter）：
+
+```json
+{
+    "plugins": [
+        {
+            "name": "OAuth2Plugin",
+            "dependencies": [],
+            "config": {
+                "storage_type": "postgres",
+                "postgres": { "db_client_name": "default" },
+                "redis": { "client_name": "default" }
+            }
+        }
+    ]
+}
+```
+
+**2. 用 `AuthorizationFilter` 保护业务 API**（全限定名 `fulla::drogon::filters::AuthorizationFilter`）：
+
+```cpp
+METHOD_LIST_BEGIN
+ADD_METHOD_TO(UserApi::getProfile, "/api/me", drogon::Get,
+              "fulla::drogon::filters::AuthorizationFilter");
+METHOD_LIST_END
+```
+
+注意：链接 `fulla::drogon` 后 Controller/Filter 由 Drogon 启动时自动注册，勿手动调用初始化宏；PostgreSQL 存储需先执行 `apps/server/migrations/`（或 `FULLA_AUTO_MIGRATE=true`）。
+
+> 本节合并自已退役的 plugin-integration.md（docs 治理 A2）。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/sdk-runtime-contract.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/sdk-runtime-contract.md
@@ -1,0 +1,72 @@
+# SDK Runtime Contract
+
+对外契约声明：Fulla SDK（`fulla::common` / `fulla::oauth2` /
+`fulla::identity` / `fulla::storage-*` / `fulla::drogon`）在 v1.x
+期间对消费者承诺的线程模型、ABI、异常、日志与依赖边界。
+
+本文档是对外承诺的单一出处；SDK 头文件注释与本文冲突时以本文为准并修头。
+
+---
+
+## 1. 线程模型
+
+- Domain 服务（`libs/oauth2`、`libs/identity`）**不自持事件循环**；所有异步
+  操作经回调返回。
+- **回调可能在任意 Drogon IO 线程触发，不保证是调用线程**。消费者不得假设
+  线程亲和性；需要回到特定线程时由消费者自行投递。
+- 只读单例（如 `JwkManager`）遵循 **init-once-then-read-only**：在服务开始
+  接受请求前完成一次性 `init()`，之后以 `shared_ptr<const T>` 发布，运行期
+  不再变更。消费者在 SDK 装配完成后并发读取是安全的。
+- 服务对象持有 `shared_ptr` 仓储句柄保证生命周期；异步续体一律捕获
+  `auto self = shared_from_this()`，禁止 `[this]` / `[&]`。
+
+## 2. ABI 稳定性
+
+- v1.x **仅支持 `find_package` 源码集成，不承诺二进制 ABI**。
+- 语义化版本只覆盖**源码级 API**：公共头 `include/fulla/**` 遵循
+  SemVer，破坏性变更必须升 major（由 api-diff 工具在 CI 强制）。
+- 跨编译器 / 跨 STL 混用预编译二进制不在支持范围；进入 Conan 二进制包
+  分发阶段后再单独制定 ABI 策略。
+- 弃用流程：`[[deprecated]]` 标注 + 至少一个 minor 周期过渡后方可移除。
+
+## 3. 异常安全约定
+
+- Domain 公共 API 以 `Result<T, Error>` 返回**可预期错误**，不用异常表达
+  业务失败。
+- 仅在不可恢复的编程错误（契约违反、断言级问题）抛异常。
+- 存储底层异常（如 `DrogonDbException`）**必须在 Adapter 层
+  （`libs/storage-*`、`libs/drogon`）捕获并转为 `Error`，不得穿透到
+  Domain 回调**。消费者在 Domain 回调内无需 try/catch 存储异常。
+
+## 4. 日志抽象
+
+- Domain 代码经 `common::ports::ILogger` 端口输出日志，**不直接使用
+  Drogon `LOG_*` 宏**（arch-guard 强制 Domain 层不 include drogon 头）。
+- SDK 默认提供 Drogon 日志适配实现（`libs/drogon` Adapter）；脱离 Drogon
+  宿主的消费者可注入自己的 `ILogger` 实现替换。
+
+## 5. 依赖声明
+
+- 特性面依赖由根 `conanfile.py` 的 **`with_webauthn` / `with_identity` /
+  `with_social` option 显式 gate**，不作为传递依赖的隐式惊喜。
+  NOTE: 真实 WebAuthn（FIDO2）需要的 CBOR 解码依赖（`libcbor`）曾在此
+  声明，但当前 WebAuthn 控制器是非加密 stub（不消费任何 CBOR），
+  `libcbor` 已作为死依赖移除；待真实 WebAuthn 加密落地时需重新添加
+  （详见 `conanfile.py` 对应注释）。
+- 关闭选项（如 `-o with_webauthn=False`）会同步映射到 CMake 侧
+  `WITH_*` 变量并裁剪对应编译面，消费者可据此收缩依赖表面。
+
+## 6. 插件注册与配置契约（宿主集成）
+
+- `OAuth2Plugin` 类名与 config `plugins[].name` 反射加载契约**保持稳定**
+  （方案 A）：各 config（`config.{json,dev,ci,prod,bench}.json`）中
+  `"plugins":[{"name":"OAuth2Plugin","config":{...}}]` 的类名字符串与
+  `config{}` 块 schema 是产品配置契约的一部分，v1.x 不改名。
+- 插件本体以 CMake **OBJECT 库**形态链接进宿主：目标文件逐个直接链入，
+  不存在静态库按需抽取丢弃自注册符号的问题，因此**当前不需要
+  whole-archive**。
+- 若未来改为**静态库形态分发**插件本体，链接器可能裁剪插件自注册符号导致
+  Drogon 反射 "plugin not found"——届时必须引入 whole-archive（或等价
+  强制链接方案）；`OAuth2Plugin` 无 `AutoCreation` 参数可用，不适用免
+  whole-archive 方案。
+- 第三方宿主集成示例见 `examples/third-party-host/`。

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,7 +1,8 @@
-// Sidebar mirrors the site IA; docs/ is user-facing only (governance §2):
-// architecture / domains / sdk / operate / contribute zones + ADRs.
-// Maintainer archives (history, branding records, process docs) live in
-// docs-local/ outside this tree and are NOT site content.
+// Sidebar mirrors the site IA; docs/ is user-facing only (governance §4A).
+// Category labels are English (site default locale); doc item labels derive
+// from each file's own H1, so the zh-CN tree shows Chinese titles
+// automatically. Maintainer archives (history, branding, process docs) live
+// in docs-local/ outside this tree and are NOT site content.
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
@@ -9,13 +10,13 @@ const sidebars = {
     'intro',
     {
       type: 'category',
-      label: '评估 · Evaluate',
+      label: 'Evaluate',
       items: [
         'architecture/architecture-overview',
         'architecture/security-architecture',
         {
           type: 'link',
-          label: '性能对比报告',
+          label: 'Benchmark Report',
           href: 'https://github.com/voidvec/fulla/blob/master/benchmarks/competitors/results/COMPARISON.md',
         },
         'benchmark/competitor-benchmark-design',
@@ -23,7 +24,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: '集成 · Integrate',
+      label: 'Integrate',
       items: [
         'sdk/sdk-integration-guide',
         'sdk/sdk-runtime-contract',
@@ -35,12 +36,17 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: '架构深潜 · Architecture',
-      items: ['architecture/data-persistence'],
+      label: 'Deep Dives',
+      items: [
+        'domains/token-lifecycle',
+        'domains/session-management',
+        'domains/multi-tenancy',
+        'architecture/data-persistence',
+      ],
     },
     {
       type: 'category',
-      label: '运维 · Operate',
+      label: 'Operate',
       items: [
         'operate/deployment',
         'operate/docker-deployment',
@@ -54,7 +60,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: '贡献 · Contribute',
+      label: 'Contribute',
       items: [
         'contribute/testing-guide',
         'contribute/ci-cd-guide',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -3,100 +3,179 @@ import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 import styles from './index.module.css';
 
-const QUICK_START = `# Docker Compose 一键起全栈（评估推荐）
-docker compose -f deploy/docker/docker-compose.yml up -d --build
+const STRINGS = {
+  en: {
+    title: 'fulla — High-performance open-source IAM core (C++17)',
+    description:
+      'Production-grade OAuth2/OIDC authorization server and embeddable C++17 SDK: auth-code+PKCE, MFA, WebAuthn, RBAC, multi-tenancy — with admin console, user frontend and official Python/Go clients.',
+    badges: ['MIT License', 'Leads all 5 benchmark scenarios', 'Docker · Helm · C++ SDK'],
+    taglinePre: 'A ',
+    taglineAccent: 'high-performance identity & access core',
+    taglinePost: ', built in C++17',
+    subtitle:
+      'A production-grade OAuth2 / OIDC authorization server that runs out of the box (Docker / Helm) — or embed it into your C++ project as an SDK (find_package(fulla-*)). Ships with an admin console, a user frontend, and official Python / Go clients.',
+    ctaDocs: 'Read the Docs',
+    ctaQuick: 'Quick Start',
+    quickTitle: 'Up and running in five minutes',
+    quickText:
+      'One command pulls up the full stack: backend (OAuth2/OIDC) + PostgreSQL 17 + Redis + user frontend + admin console + Prometheus. Seed data is built in — sign in to the admin console with admin / admin and walk the whole flow.',
+    quickHint: { pre: 'Building from source (Conan 2 + CMake presets, same as CI) — see ', post: '.' },
+    quickHintLink: 'Docs · Get started',
+    whyTitle: 'Why fulla',
+    benchTitle: 'Performance: ahead in all five scenarios',
+    benchSubtitlePre:
+      'Same machine, same backend, against Keycloak 26 / Ory Hydra v26 / Zitadel v4 (WSL2 8 vCPU · PostgreSQL 17 · wrk ladder · each vendor\u2019s official production config). Steady-state QPS below; \u201cclosest rival\u201d is the best of the three. Full methodology and data: ',
+    benchSubtitleLink: 'benchmark report',
+    benchSubtitlePost: '.',
+    leadPrefix: 'Ahead of the closest rival by ',
+    rivalQps: 'closest rival',
+    closingTitle: 'Get started',
+    closingText:
+      'Evaluate the architecture → run it → integrate → deploy to production: every step has a doc, and every key decision has an ADR behind it.',
+    closingDocs: 'Open the Docs',
+    closingAdr: 'Browse the ADRs',
+    features: [
+      {
+        title: 'High-performance C++17 core',
+        description:
+          'Async non-blocking Drogon framework with callback-based storage ports. Leads Keycloak, Ory Hydra and Zitadel in all five benchmark scenarios (discovery / client_credentials / introspect / refresh_token / userinfo).',
+      },
+      {
+        title: 'Production-grade OAuth2 / OIDC',
+        description:
+          'Authorization code + PKCE, client credentials, device flow, refresh rotation with reuse detection, introspection / revocation, OIDC discovery, RP-Initiated Logout, Backchannel Logout.',
+      },
+      {
+        title: 'Embeddable C++ SDK',
+        description:
+          'The protocol engine is decoupled from the server: the domain layer has zero Drogon dependencies. Take the eight static libraries via find_package(fulla-*) — or add_subdirectory from source; same SDK surface.',
+      },
+      {
+        title: 'Full authentication coverage',
+        description:
+          'TOTP MFA (second-factor session binding), WebAuthn/Passkeys, GitHub / Google / WeChat social login, progressive account lockout, and anti-enumeration-consistent auth failure handling.',
+      },
+      {
+        title: 'RBAC + granular scopes',
+        description:
+          'Dual-gate authorization — roles (admin / user / custom) plus resource scopes; roles are issued into JWT claims. Admin APIs cover the full lifecycle of users / clients / roles / scopes / tokens.',
+      },
+      {
+        title: 'Production-ready operations',
+        description:
+          'Prometheus metrics + six-level structured logging, account-lockout and PG-upgrade runbooks, a deployment acceptance checklist, Redis L2 caching (delayed double-delete consistency), and an official performance baseline.',
+      },
+    ],
+    QUICK_START_COMMENT_1: '# One command, full stack (recommended for evaluation)',
+    QUICK_START_COMMENT_2: '#   User frontend    http://localhost:8080',
+    QUICK_START_COMMENT_3: '#   Admin console    http://localhost:8081',
+    QUICK_START_COMMENT_4: '#   Backend API      http://localhost:5555/.well-known/openid-configuration',
+  },
+  'zh-CN': {
+    title: 'fulla — 高性能开源 IAM 内核（C++17）',
+    description:
+      '生产级 OAuth2/OIDC 授权服务器 + 可嵌入 C++17 SDK：授权码/PKCE、MFA、WebAuthn、RBAC、多租户，附管理后台、用户前端与官方 Python/Go 客户端。',
+    badges: ['MIT License', '五项基准场景全面领先', 'Docker · Helm · C++ SDK'],
+    taglinePre: '以 C++17 构建的',
+    taglineAccent: '高性能身份与访问管理内核',
+    taglinePost: '',
+    subtitle:
+      '生产级 OAuth2 / OIDC 授权服务器，开箱即用（Docker / Helm）；亦可作为可嵌入 SDK（find_package(fulla-*)）集成进你的 C++ 工程。附管理后台、用户前端与官方 Python / Go 客户端。',
+    ctaDocs: '阅读文档',
+    ctaQuick: '快速开始',
+    quickTitle: '五分钟跑起来',
+    quickText:
+      '一条命令拉起全栈：后端（OAuth2/OIDC）+ PostgreSQL 17 + Redis + 用户前端 + 管理后台 + Prometheus。种子数据内置，admin / admin 登录管理后台即可体验完整流程。',
+    quickHint: { pre: '从源码构建（Conan 2 + CMake presets，与 CI 同构）见 ', post: '。' },
+    quickHintLink: '文档 · 开始',
+    whyTitle: '为什么选择 fulla',
+    benchTitle: '性能：同机同后端，五项场景全部领先',
+    benchSubtitlePre:
+      '与 Keycloak 26 / Ory Hydra v26 / Zitadel v4 同机对比（WSL2 8 vCPU · PostgreSQL 17 · wrk 阶梯负载 · 各家官方生产配置）。下表为稳态 QPS，“最快竞品”为三者中最高值；完整方法学与数据见 ',
+    benchSubtitleLink: '基准对比报告',
+    benchSubtitlePost: '。',
+    leadPrefix: '领先最快竞品 ',
+    rivalQps: '最快竞品',
+    closingTitle: '开始使用',
+    closingText: '评估架构 → 跑起来 → 集成 → 部署生产，每一步都有对应文档；每个关键设计决策都有 ADR 可溯。',
+    closingDocs: '进入文档',
+    closingAdr: '浏览 ADR',
+    features: [
+      {
+        title: '高性能 C++17 内核',
+        description:
+          '异步非阻塞 Drogon 框架 + 回调式存储端口。五项基准场景（discovery / client_credentials / introspect / refresh_token / userinfo）全面领先 Keycloak、Ory Hydra 与 Zitadel。',
+      },
+      {
+        title: '生产级 OAuth2 / OIDC',
+        description:
+          '授权码 + PKCE、client_credentials、device_code、refresh 轮换与重用检测、introspection / revocation、OIDC 发现文档、RP-Initiated Logout、Backchannel Logout。',
+      },
+      {
+        title: '可嵌入 C++ SDK',
+        description:
+          '协议引擎与服务器解耦：Domain 层零 Drogon 依赖，find_package(fulla-*) 取走八包静态库，或 add_subdirectory 源码集成——同一 SDK 面。',
+      },
+      {
+        title: '认证与 MFA 全覆盖',
+        description:
+          'TOTP MFA（第二因子会话绑定）、WebAuthn/Passkeys、GitHub / Google / WeChat 社交登录、账号锁定与防枚举口径统一的认证失败处理。',
+      },
+      {
+        title: 'RBAC + 细粒度 Scope',
+        description:
+          '角色（admin / user / 自定义角色）与资源 scope 双闸授权模型，roles 已签发进 JWT；管理 API 覆盖用户 / 客户端 / 角色 / scope / token 全生命周期。',
+      },
+      {
+        title: '生产就绪运维面',
+        description:
+          'Prometheus 指标 + 六级结构化日志、账号锁定与 PG 大版本升级 runbook、部署验收清单、Redis L2 缓存（延迟双删一致性）与官方性能调优基线。',
+      },
+    ],
+    QUICK_START_COMMENT_1: '# Docker Compose 一键起全栈（评估推荐）',
+    QUICK_START_COMMENT_2: '#   用户前端    http://localhost:8080',
+    QUICK_START_COMMENT_3: '#   管理后台    http://localhost:8081',
+    QUICK_START_COMMENT_4: '#   后端 API    http://localhost:5555/.well-known/openid-configuration',
+  },
+};
 
-#   用户前端    http://localhost:8080
-#   管理后台    http://localhost:8081
-#   后端 API    http://localhost:5555/.well-known/openid-configuration`;
-
-const FEATURES = [
-  {
-    title: '高性能 C++17 内核',
-    svg: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-        <path d="M13 2L4.5 13.5H11L9.5 22 19 10h-6.5L13 2z" strokeLinejoin="round" />
-      </svg>
-    ),
-    description: (
-      <>异步非阻塞 Drogon 框架 + 回调式存储端口。五项基准场景
-        （discovery / client_credentials / introspect / refresh_token / userinfo）
-        全面领先 Keycloak、Ory Hydra 与 Zitadel。</>
-    ),
-  },
-  {
-    title: '生产级 OAuth2 / OIDC',
-    svg: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-        <rect x="4" y="10" width="16" height="10" rx="2" />
-        <path d="M8 10V7a4 4 0 018 0v3" strokeLinecap="round" />
-      </svg>
-    ),
-    description: (
-      <>授权码 + PKCE、client_credentials、device_code、refresh 轮换与重用检测、
-        introspection / revocation、OIDC 发现文档、RP-Initiated Logout、
-        Backchannel Logout。</>
-    ),
-  },
-  {
-    title: '可嵌入 C++ SDK',
-    svg: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-        <path d="M8 8l-5 4 5 4M16 8l5 4-5 4M13 5l-2 14" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-    description: (
-      <>协议引擎与服务器解耦：Domain 层零 Drogon 依赖，
-        <code>find_package(fulla-*)</code> 取走八包静态库，
-        或 <code>add_subdirectory</code> 源码集成——同一 SDK 面。</>
-    ),
-  },
-  {
-    title: '认证与 MFA 全覆盖',
-    svg: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-        <path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7l8-4z" strokeLinejoin="round" />
-        <path d="M9 12l2 2 4-4" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-    description: (
-      <>TOTP MFA（第二因子会话绑定）、WebAuthn/Passkeys、GitHub / Google / WeChat
-        社交登录、账号锁定与防枚举口径统一的认证失败处理。</>
-    ),
-  },
-  {
-    title: 'RBAC + 细粒度 Scope',
-    svg: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-        <circle cx="9" cy="8" r="3.2" />
-        <path d="M3.5 19c.7-3 2.9-4.5 5.5-4.5S13.8 16 14.5 19" strokeLinecap="round" />
-        <circle cx="17" cy="9" r="2.4" />
-        <path d="M15.8 13.6c2 .2 3.7 1.5 4.7 4.4" strokeLinecap="round" />
-      </svg>
-    ),
-    description: (
-      <>角色（admin / user / org 角色）与资源 scope 双闸授权模型，
-        roles 已签发进 JWT；管理 API 覆盖用户 / 客户端 / 角色 / scope / token 全生命周期。</>
-    ),
-  },
-  {
-    title: '生产就绪运维面',
-    svg: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
-        <path d="M4 17a8 8 0 0116 0" strokeLinecap="round" />
-        <path d="M12 17l3.5-4" strokeLinecap="round" />
-        <circle cx="12" cy="17" r="1.4" />
-        <path d="M3 20h18" strokeLinecap="round" />
-      </svg>
-    ),
-    description: (
-      <>Prometheus 指标 + 六级结构化日志、账号锁定 runbook、PG 大版本升级 runbook、
-        部署验收清单、Redis L2 缓存（延迟双删一致性）与官方性能调优基线。</>
-    ),
-  },
+const FEATURE_ICONS = [
+  // bolt
+  <svg key="b" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <path d="M13 2L4.5 13.5H11L9.5 22 19 10h-6.5L13 2z" strokeLinejoin="round" />
+  </svg>,
+  // lock
+  <svg key="l" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <rect x="4" y="10" width="16" height="10" rx="2" />
+    <path d="M8 10V7a4 4 0 018 0v3" strokeLinecap="round" />
+  </svg>,
+  // code
+  <svg key="c" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <path d="M8 8l-5 4 5 4M16 8l5 4-5 4M13 5l-2 14" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
+  // shield-check
+  <svg key="s" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7l8-4z" strokeLinejoin="round" />
+    <path d="M9 12l2 2 4-4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
+  // users
+  <svg key="u" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <circle cx="9" cy="8" r="3.2" />
+    <path d="M3.5 19c.7-3 2.9-4.5 5.5-4.5S13.8 16 14.5 19" strokeLinecap="round" />
+    <circle cx="17" cy="9" r="2.4" />
+    <path d="M15.8 13.6c2 .2 3.7 1.5 4.7 4.4" strokeLinecap="round" />
+  </svg>,
+  // gauge
+  <svg key="g" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <path d="M4 17a8 8 0 0116 0" strokeLinecap="round" />
+    <path d="M12 17l3.5-4" strokeLinecap="round" />
+    <circle cx="12" cy="17" r="1.4" />
+    <path d="M3 20h18" strokeLinecap="round" />
+  </svg>,
 ];
 
 const BENCHMARKS = [
@@ -118,49 +197,56 @@ function Feature({ title, svg, description }) {
 }
 
 export default function Home() {
+  const { i18n } = useDocusaurusContext();
+  const t = STRINGS[i18n.currentLocale] || STRINGS.en;
+
+  const quickStart = [
+    t.QUICK_START_COMMENT_1,
+    'docker compose -f deploy/docker/docker-compose.yml up -d --build',
+    '',
+    t.QUICK_START_COMMENT_2,
+    t.QUICK_START_COMMENT_3,
+    t.QUICK_START_COMMENT_4,
+  ].join('\n');
+
+  const githubBtn = (
+    <a className={clsx('button button--secondary button--lg', styles.githubBtn)} href="https://github.com/voidvec/fulla">
+      <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
+      </svg>
+      GitHub
+    </a>
+  );
+
   return (
-    <Layout
-      title="fulla — 高性能开源 IAM 内核（C++17）"
-      description="生产级 OAuth2/OIDC 授权服务器 + 可嵌入 C++17 SDK：授权码/PKCE、MFA、WebAuthn、RBAC、多租户，附管理后台、用户前端与官方 Python/Go 客户端。"
-    >
+    <Layout title={t.title} description={t.description}>
       <main>
         {/* ---------------- Hero ---------------- */}
         <section className={styles.hero}>
           <div className="container">
             <div className={styles.heroBadges}>
-              <span className={styles.badge}>MIT License</span>
-              <span className={styles.badge}>五项基准场景全面领先</span>
-              <span className={styles.badge}>Docker · Helm · C++ SDK</span>
+              {t.badges.map((b) => (
+                <span key={b} className={styles.badge}>{b}</span>
+              ))}
             </div>
             <h1 className={styles.heroTitle}>
               <img src="/img/favicon.svg" alt="fulla" className={styles.heroLogo} />
               fulla
             </h1>
             <p className={styles.heroTagline}>
-              以 C++17 构建的<span className={styles.heroAccent}> 高性能身份与访问管理内核</span>
+              {t.taglinePre}
+              <span className={styles.heroAccent}>{t.taglineAccent}</span>
+              {t.taglinePost}
             </p>
-            <p className={styles.heroSubtitle}>
-              生产级 OAuth2 / OIDC 授权服务器，开箱即用（Docker / Helm）；
-              亦可作为可嵌入 SDK（<code>find_package(fulla-*)</code>）集成进你的 C++ 工程。
-              附管理后台、用户前端与官方 Python / Go 客户端。
-            </p>
+            <p className={styles.heroSubtitle}>{t.subtitle}</p>
             <div className={styles.heroCtas}>
               <Link className="button button--primary button--lg" to="/docs/intro">
-                阅读文档
+                {t.ctaDocs}
               </Link>
-              <Link
-                className="button button--secondary button--lg"
-                to="/docs/operate/docker-deployment">
-                快速开始
+              <Link className="button button--secondary button--lg" to="/docs/operate/docker-deployment">
+                {t.ctaQuick}
               </Link>
-              <a
-                className={clsx('button button--secondary button--lg', styles.githubBtn)}
-                href="https://github.com/voidvec/fulla">
-                <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-                GitHub
-              </a>
+              {githubBtn}
             </div>
           </div>
         </section>
@@ -170,19 +256,16 @@ export default function Home() {
           <div className="container">
             <div className={clsx('row', styles.quickRow)}>
               <div className={clsx('col col--5', styles.quickText)}>
-                <h2>五分钟跑起来</h2>
-                <p>
-                  一条命令拉起全栈：后端（OAuth2/OIDC）+ PostgreSQL 17 + Redis +
-                  用户前端 + 管理后台 + Prometheus。种子数据内置，
-                  <code>admin / admin</code> 登录管理后台即可体验完整流程。
-                </p>
+                <h2>{t.quickTitle}</h2>
+                <p>{t.quickText}</p>
                 <p className={styles.quickHint}>
-                  从源码构建（Conan 2 + CMake presets，与 CI 同构）见
-                  <Link to="/docs/intro">文档 · 开始</Link>。
+                  {t.quickHint.pre}
+                  <Link to="/docs/intro">{t.quickHintLink}</Link>
+                  {t.quickHint.post}
                 </p>
               </div>
               <div className={clsx('col col--7', styles.quickCode)}>
-                <CodeBlock language="bash">{QUICK_START}</CodeBlock>
+                <CodeBlock language="bash">{quickStart}</CodeBlock>
               </div>
             </div>
           </div>
@@ -191,10 +274,10 @@ export default function Home() {
         {/* ---------------- Features ---------------- */}
         <section className={clsx(styles.section, styles.featuresSection)}>
           <div className="container">
-            <h2 className={styles.sectionTitle}>为什么选择 fulla</h2>
+            <h2 className={styles.sectionTitle}>{t.whyTitle}</h2>
             <div className="row">
-              {FEATURES.map((f) => (
-                <Feature key={f.title} {...f} />
+              {t.features.map((f, i) => (
+                <Feature key={f.title} title={f.title} svg={FEATURE_ICONS[i]} description={f.description} />
               ))}
             </div>
           </div>
@@ -203,23 +286,21 @@ export default function Home() {
         {/* ---------------- Benchmark strip ---------------- */}
         <section className={styles.section}>
           <div className="container">
-            <h2 className={styles.sectionTitle}>
-              性能：同机同后端，五项场景全部领先
-            </h2>
+            <h2 className={styles.sectionTitle}>{t.benchTitle}</h2>
             <p className={styles.sectionSubtitle}>
-              与 Keycloak 26 / Ory Hydra v26 / Zitadel v4 同机对比
-              （WSL2 8 vCPU · PostgreSQL 17 · wrk 阶梯负载 · 各家官方生产配置）。
-              下表为稳态 QPS，"最快竞品"为三者中最高值；完整方法学与数据见
+              {t.benchSubtitlePre}
               <a href="https://github.com/voidvec/fulla/blob/master/benchmarks/competitors/results/COMPARISON.md" target="_blank" rel="noopener">
-                基准对比报告</a>。
+                {t.benchSubtitleLink}
+              </a>
+              {t.benchSubtitlePost}
             </p>
             <div className={styles.benchRow}>
               {BENCHMARKS.map((b) => (
                 <div key={b.scenario} className={styles.benchCard}>
                   <div className={styles.benchScenario}>{b.scenario}</div>
                   <div className={styles.benchQps}>{b.fulla}</div>
-                  <div className={styles.benchRatio}>领先最快竞品 {b.ratio}</div>
-                  <div className={styles.benchBest}>最快竞品 {b.best} QPS</div>
+                  <div className={styles.benchRatio}>{t.leadPrefix}{b.ratio}</div>
+                  <div className={styles.benchBest}>{t.rivalQps} {b.best} QPS</div>
                 </div>
               ))}
             </div>
@@ -229,17 +310,14 @@ export default function Home() {
         {/* ---------------- Closing CTA ---------------- */}
         <section className={clsx(styles.section, styles.closing)}>
           <div className="container">
-            <h2>开始使用</h2>
-            <p>
-              评估架构 → 跑起来 → 集成 → 部署生产，每一步都有对应文档；
-              每个关键设计决策都有 ADR 可溯。
-            </p>
+            <h2>{t.closingTitle}</h2>
+            <p>{t.closingText}</p>
             <div className={styles.heroCtas}>
               <Link className="button button--primary button--lg" to="/docs/intro">
-                进入文档
+                {t.closingDocs}
               </Link>
               <Link className="button button--secondary button--lg" to="/docs/adr/ADR-0001">
-                浏览 ADR
+                {t.closingAdr}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Closes governance Phase C (docs/documentation-governance.md v4).

## Phase C deep-dives (both languages)
- **token-lifecycle** — three token shapes (opaque access/refresh + JWT id_token per ADR-0004), hash-at-rest, refresh family rotation & reuse cascade, revocation surfaces, cache interplay
- **session-management** — SSO session vs token lifetimes; drogon#278 retention cost + the sizing table, now its single home (deployment.md keeps an operational pointer only)
- **multi-tenancy** — V017 org model + admin API, with an explicit not-yet roadmap (issuer_override stored-not-applied etc.)

## English-primary bilingual site
- docs/ = English canonical (~40 files translated; code byte-identical)
- Chinese tree verbatim-moved to website/i18n/zh-CN/...
- navbar locale switcher, editLocalizedFiles, locale-aware chrome, bilingual landing
- trust archives keep Chinese body in both locales + English note; governance v4 (same-PR dual-write discipline)
- legacy docs/CNAME removed (Pages = GitHub Actions + website/static/CNAME)

## Verification
- `npm run build` green for **both** locales incl. broken-link gates (10 tree-escaping links absolutized)
- landing/sidebar/footer/search indexes spot-checked per locale