### PR TITLE
fix(admin): keep mapped host port in nginx redirects (absolute_redirect off)

### DIFF
--- a/frontends/admin/nginx.conf
+++ b/frontends/admin/nginx.conf
@@ -3,6 +3,12 @@ server {
     server_name _;
     root /usr/share/nginx/html;
 
+    # Relative Location on redirects: the container listens on 80 but is
+    # mapped to an arbitrary host port (8081 in deploy/docker) — nginx's
+    # default absolute URL would drop the mapped port and send browsers to
+    # http://localhost/admin/.
+    absolute_redirect off;
+
     # Redirect root to /admin/
     location = / {
         return 302 /admin/;


### PR DESCRIPTION
## Summary

After `docker compose -f deploy/docker/docker-compose.yml up -d --build`, the admin console at `http://localhost:8081` was unreachable, while the user portal on `:8080` worked fine. Both containers were actually running and healthy — only the redirects were broken.

## Root cause

The admin nginx config issues two redirects (`location = /` → `302 /admin/` and `location = /admin` → `301 /admin/`). With nginx's default `absolute_redirect on`, the `Location` header is built from the Host header plus the **container-internal listen port (80)** — the host-side mapped port (8081) is dropped:

```
GET /  →  302 Location: http://localhost/admin/     # port 8081 lost
```

Browsers get sent to a dead `localhost:80` origin, which reads as "site won't open". The user portal on `:8080` is unaffected because it serves the SPA directly at `/` and never redirects.

## Changes

- `frontends/admin/nginx.conf`: `absolute_redirect off;` in the server block, so redirect `Location`s stay relative (`/admin/`) and resolve against whatever origin/port the browser actually used. Correct for any host port mapping, not just 8081.

Note: the config is `COPY`-ed into the image at build time (no volume mount), so deploying this fix requires an image rebuild — it cannot hot-apply.

## Testing

- [x] Rebuilt locally: `docker compose -f deploy/docker/docker-compose.yml up -d --build fulla-admin`
- [x] `GET /` → `302 Location: /admin/` (relative); `curl -L http://localhost:8081/` lands `200` at `http://localhost:8081/admin/`
- [x] `GET /admin` (no slash) → `301 http://localhost:8081/admin/` — port preserved now
- [x] SPA loads: `/admin/assets/index-*.js` → `200`
- [x] API proxy parity: `/health` → `200` and `/api/admin/dashboard/stats` → `401` (unauthenticated, expected) through `:8081`, identical to direct backend `:5555`
