### PR TITLE
docs: bilingual follow-up (zh README links, CONTRIBUTING dual-write rule, changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ For the versioning policy (when to cut, what to bump, why), see
 
 ## [Unreleased]
 
+### 文档
+
+- **文档治理收官**（PR #114/#116，治理文档 v4，[docs/documentation-governance.md](docs/documentation-governance.md)）：
+  用户向文档树按受众七区重构（evaluate / integrate / deep dives / operate /
+  contribute / benchmark / adr），12 篇 ADR + 三份信任档案（合规尽调、改名
+  影响、仓库审计）入库；fulla.dev 上线为 Docusaurus 双语站——**英文主站**
+  （`docs/` 为英文正本）+ `/zh-CN` 中文站（译本树
+  `website/i18n/zh-CN/`，同构同 URL，导航栏切换）；新增三篇深潜
+  （令牌生命周期 / 会话管理 / 多租户）；站点带离线中文搜索与死链门。
+  文档改动义务：**同 PR 双写**（en/zh 同步，见 CONTRIBUTING）。
+
 ## [1.0.0] - 2026-08-26
 
 > **版本序列重置说明**：项目由 **authforge 更名为 fulla**（北欧神话中 Frigg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,15 @@ Rules:
 - Branch names: `feat/<topic>`, `fix/<topic>`, `docs/<topic>`.
 - Target branch is `master`; every PR must pass all CI checks before merge.
 
+### Documentation changes are bilingual (same-PR dual write)
+
+The docs are bilingual: `docs/` is the English canonical and
+`website/i18n/zh-CN/docusaurus-plugin-content-docs/current/` is the Chinese
+mirror (identical layout/URLs; both feed [fulla.dev](https://fulla.dev)).
+A PR that changes a document under `docs/` **must update its Chinese
+counterpart in the same PR** (and vice versa). Full rules:
+[docs/documentation-governance.md](docs/documentation-governance.md) §4.
+
 ## CI Gates
 
 A PR runs `ci.yml` + `security.yml`:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,13 +22,13 @@ Fulla 是以 C++17 构建的**高性能开源身份与访问管理（IAM）核�
 
 | 领域 | 能力 | 深入文档 |
 |------|------|----------|
-| **认证** | 登录/注册、邮箱验证、密码重置、TOTP MFA、WebAuthn (FIDO2)、Google/微信社交登录、渐进式账户锁定 | [安全架构](docs/architecture/security-architecture.md) |
-| **授权（OAuth2/OIDC）** | 授权码 + PKCE、client-credentials、刷新轮换、设备流、动态客户端注册、用户同意、内省、吊销、OIDC discovery/JWKS/UserInfo、含前/后向通道登出的 end-session | [架构总览](docs/architecture/architecture-overview.md) |
-| **访问控制** | RBAC（内置 admin/user + 自定义角色）、细粒度 scope、DB 驱动的资源 scope 注册表、三重校验（客户端限制 + 角色 + 同意） | [RBAC 指南](docs/domains/rbac-guide.md) |
+| **认证** | 登录/注册、邮箱验证、密码重置、TOTP MFA、WebAuthn (FIDO2)、Google/微信社交登录、渐进式账户锁定 | [安全架构](https://fulla.dev/zh-CN/docs/architecture/security-architecture) |
+| **授权（OAuth2/OIDC）** | 授权码 + PKCE、client-credentials、刷新轮换、设备流、动态客户端注册、用户同意、内省、吊销、OIDC discovery/JWKS/UserInfo、含前/后向通道登出的 end-session | [架构总览](https://fulla.dev/zh-CN/docs/architecture/architecture-overview) |
+| **访问控制** | RBAC（内置 admin/user + 自定义角色）、细粒度 scope、DB 驱动的资源 scope 注册表、三重校验（客户端限制 + 角色 + 同意） | [RBAC 指南](https://fulla.dev/zh-CN/docs/domains/rbac-guide) |
 | **令牌生命周期** | 签发、TTL 约束保留、基于家族的刷新轮换、按令牌/客户端/用户吊销、延迟双删的缓存旁路失效 | — |
 | **多租户** | 组织、组织级客户端与用户、租户感知的管理 | — |
-| **可观测性** | Prometheus 指标、结构化审计日志（登录/令牌/密码事件）、健康探针（live/ready） | [可观测性](docs/operate/observability.md) |
-| **运维** | Docker Compose / Helm 部署、cosign 签名多架构镜像、SBOM、配置文件 + 环境变量驱动配置 | [生产部署](docs/operate/deployment.md) |
+| **可观测性** | Prometheus 指标、结构化审计日志（登录/令牌/密码事件）、健康探针（live/ready） | [可观测性](https://fulla.dev/zh-CN/docs/operate/observability) |
+| **运维** | Docker Compose / Helm 部署、cosign 签名多架构镜像、SBOM、配置文件 + 环境变量驱动配置 | [生产部署](https://fulla.dev/zh-CN/docs/operate/deployment) |
 
 ## 模块地图（Module Map）
 
@@ -201,7 +201,7 @@ python3 benchmarks/reporting/gen-comparison.py
 ```
 
 方法论与公平性偏离项（各家配置出处、对齐了什么没对齐什么）：
-[competitor-benchmark-design.md](docs/benchmark/competitor-benchmark-design.md)。
+[competitor-benchmark-design.md](https://fulla.dev/zh-CN/docs/benchmark/competitor-benchmark-design)。
 Fulla 侧场景细节：[benchmarks/README.md](benchmarks/README.md)。
 
 ---
@@ -267,7 +267,7 @@ find_package(fulla-storage-memory CONFIG REQUIRED)
 target_link_libraries(my-engine PRIVATE fulla::oauth2 fulla::storage::memory)
 ```
 
-> v1.x 对公共头（`include/fulla/**`）承诺**源码级 SemVer**（CI 中 api-diff 门禁强制），不承诺二进制 ABI。第三方依赖请用仓库的 `conanfile.py` + `conan.lock` 解析。详见 [SDK 集成指南](docs/sdk/sdk-integration-guide.md) · [SDK 运行时契约](docs/sdk/sdk-runtime-contract.md)；参考消费方：[`examples/full-stack-host`](examples/full-stack-host)、[`examples/third-party-host`](examples/third-party-host)（均由 CI 持续验证）。
+> v1.x 对公共头（`include/fulla/**`）承诺**源码级 SemVer**（CI 中 api-diff 门禁强制），不承诺二进制 ABI。第三方依赖请用仓库的 `conanfile.py` + `conan.lock` 解析。详见 [SDK 集成指南](https://fulla.dev/zh-CN/docs/sdk/sdk-integration-guide) · [SDK 运行时契约](https://fulla.dev/zh-CN/docs/sdk/sdk-runtime-contract)；参考消费方：[`examples/full-stack-host`](examples/full-stack-host)、[`examples/third-party-host`](examples/third-party-host)（均由 CI 持续验证）。
 
 ### 路径 D — 客户端 SDK（Python / Go）
 
@@ -307,7 +307,7 @@ client, _ := af.NewM2MClient(ctx, "http://localhost:5555", "backend-svc", "…",
 helm install fulla deploy/helm/fulla -f my-values.yaml
 ```
 
-完整流程：[生产部署指南](docs/operate/deployment.md) · [Windows / Docker Desktop](docs/operate/deployment-windows-docker-desktop.md) · [安全清单](docs/architecture/security-architecture.md)
+完整流程：[生产部署指南](https://fulla.dev/zh-CN/docs/operate/deployment) · [Windows / Docker Desktop](https://fulla.dev/zh-CN/docs/operate/deployment-windows-docker-desktop) · [安全清单](https://fulla.dev/zh-CN/docs/architecture/security-architecture)
 
 ---
 
@@ -377,7 +377,7 @@ ctest --output-on-failure
 
 - **OpenAPI 规范**：[openapi.yaml](apps/server/openapi.yaml)
 - **Swagger UI**：`http://localhost:5555/docs/api`（需部署 Swagger UI 静态文件）
-- **E2E 测试指南**：[Admin E2E 方法论](docs/contribute/admin-e2e-testing-guide.md)
+- **E2E 测试指南**：[Admin E2E 方法论](https://fulla.dev/zh-CN/docs/contribute/admin-e2e-testing-guide)
 
 ---
 
@@ -386,15 +386,15 @@ ctest --output-on-failure
 **在线文档站：[fulla.dev/zh-CN](https://fulla.dev/zh-CN)** —— 由本仓库 `docs/` 目录（英文正本）及其
 `website/i18n/zh-CN/` 中文译本直接构建，随 master 持续更新；站点右上角可切换中英文。
 
-**评估选型** — [架构总览](docs/architecture/architecture-overview.md) · [安全架构](docs/architecture/security-architecture.md) · [RBAC 权限](docs/domains/rbac-guide.md) · [性能对比](benchmarks/competitors/results/COMPARISON.md)
+**评估选型** — [架构总览](https://fulla.dev/zh-CN/docs/architecture/architecture-overview) · [安全架构](https://fulla.dev/zh-CN/docs/architecture/security-architecture) · [RBAC 权限](https://fulla.dev/zh-CN/docs/domains/rbac-guide) · [性能对比](benchmarks/competitors/results/COMPARISON.md)
 
-**SDK 集成** — [SDK 集成指南](docs/sdk/sdk-integration-guide.md) · [SDK 运行时契约](docs/sdk/sdk-runtime-contract.md) · [API 参考](docs/domains/api-reference.md)
+**SDK 集成** — [SDK 集成指南](https://fulla.dev/zh-CN/docs/sdk/sdk-integration-guide) · [SDK 运行时契约](https://fulla.dev/zh-CN/docs/sdk/sdk-runtime-contract) · [API 参考](https://fulla.dev/zh-CN/docs/domains/api-reference)
 
-**运维部署** — [生产部署指南](docs/operate/deployment.md) · [配置指南](docs/operate/configuration-guide.md) · [可观测性](docs/operate/observability.md) · [账号锁定机制](docs/operate/account-lockout.md)
+**运维部署** — [生产部署指南](https://fulla.dev/zh-CN/docs/operate/deployment) · [配置指南](https://fulla.dev/zh-CN/docs/operate/configuration-guide) · [可观测性](https://fulla.dev/zh-CN/docs/operate/observability) · [账号锁定机制](https://fulla.dev/zh-CN/docs/operate/account-lockout)
 
-**参与贡献** — [CONTRIBUTING.md](CONTRIBUTING.md) · [测试指南](docs/contribute/testing-guide.md) · [CI/CD 流水线](docs/contribute/ci-cd-guide.md)
+**参与贡献** — [CONTRIBUTING.md](CONTRIBUTING.md) · [测试指南](https://fulla.dev/zh-CN/docs/contribute/testing-guide) · [CI/CD 流水线](https://fulla.dev/zh-CN/docs/contribute/ci-cd-guide)
 
-完整索引：[docs/README.md](docs/README.md)
+完整索引：[docs/README.md](https://fulla.dev/zh-CN/docs/intro)
 
 ---
 


### PR DESCRIPTION
Three follow-ups from the docs-governance wrap-up:

- **README.zh-CN.md**: 25 `docs/` links repointed to their fulla.dev/zh-CN counterparts — Chinese readers previously landed on the English repo files
- **CONTRIBUTING.md**: documents the same-PR dual-write obligation (docs/ English canonical + website/i18n/zh-CN/ mirror) per governance v4 §4
- **CHANGELOG.md**: Unreleased archival entry for the docs-governance conclusion (PR #114/#116) and the bilingual site

No code changes; docs/ tree untouched (site unaffected).