### PR TITLE
docs: P2 cleanup — verification script into scripts/, ADR reference linkification

### DIFF
--- a/docs/adr/ADR-0001.md
+++ b/docs/adr/ADR-0001.md
@@ -12,7 +12,7 @@ The repository carries both a directly deployable authorization-server product a
 
 ## Decision
 
-Deliver with the product as the mainline while distilling fulla::oauth2 and fulla::identity into two embeddable SDKs. The three Domain packages (common/oauth2/identity) are forbidden from including Drogon (jsoncpp is allowed); oauth2 and identity have no compile-time dependency on each other; all cross-package ports sink into common; apps/server is the sole assembly point responsible for dependency injection; tools/arch-guard enforces all of the above in CI.
+Deliver with the product as the mainline while distilling fulla::oauth2 and fulla::identity into two embeddable SDKs. The three Domain packages (common/oauth2/identity) are forbidden from including Drogon (jsoncpp is allowed); oauth2 and identity have no compile-time dependency on each other; all cross-package ports sink into common; apps/server is the sole assembly point responsible for dependency injection; [tools/arch-guard](https://github.com/voidvec/fulla/blob/master/tools/arch-guard) enforces all of the above in CI.
 
 ## Consequences and Current State
 

--- a/docs/adr/ADR-0003.md
+++ b/docs/adr/ADR-0003.md
@@ -16,4 +16,4 @@ For every error code (including OAuth2 protocol codes), the code/numeric/categor
 
 ## Consequences and Current State
 
-ErrorCatalog.cc (525 lines) + unit tests force documentation sync (the api-reference error table is verified by tests); the 4006 added in PR#85 went through exactly this process.
+ErrorCatalog.cc (525 lines) + unit tests force documentation sync (the [api-reference](../domains/api-reference.md) error table is verified by tests); the 4006 added in [PR#85](https://github.com/voidvec/fulla/pull/85) went through exactly this process.

--- a/docs/adr/ADR-0004.md
+++ b/docs/adr/ADR-0004.md
@@ -16,4 +16,4 @@ Access tokens remain opaque random strings, validated by resource servers via in
 
 ## Consequences and Current State
 
-The introspection/revocation endpoints are public contract; V001–V026 evolved append-only; migration immutability is enforced by the CI migration-check gate.
+The introspection/revocation endpoints are public contract; V001–V026 evolved append-only; migration immutability is enforced by the migration-hygiene gate in [ci.yml](https://github.com/voidvec/fulla/blob/master/.github/workflows/ci.yml).

--- a/docs/adr/ADR-0005.md
+++ b/docs/adr/ADR-0005.md
@@ -16,4 +16,4 @@ Login identifiers are dispatched by whether they contain @ (the username charset
 
 ## Consequences and Current State
 
-The V020 migration is in the repository; the login semantics in operational documents such as verification-checklist follow this ADR.
+The V020 migration is in the repository; the login semantics in operational documents such as the [verification checklist](../operate/verification-checklist.md) follow this ADR.

--- a/docs/adr/ADR-0006.md
+++ b/docs/adr/ADR-0006.md
@@ -16,4 +16,4 @@ Any object carrying async callbacks uses enable_shared_from_this; lambdas captur
 
 ## Consequences and Current State
 
-This discipline is codified in .claude/rules/db-operations.md as a project iron rule; all 11 concurrency-audit defects have been fixed with regression tests.
+This discipline is codified in [`db-operations.md`](https://github.com/voidvec/fulla/blob/master/.claude/rules/db-operations.md) (maintainer-facing rule source) as a project iron rule; all 11 concurrency-audit defects have been fixed with regression tests.

--- a/docs/adr/ADR-0008.md
+++ b/docs/adr/ADR-0008.md
@@ -16,4 +16,4 @@ First-party login keeps the AJAX /oauth2/login (json=true) flow that returns the
 
 ## Consequences and Current State
 
-frontends/user's authService/http implement this; the third-party integration path is documented in oidc-guide.
+[frontends/user](https://github.com/voidvec/fulla/tree/master/frontends/user)'s authService/http implement this; the third-party integration path is documented in the [OIDC guide](../domains/oidc-guide.md).

--- a/docs/adr/ADR-0009.md
+++ b/docs/adr/ADR-0009.md
@@ -16,4 +16,4 @@ The 14 drogon_ctl-generated model class names/namespaces are never renamed (this
 
 ## Consequences and Current State
 
-This decision was validated through both the repo refactor and the SDK refactor; migration-check (M5) enforces migration immutability in CI; keeping the oauth2_* table/class names intact during the 2026-08 renaming project is precisely this ADR in action.
+This decision was validated through both the repo refactor and the SDK refactor; the migration-hygiene gate in [ci.yml](https://github.com/voidvec/fulla/blob/master/.github/workflows/ci.yml) enforces migration immutability in CI; keeping the oauth2_* table/class names intact during the 2026-08 renaming project is precisely this ADR in action.

--- a/docs/adr/ADR-0011.md
+++ b/docs/adr/ADR-0011.md
@@ -16,4 +16,4 @@ DB-backed integration/contract tests run only on the Linux CI leg (with PG/Redis
 
 ## Consequences and Current State
 
-The ci.yml three-platform matrix is tiered accordingly; the local full_test runs against a real DB.
+The [ci.yml](https://github.com/voidvec/fulla/blob/master/.github/workflows/ci.yml) three-platform matrix is tiered accordingly; the local full_test runs against a real DB.

--- a/docs/adr/ADR-0012.md
+++ b/docs/adr/ADR-0012.md
@@ -16,4 +16,4 @@ Stay on C++17 with the callback style: coroutines are excluded because MSVC/gcc 
 
 ## Consequences and Current State
 
-Callback discipline is governed by the lifetime pattern of ADR-0006; db-operations.md explicitly bans CoroMapper.
+Callback discipline is governed by the lifetime pattern of [ADR-0006](ADR-0006.md); [db-operations.md](https://github.com/voidvec/fulla/blob/master/.claude/rules/db-operations.md) explicitly bans CoroMapper.

--- a/docs/operate/verification-checklist.md
+++ b/docs/operate/verification-checklist.md
@@ -761,170 +761,20 @@ docker logs fulla-backend | grep -i "auth\|token"
 
 ### Full Verification Script (PowerShell)
 
-Save as `verify-deployment.ps1`:
-
-```powershell
-# fulla deployment verification script
-param(
-    [string]$BackendUrl = "http://localhost:5555",
-    [string]$FrontendUrl = "http://localhost:8080",
-    [string]$AdminUrl = "http://localhost:8081",
-    [switch]$Verbose
-}
-
-function Test-ContainerStatus {
-    Write-Host "`n[1/8] Checking container status..." -ForegroundColor Cyan
-    $containers = docker compose -f deploy/docker/docker-compose.yml ps
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "[+] All containers are running normally" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] Container status abnormal" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-BackendHealth {
-    Write-Host "`n[2/8] Checking backend health..." -ForegroundColor Cyan
-    try {
-        $response = Invoke-RestMethod -Uri "$BackendUrl/health" -Method Get
-        if ($response.status -eq "healthy") {
-            Write-Host "[+] Backend health check passed" -ForegroundColor Green
-            return $true
-        }
-    } catch {
-        Write-Host "[-] Backend health check failed: $_" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-DatabaseConnection {
-    Write-Host "`n[3/8] Checking database connection..." -ForegroundColor Cyan
-    $result = docker exec fulla-postgres pg_isready -U fulla_user 2>&1
-    if ($LASTEXITCODE -eq 0 -and $result -match "accepting connections") {
-        Write-Host "[+] Database connection is normal" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] Database connection failed" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-DatabaseTables {
-    Write-Host "`n[4/8] Checking database table structure..." -ForegroundColor Cyan
-    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
-        SELECT COUNT(*) FROM information_schema.tables 
-        WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
-    " 2>&1
-    
-    $tableCount = [int]$result.Trim()
-    if ($tableCount -ge 20) {
-        Write-Host "[+] Database table structure complete ($tableCount tables)" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] Database table structure incomplete (only $tableCount tables)" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-SeedData {
-    Write-Host "`n[5/8] Checking seed data..." -ForegroundColor Cyan
-    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
-        SELECT COUNT(*) FROM users WHERE username = 'admin';
-    " 2>&1
-    
-    $count = [int]$result.Trim()
-    if ($count -eq 1) {
-        Write-Host "[+] Admin account has been created" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] Admin account has not been created" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-RedisConnection {
-    Write-Host "`n[6/8] Checking Redis connection..." -ForegroundColor Cyan
-    $result = docker exec fulla-redis redis-cli -a redis_secret_pass ping 2>&1
-    if ($result -match "PONG") {
-        Write-Host "[+] Redis connection is normal" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] Redis connection failed" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-DiscoveryEndpoint {
-    Write-Host "`n[7/8] Testing the OIDC discovery endpoint..." -ForegroundColor Cyan
-    # For the full login flow (PKCE), see Phase 3 above; scripted deployment checks use the discovery
-    # endpoint to verify that the backend OAuth2 stack is ready without depending on specific credentials.
-    try {
-        $response = Invoke-RestMethod -Uri "$BackendUrl/.well-known/openid-configuration" -Method Get
-        if ($response.issuer -and $response.token_endpoint) {
-            Write-Host "[+] OIDC discovery endpoint is normal (issuer: $($response.issuer))" -ForegroundColor Green
-            return $true
-        }
-    } catch {
-        Write-Host "[-] OIDC discovery endpoint failed: $_" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-FrontendAccess {
-    Write-Host "`n[8/8] Checking frontend access..." -ForegroundColor Cyan
-    try {
-        $response = Invoke-WebRequest -Uri $FrontendUrl -Method Get -UseBasicParsing
-        if ($response.StatusCode -eq 200) {
-            Write-Host "[+] Frontend page is accessible" -ForegroundColor Green
-            return $true
-        }
-    } catch {
-        Write-Host "[-] Frontend page access failed: $_" -ForegroundColor Red
-        return $false
-    }
-}
-
-# Run all tests
-$results = @()
-$results += Test-ContainerStatus
-$results += Test-BackendHealth
-$results += Test-DatabaseConnection
-$results += Test-DatabaseTables
-$results += Test-SeedData
-$results += Test-RedisConnection
-$results += Test-DiscoveryEndpoint
-$results += Test-FrontendAccess
-
-# Summarize the results
-$passed = ($results | Where-Object { $_ -eq $true }).Count
-$total = $results.Count
-
-Write-Host "`n" -NoNewline
-Write-Host ("=" * 60) -ForegroundColor DarkGray
-Write-Host "Verification results: $passed / $total passed" -ForegroundColor $(if ($passed -eq $total) { "Green" } else { "Yellow" })
-Write-Host ("=" * 60) -ForegroundColor DarkGray
-
-if ($passed -eq $total) {
-    Write-Host "`n[+] Deployment verification fully passed! The system is ready for use." -ForegroundColor Green
-    exit 0
-} else {
-    Write-Host "`n[-] Deployment verification failed; please review the failed items above." -ForegroundColor Red
-    exit 1
-}
-```
+The script ships in the repository:
+[`scripts/backend/verify-deployment.ps1`](https://github.com/voidvec/fulla/blob/master/scripts/backend/verify-deployment.ps1).
+Run it from the repo root — it executes the eight checks below (container
+status, backend health, DB connection, table completeness, seed admin,
+Redis, OIDC discovery, frontend access) and exits non-zero on any failure.
 
 **Usage**:
 
 ```powershell
 # Basic verification
-.\verify-deployment.ps1
-
-# Verbose mode
-.\verify-deployment.ps1 -Verbose
+.\scripts\backend\verify-deployment.ps1
 
 # Custom endpoints
-.\verify-deployment.ps1 -BackendUrl "https://your-domain.com" -FrontendUrl "https://your-domain.com"
+.\scripts\backend\verify-deployment.ps1 -BackendUrl "https://your-domain.com" -FrontendUrl "https://your-domain.com"
 ```
 
 ---

--- a/scripts/backend/verify-deployment.ps1
+++ b/scripts/backend/verify-deployment.ps1
@@ -1,0 +1,156 @@
+# fulla deployment verification script
+# ----------------------------------------------------------------
+# 8-step post-deployment acceptance check (see docs/operate/verification-checklist.md
+# "Automated Verification Script"): containers, backend health, DB connection,
+# table count, seed admin, Redis, OIDC discovery, frontend reachability.
+# Run from the repository root (docker compose paths are relative to it).
+#
+# Exit codes: 0 = all checks passed, 1 = at least one failed.
+param(
+    [string]$BackendUrl = "http://localhost:5555",
+    [string]$FrontendUrl = "http://localhost:8080",
+    [string]$AdminUrl = "http://localhost:8081",
+    [switch]$Verbose
+)
+
+function Test-ContainerStatus {
+    Write-Host "`n[1/8] Checking container status..." -ForegroundColor Cyan
+    $containers = docker compose -f deploy/docker/docker-compose.yml ps
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "[+] All containers are running normally" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] Container status abnormal" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-BackendHealth {
+    Write-Host "`n[2/8] Checking backend health..." -ForegroundColor Cyan
+    try {
+        $response = Invoke-RestMethod -Uri "$BackendUrl/health" -Method Get
+        if ($response.status -eq "healthy") {
+            Write-Host "[+] Backend health check passed" -ForegroundColor Green
+            return $true
+        }
+    } catch {
+        Write-Host "[-] Backend health check failed: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-DatabaseConnection {
+    Write-Host "`n[3/8] Checking database connection..." -ForegroundColor Cyan
+    $result = docker exec fulla-postgres pg_isready -U fulla_user 2>&1
+    if ($LASTEXITCODE -eq 0 -and $result -match "accepting connections") {
+        Write-Host "[+] Database connection is normal" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] Database connection failed" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-DatabaseTables {
+    Write-Host "`n[4/8] Checking database table structure..." -ForegroundColor Cyan
+    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
+        SELECT COUNT(*) FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
+    " 2>&1
+
+    $tableCount = [int]$result.Trim()
+    if ($tableCount -ge 20) {
+        Write-Host "[+] Database table structure complete ($tableCount tables)" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] Database table structure incomplete (only $tableCount tables)" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-SeedData {
+    Write-Host "`n[5/8] Checking seed data..." -ForegroundColor Cyan
+    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
+        SELECT COUNT(*) FROM users WHERE username = 'admin';
+    " 2>&1
+
+    $count = [int]$result.Trim()
+    if ($count -eq 1) {
+        Write-Host "[+] Admin account has been created" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] Admin account has not been created" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-RedisConnection {
+    Write-Host "`n[6/8] Checking Redis connection..." -ForegroundColor Cyan
+    $result = docker exec fulla-redis redis-cli -a redis_secret_pass ping 2>&1
+    if ($result -match "PONG") {
+        Write-Host "[+] Redis connection is normal" -ForegroundColor Green
+        return $true
+    } else {
+        Write-Host "[-] Redis connection failed" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-DiscoveryEndpoint {
+    Write-Host "`n[7/8] Testing the OIDC discovery endpoint..." -ForegroundColor Cyan
+    # For the full login flow (PKCE), see the checklist's Phase 3; scripted deployment
+    # checks use the discovery endpoint to verify that the backend OAuth2 stack is
+    # ready without depending on specific credentials.
+    try {
+        $response = Invoke-RestMethod -Uri "$BackendUrl/.well-known/openid-configuration" -Method Get
+        if ($response.issuer -and $response.token_endpoint) {
+            Write-Host "[+] OIDC discovery endpoint is normal (issuer: $($response.issuer))" -ForegroundColor Green
+            return $true
+        }
+    } catch {
+        Write-Host "[-] OIDC discovery endpoint failed: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Test-FrontendAccess {
+    Write-Host "`n[8/8] Checking frontend access..." -ForegroundColor Cyan
+    try {
+        $response = Invoke-WebRequest -Uri $FrontendUrl -Method Get -UseBasicParsing
+        if ($response.StatusCode -eq 200) {
+            Write-Host "[+] Frontend page is accessible" -ForegroundColor Green
+            return $true
+        }
+    } catch {
+        Write-Host "[-] Frontend page access failed: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+# Run all tests
+$results = @()
+$results += Test-ContainerStatus
+$results += Test-BackendHealth
+$results += Test-DatabaseConnection
+$results += Test-DatabaseTables
+$results += Test-SeedData
+$results += Test-RedisConnection
+$results += Test-DiscoveryEndpoint
+$results += Test-FrontendAccess
+
+# Summarize the results
+$passed = ($results | Where-Object { $_ -eq $true }).Count
+$total = $results.Count
+
+Write-Host "`n" -NoNewline
+Write-Host ("=" * 60) -ForegroundColor DarkGray
+Write-Host "Verification results: $passed / $total passed" -ForegroundColor $(if ($passed -eq $total) { "Green" } else { "Yellow" })
+Write-Host ("=" * 60) -ForegroundColor DarkGray
+
+if ($passed -eq $total) {
+    Write-Host "`n[+] Deployment verification fully passed! The system is ready for use." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "`n[-] Deployment verification failed; please review the failed items above." -ForegroundColor Red
+    exit 1
+}

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0001.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0001.md
@@ -12,7 +12,7 @@ source: sdk-refactor design.md §2/§4.1/§5.2（原始档案已出库，git 历
 
 ## 决策
 
-以产品为主线交付，同时沉淀 fulla::oauth2 与 fulla::identity 两个可嵌入 SDK。Domain 三包（common/oauth2/identity）禁止 include Drogon（允许 jsoncpp）；oauth2 与 identity 互不编译依赖；跨包端口全部下沉 common；apps/server 是唯一装配点负责依赖注入；tools/arch-guard 在 CI 强制以上全部。
+以产品为主线交付，同时沉淀 fulla::oauth2 与 fulla::identity 两个可嵌入 SDK。Domain 三包（common/oauth2/identity）禁止 include Drogon（允许 jsoncpp）；oauth2 与 identity 互不编译依赖；跨包端口全部下沉 common；apps/server 是唯一装配点负责依赖注入；[tools/arch-guard](https://github.com/voidvec/fulla/blob/master/tools/arch-guard) 在 CI 强制以上全部。
 
 ## 后果与现状对照
 

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0003.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0003.md
@@ -16,4 +16,4 @@ source: error-code-message-standardization design.md（AD-1..AD-6）+ auth-flow-
 
 ## 后果与现状对照
 
-ErrorCatalog.cc（525 行）+ 单测强制文档同步（api-reference 错误表由测试校验）；PR#85 的 4006 即按此流程新增。
+ErrorCatalog.cc（525 行）+ 单测强制文档同步（[api-reference](../domains/api-reference.md) 错误表由测试校验）；[PR#85](https://github.com/voidvec/fulla/pull/85) 的 4006 即按此流程新增。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0004.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0004.md
@@ -16,4 +16,4 @@ Access Token 保持 Opaque 随机串，资源服务器经 introspection（RFC 76
 
 ## 后果与现状对照
 
-introspection/revocation 端点为公开契约；V001–V026 追加式演进；迁移不可变由 CI migration-check 门禁。
+introspection/revocation 端点为公开契约；V001–V026 追加式演进；迁移不可变由 [ci.yml](https://github.com/voidvec/fulla/blob/master/.github/workflows/ci.yml) 的迁移卫生门禁。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0005.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0005.md
@@ -16,4 +16,4 @@ username 与 email 双标识并存导致登录歧义与唯一约束冲突。
 
 ## 后果与现状对照
 
-V020 迁移在库；verification-checklist 等运维文档的登录口径以此为准。
+V020 迁移在库；[部署验证清单](../operate/verification-checklist.md) 等运维文档的登录口径以此为准。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0006.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0006.md
@@ -16,4 +16,4 @@ Drogon 异步回调中裸 this 捕获与跨线程无锁访问是历史缺陷的�
 
 ## 后果与现状对照
 
-该纪律写入 .claude/rules/db-operations.md 成为项目铁律；并发审计的 11 项缺陷全部修复并有回归测试。
+该纪律写入 [`db-operations.md`](https://github.com/voidvec/fulla/blob/master/.claude/rules/db-operations.md)（维护者规则源）成为项目铁律；并发审计的 11 项缺陷全部修复并有回归测试。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0008.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0008.md
@@ -16,4 +16,4 @@ SPA 登录若把 PKCE verifier/token 持久化到 storage，XSS 即等于会话�
 
 ## 后果与现状对照
 
-frontends/user 的 authService/http 按此实现；第三方集成路径在 oidc-guide 说明。
+[frontends/user](https://github.com/voidvec/fulla/tree/master/frontends/user) 的 authService/http 按此实现；第三方集成路径在 [OIDC 指南](../domains/oidc-guide.md)说明。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0009.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0009.md
@@ -16,4 +16,4 @@ drogon_ctl 生成的 14 个模型类名/命名空间永不重命名（凌驾于�
 
 ## 后果与现状对照
 
-该决策穿越 repo 重构与 SDK 重构两次验证；migration-check（M5）在 CI 强制迁移不可变；2026-08 更名工程中 oauth2_* 表名/类名保持正是此 ADR 的应用。
+该决策穿越 repo 重构与 SDK 重构两次验证；[ci.yml](https://github.com/voidvec/fulla/blob/master/.github/workflows/ci.yml) 的迁移卫生门禁在 CI 强制迁移不可变；2026-08 更名工程中 oauth2_* 表名/类名保持正是此 ADR 的应用。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0011.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0011.md
@@ -16,4 +16,4 @@ DB-backed 集成/契约测试只在 Linux CI 腿运行（配 PG/Redis 服务容�
 
 ## 后果与现状对照
 
-ci.yml 三平台矩阵按此分档；本地 full_test 走真实 DB。
+[ci.yml](https://github.com/voidvec/fulla/blob/master/.github/workflows/ci.yml) 三平台矩阵按此分档；本地 full_test 走真实 DB。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0012.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/adr/ADR-0012.md
@@ -16,4 +16,4 @@ source: async-refactor-assessment.md 蒸馏（原始档案已出库，git 历史
 
 ## 后果与现状对照
 
-回调纪律由 ADR-0006 的生命周期模式约束；db-operations.md 明确禁 CoroMapper。
+回调纪律由 [ADR-0006](ADR-0006.md) 的生命周期模式约束；[db-operations.md](https://github.com/voidvec/fulla/blob/master/.claude/rules/db-operations.md) 明确禁 CoroMapper。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/verification-checklist.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/verification-checklist.md
@@ -761,170 +761,20 @@ docker logs fulla-backend | grep -i "auth\|token"
 
 ### 完整验证脚本（PowerShell）
 
-保存为 `verify-deployment.ps1`：
-
-```powershell
-# fulla 部署验证脚本
-param(
-    [string]$BackendUrl = "http://localhost:5555",
-    [string]$FrontendUrl = "http://localhost:8080",
-    [string]$AdminUrl = "http://localhost:8081",
-    [switch]$Verbose
-}
-
-function Test-ContainerStatus {
-    Write-Host "`n[1/8] 检查容器状态..." -ForegroundColor Cyan
-    $containers = docker compose -f deploy/docker/docker-compose.yml ps
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "[+] 所有容器运行正常" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] 容器状态异常" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-BackendHealth {
-    Write-Host "`n[2/8] 检查后端健康..." -ForegroundColor Cyan
-    try {
-        $response = Invoke-RestMethod -Uri "$BackendUrl/health" -Method Get
-        if ($response.status -eq "healthy") {
-            Write-Host "[+] 后端健康检查通过" -ForegroundColor Green
-            return $true
-        }
-    } catch {
-        Write-Host "[-] 后端健康检查失败: $_" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-DatabaseConnection {
-    Write-Host "`n[3/8] 检查数据库连接..." -ForegroundColor Cyan
-    $result = docker exec fulla-postgres pg_isready -U fulla_user 2>&1
-    if ($LASTEXITCODE -eq 0 -and $result -match "accepting connections") {
-        Write-Host "[+] 数据库连接正常" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] 数据库连接失败" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-DatabaseTables {
-    Write-Host "`n[4/8] 检查数据库表结构..." -ForegroundColor Cyan
-    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
-        SELECT COUNT(*) FROM information_schema.tables 
-        WHERE table_schema = 'public' AND table_type = 'BASE TABLE';
-    " 2>&1
-    
-    $tableCount = [int]$result.Trim()
-    if ($tableCount -ge 20) {
-        Write-Host "[+] 数据库表结构完整 ($tableCount 张表)" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] 数据库表结构不完整 (仅 $tableCount 张表)" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-SeedData {
-    Write-Host "`n[5/8] 检查种子数据..." -ForegroundColor Cyan
-    $result = docker exec fulla-postgres psql -U fulla_user -d fulla_db -t -c "
-        SELECT COUNT(*) FROM users WHERE username = 'admin';
-    " 2>&1
-    
-    $count = [int]$result.Trim()
-    if ($count -eq 1) {
-        Write-Host "[+] 管理员账号已创建" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] 管理员账号未创建" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-RedisConnection {
-    Write-Host "`n[6/8] 检查 Redis 连接..." -ForegroundColor Cyan
-    $result = docker exec fulla-redis redis-cli -a redis_secret_pass ping 2>&1
-    if ($result -match "PONG") {
-        Write-Host "[+] Redis 连接正常" -ForegroundColor Green
-        return $true
-    } else {
-        Write-Host "[-] Redis 连接失败" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-DiscoveryEndpoint {
-    Write-Host "`n[7/8] 测试 OIDC 发现端点..." -ForegroundColor Cyan
-    # 完整登录流程（PKCE）见上文阶段三；脚本化部署检查用发现端点验证
-    # 后端 OAuth2 栈已就绪，且不依赖具体凭证。
-    try {
-        $response = Invoke-RestMethod -Uri "$BackendUrl/.well-known/openid-configuration" -Method Get
-        if ($response.issuer -and $response.token_endpoint) {
-            Write-Host "[+] OIDC 发现端点正常 (issuer: $($response.issuer))" -ForegroundColor Green
-            return $true
-        }
-    } catch {
-        Write-Host "[-] OIDC 发现端点失败: $_" -ForegroundColor Red
-        return $false
-    }
-}
-
-function Test-FrontendAccess {
-    Write-Host "`n[8/8] 检查前端访问..." -ForegroundColor Cyan
-    try {
-        $response = Invoke-WebRequest -Uri $FrontendUrl -Method Get -UseBasicParsing
-        if ($response.StatusCode -eq 200) {
-            Write-Host "[+] 前端页面可访问" -ForegroundColor Green
-            return $true
-        }
-    } catch {
-        Write-Host "[-] 前端页面访问失败: $_" -ForegroundColor Red
-        return $false
-    }
-}
-
-# 执行所有测试
-$results = @()
-$results += Test-ContainerStatus
-$results += Test-BackendHealth
-$results += Test-DatabaseConnection
-$results += Test-DatabaseTables
-$results += Test-SeedData
-$results += Test-RedisConnection
-$results += Test-DiscoveryEndpoint
-$results += Test-FrontendAccess
-
-# 汇总结果
-$passed = ($results | Where-Object { $_ -eq $true }).Count
-$total = $results.Count
-
-Write-Host "`n" -NoNewline
-Write-Host ("=" * 60) -ForegroundColor DarkGray
-Write-Host "验证结果: $passed / $total 通过" -ForegroundColor $(if ($passed -eq $total) { "Green" } else { "Yellow" })
-Write-Host ("=" * 60) -ForegroundColor DarkGray
-
-if ($passed -eq $total) {
-    Write-Host "`n[+] 部署验证完全通过！系统可以投入使用。" -ForegroundColor Green
-    exit 0
-} else {
-    Write-Host "`n[-] 部署验证失败，请检查上述错误项。" -ForegroundColor Red
-    exit 1
-}
-```
+脚本已随仓库提供：
+[`scripts/backend/verify-deployment.ps1`](https://github.com/voidvec/fulla/blob/master/scripts/backend/verify-deployment.ps1)。
+在仓库根目录运行——它执行下述八项检查（容器状态、后端健康、数据库连接、
+表完整性、种子管理员、Redis、OIDC 发现端点、前端可达性），任一失败即以
+非零码退出（脚本输出为英文）。
 
 **使用方法**：
 
 ```powershell
 # 基本验证
-.\verify-deployment.ps1
-
-# 详细模式
-.\verify-deployment.ps1 -Verbose
+.\scriptsackenderify-deployment.ps1
 
 # 自定义端点
-.\verify-deployment.ps1 -BackendUrl "https://your-domain.com" -FrontendUrl "https://your-domain.com"
+.\scriptsackenderify-deployment.ps1 -BackendUrl "https://your-domain.com" -FrontendUrl "https://your-domain.com"
 ```
 
 ---


### PR DESCRIPTION
Follow-up P2 doc-debt batch (from the governance wrap-up list):

- **verify-deployment.ps1 ships in the repo** (`scripts/backend/`) — both locale editions of the verification checklist now reference it instead of embedding ~160 lines; the embedded copy's `param()` syntax error (`}` closer) is fixed in the shipped script
- **ADR references linkified** (en + zh, 20 edits): repo files → GitHub links, in-site docs → relative links, PR#85 → PR link, internal task id 'migration-check (M5)' reworded to the actual CI gate

No behavior changes; both locales rebuild green.