### PR TITLE
Non-functional repo-building tranche: community files, vendor-neutral root, full-test endpoint dedup

### DIFF
--- a/.claude/skills/full-test/SKILL.md
+++ b/.claude/skills/full-test/SKILL.md
@@ -9,9 +9,9 @@ description: 全量测试 — 后端 8 步（full_test.bat/full-test.sh）+ 前�
 
 ## 步骤
 
-1. **执行 `/full-backend-test`** — 后端 8 步流水线（DB重置→ORM→构建→ctest→服务器→59+52 端点测试→关闭）
+1. **执行 `/full-backend-test`** — 后端 8 步流水线（DB重置→ORM→构建→ctest→服务器→59+52 端点测试→关闭）。注：ctest 步骤内的 `EndpointTests_OutOfProcess` 跑绿后，步骤 5-8（手动端点层）会自动去重跳过并打印 `[SKIP #119]` 理由（#119）；摘要里 5-8 显示 SKIPPED 属正常
 2. **执行 `/full-frontend-test`** — 前端（Admin: build[tsc&&vite build]+16 e2e；User: build[vite build]+8 e2e+test:unit 5 文件[含 3 属性测试]）
 
 ## 通过标准
 
-后端 8/8 PASS + 前端 0 FAIL = 全量测试通过。
+后端 1-4 PASS 且 5-8 为 PASS 或 SKIPPED(#119) + 前端 0 FAIL = 全量测试通过。

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner: single-maintainer project (see MAINTAINERS.md)
+* @voidvec

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[the maintainer's GitHub profile](https://github.com/voidvec)
+(private message, or mention in a security-sensitive context — see
+[SECURITY.md](../SECURITY.md) for the vulnerability reporting channel, which is
+separate from conduct reports).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Thanks for contributing! See CONTRIBUTING.md for the full guide. -->
+
+## Summary
+
+<!-- What changed and why. Reference the issue ("Closes #N") when one exists. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (API, config, or protocol surface)
+- [ ] Docs / tests / CI only
+
+## Checklist
+
+General:
+
+- [ ] Tests added or updated; full suite green locally (or N/A — say why)
+- [ ] `CHANGELOG.md` entry added (user-visible changes)
+- [ ] Docs updated (incl. `website/i18n/zh-CN` mirrors when `docs/` content changed)
+
+If this touches the API surface (skip otherwise):
+
+- [ ] OpenAPI spec kept in sync (authoritative `apps/server/openapi.yaml` and its mirror points)
+- [ ] Error codes synced at all five points (spec, catalog test, SDKs where applicable)
+- [ ] Endpoint fingerprints / golden baselines regenerated if endpoints changed
+- [ ] `api-diff` and `oasdiff` gates addressed (a justified `--force` / ignore entry is fine — explain below)
+- [ ] Breaking changes curated into the `Breaking changes` section of `CHANGELOG.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,77 +1,16 @@
 # CLAUDE.md
 
-fulla — Production-grade OAuth2.0/OIDC authorization server (Drogon / C++17,
-PostgreSQL, Redis, Vue.js frontends). Supports RFC 6749, 7662, 7009, 8414, 8628, 7591.
+This file is a thin pointer: Fulla keeps a single, tool-neutral set of
+project instructions rather than per-assistant copies.
 
-## Build & Test (non-standard flags only)
+- **Read [AGENTS.md](AGENTS.md) first** — the cross-tool entry point. It
+  indexes the authoritative rule files and module guides.
+- **`.claude/rules/`** auto-loads path-scoped hard constraints (DB operations,
+  ORM model generation, data access, dev workflow). When a rule there applies
+  to files you are touching, follow it.
+- Human-facing docs cover the rest: [CONTRIBUTING.md](CONTRIBUTING.md)
+  (build/test, conventions, CI gates), [docs/](docs/) (architecture, testing,
+  operations, SDK contracts), [README.md](README.md) (quick start).
 
-Standard build / run / test goes through the unified wrappers
-`./manage.sh` / `./manage.ps1` — see `README.md` "Quick Start", or the
-`/build-and-test` skill. Only the non-obvious flags are listed here:
-
-- Debug build: append `-debug`.  Sanitizers: `--sanitizer=thread|address`
-  (Linux/macOS only, imply `-debug`).
-- No-external-DB test build: `-DFULLA_MEMORY_TESTS_ONLY=ON`.
-- Run C++ tests by label: `ctest -R Unit|Integration|E2E|Security|Performance`.
-- All platforms build through Conan + `cmake --preset`
-  (`scripts/backend/build.bat` on Windows, `scripts/backend/build.sh` on
-  Linux/macOS). Each preset installs to `build/<preset>` (e.g.
-  `build/windows-msvc`, `build/linux-release`, `build/macos-arm64`); see
-  `CMakePresets.json`. `cmake --list-presets` lists them.
-
-## Architecture
-
-### Key Patterns
-
-- **Plugin-based DI**: `OAuth2Plugin` is a Drogon `HttpPlugin<>` singleton.
-  `initAndStart()` creates the storage, services (TokenService, ClientService,
-  IdentityService), JwkManager and CleanupService. Access them via
-  `drogon::app().getPlugin<OAuth2Plugin>()`.
-- **Storage Strategy**: the monolithic `IOAuth2Storage` is retired. `storage_type`
-  in config (`postgres` / `redis` / `memory`) selects the backend;
-  `OAuth2Plugin::initStorage()` constructs the per-backend `RepositoryBundle`
-  (`libs/storage-postgres|redis|memory`) for the 4 oauth2 repositories
-  (client/grant/token/consent) and a separate `fulla::identity` backing
-  store (`PostgresIdentityRepository` / `MemoryIdentityRepository`) for the 3
-  identity repositories (user/role/subject-mapping). `redis` has no dedicated
-  identity backend — it falls back to the memory identity repo as a placeholder.
-- **Async callbacks**: all repository/service methods are async with
-  `std::function<void(result)> &&callback` as the last parameter. Services hold
-  `shared_ptr` repository handles for lifetime; async continuations capture
-  `auto self = shared_from_this()` to prevent use-after-free.
-- **Error system**: `Error` → `ErrorCatalog` (single source for error codes and
-  messages) → `ErrorResponder` renders JSON error envelopes. Codes are stable
-  strings (e.g. `AUTH_INVALID_CREDENTIALS`), never integers.
-
-## Critical Rules
-
-Path-scoped hard constraints and workflow entry points live in `.claude/rules/`
-and auto-load when you touch matching files:
-- `orm-models.md` — never hand-edit `models/**`; regenerate with `/orm-gen`.
-- `db-operations.md` — DB access is the async + Mapper + Criteria combo; raw SQL only for DDL / `UPDATE...RETURNING` / documented batch.
-- `data-access.md` — pointer to `db-operations.md` for storage code.
-- `dev-workflow.md` — dev commands: prefer `./manage.sh` / `./manage.ps1`; backend rebuild-DB / ORM / build / test / endpoint tests, frontend build / run / test.
-
-`git push` is forbidden (human review required) and enforced as a deny rule in
-`.claude/settings.json`.
-
-Code-style and async/lambda/ORM conventions are in the `project-conventions`
-skill (the single source for those). Highlights that matter in every edit:
-never use `CoroMapper`; never capture `[this]` or `[&]` in async contexts (use
-`shared_from_this()`); no emoji in code/output (use `[+]`/`[-]`/`[!]`).
-
-## Configuration
-
-- Sensitive values via env vars: `FULLA_DB_PASSWORD`, `FULLA_REDIS_PASSWORD`.
-- No-external-DB test build flag: `-DFULLA_MEMORY_TESTS_ONLY=ON`.
-- Config files: `apps/server/config/config*.json` + `config.{dev,ci,prod}.json` overrides.
-
-## Test Architecture
-
-Tests live in `tests/`; category labels and priorities are defined
-authoritatively in `tests/common/test_categories.h`.
-
-- `TestBase.h` provides `TestTransaction` (RAII rollback wrapper) — prefer it
-  over manual rollback so every test reverts its DB changes.
-- CI runs on three platforms: Linux (GCC + PostgreSQL + Redis), Windows
-  (MSVC 2022, memory-storage only), macOS (Clang ARM64, build verification only).
+`git push` is forbidden for agents (human review required); enforced as a deny
+rule in `.claude/settings.json`.

--- a/CODEBUDDY.md
+++ b/CODEBUDDY.md
@@ -1,6 +1,8 @@
 # CODEBUDDY.md
 
-All agent guidance for this repository lives in [CLAUDE.md](CLAUDE.md) — build
-commands, architecture patterns, critical rules, and test conventions apply
-identically here. Path-scoped rules auto-load from `.codebuddy/rules/`, and
-`git push` remains forbidden (deny rule in `.codebuddy/settings.json`).
+All agent guidance for this repository lives in [AGENTS.md](AGENTS.md) — the
+cross-tool entry point indexing the authoritative rules, module guides, and
+docs. Build commands, architecture patterns, critical rules, and test
+conventions apply identically here. Path-scoped rules auto-load from
+`.claude/rules/` (see AGENTS.md). `git push` remains forbidden (deny rule in
+`.codebuddy/settings.json`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 Thanks for your interest in contributing! This document covers the local
 workflow, conventions, and CI gates a change must pass.
 
+By participating in this project you agree to uphold its
+[Code of Conduct](.github/CODE_OF_CONDUCT.md). Not sure where to ask
+something? See [SUPPORT.md](SUPPORT.md) for the right channel.
+
 ## Prerequisites
 
 | Tool | Version |
@@ -123,6 +127,8 @@ the description — breaking changes require a major version bump.
 
 ## Reporting Issues
 
+- Usage questions / discussions: [GitHub Discussions](https://github.com/voidvec/fulla/discussions)
+  (see [SUPPORT.md](SUPPORT.md) for the full routing table).
 - Bugs / features: open a GitHub issue with reproduction steps.
 - Security vulnerabilities: **do not open a public issue** — see
   [SECURITY.md](SECURITY.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,47 @@
+# Governance
+
+This document describes how decisions are made in the Fulla project and how
+responsibility is distributed. It is intentionally minimal — it will grow with
+the team, not ahead of it.
+
+## Roles
+
+### Maintainers
+
+Maintainers have commit access and are responsible for review, release
+engineering, and the long-term health of the codebase. The current list lives
+in [MAINTAINERS.md](MAINTAINERS.md).
+
+### Contributors
+
+Anyone who submits issues, discussions, documentation, or pull requests.
+Contributions are merged through the standard
+[PR workflow](CONTRIBUTING.md) — there is no separate contributor tier.
+
+## Decision process
+
+| Decision class | Process |
+|---|---|
+| Bug fixes, docs, tests, refactors | PR + passing CI + one maintainer review |
+| New features / behavior additions | Open an issue (or Discussion) first to agree on scope, then a PR |
+| Breaking changes (API, config, protocol surface) | Same as features, plus: a curated entry in the `Breaking changes` section of [CHANGELOG.md](CHANGELOG.md), a version bump per the versioning policy, and OpenAPI/SDK surface sync (see `docs/`) |
+| Security fixes | Private channel per [SECURITY.md](SECURITY.md); coordinated disclosure, then public PR/release |
+| Governance itself (this file, MAINTAINERS.md, CODE_OF_CONDUCT.md) | Maintainer consensus |
+
+Maintainers seek consensus. If consensus cannot be reached on a matter that
+must be decided, the final call rests with the project founder (@voidvec),
+who records the rationale in the relevant issue.
+
+## Versioning and releases
+
+Fulla follows [Semantic Versioning](https://semver.org/) for its published
+artifacts (C++ SDK, Python/Go clients, container images). Releases are cut via
+the automated pipeline (`.github/workflows/release.yml`) driven by version
+tags; the release checklist and the six-point version sync list live in
+`docs/` and the release workflow.
+
+## Code of conduct
+
+All participation is governed by the
+[Code of Conduct](.github/CODE_OF_CONDUCT.md). Enforcement is handled by the
+maintainers.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+# Maintainers
+
+| Name | GitHub | Scope |
+|---|---|---|
+| Luca | [@voidvec](https://github.com/voidvec) | All areas (founder) |
+
+## Contact
+
+The fastest channel for maintainers is a GitHub mention in the relevant issue
+or pull request. For sensitive matters, see
+[SUPPORT.md](SUPPORT.md) and [SECURITY.md](SECURITY.md).
+
+## Adding a maintainer
+
+Maintainers are added by maintainer consensus after a sustained record of
+high-quality contributions and reviews (see [GOVERNANCE.md](GOVERNANCE.md)).
+A new maintainer is announced in GitHub Discussions and added to this file and
+to `.github/CODEOWNERS` in the same change.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,32 @@
+# Support
+
+Thanks for using Fulla! This page routes you to the right channel.
+
+| I want to… | Channel |
+|---|---|
+| Ask a question / discuss usage or design | [GitHub Discussions](https://github.com/voidvec/fulla/discussions) |
+| Report a bug or request a feature | [open an issue](https://github.com/voidvec/fulla/issues/new/choose) (bug report or feature request template) |
+| Report a security vulnerability | **privately** — see [SECURITY.md](SECURITY.md); do not open a public issue |
+| Read the docs | [fulla.dev](https://fulla.dev) (rendered site) or the [`docs/`](docs/) tree in this repo |
+| Contribute code | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+## Before opening an issue
+
+1. Search [existing issues](https://github.com/voidvec/fulla/issues?q=) — the
+   fastest answer is often already there.
+2. Check the version you run (`fulla-server --version` / image tag) and include
+   it, plus the smallest reproducer you can manage.
+3. For install/deploy problems, include your deployment shape (Docker Compose,
+   Helm, bare binary) and relevant config (with secrets redacted).
+
+## Response expectations
+
+Fulla is maintained by a small team (see
+[MAINTAINERS.md](MAINTAINERS.md)). There is no SLA; issues and discussions are
+triaged as maintainer time allows. Security reports follow the timeline in
+[SECURITY.md](SECURITY.md) and take priority.
+
+## Commercial support
+
+Not offered at this time. The project is licensed under AGPL-3.0 (core) — see
+[LICENSE](LICENSE) and [CLA.md](CLA.md).

--- a/docs/contribute/testing-guide.md
+++ b/docs/contribute/testing-guide.md
@@ -137,6 +137,39 @@ cd build\windows-msvc\tests\Release
 .\manage.ps1 test-oauth2-endpoints
 ```
 
+### The full-test pipeline: three execution layers (and what is deduplicated)
+
+`manage full-test` (backed by `scripts/backend/full_test.bat` /
+`full-test.sh` / `full-test-docker.sh`) stacks three layers. Knowing how they
+overlap explains what a full run actually executes:
+
+1. **ctest layer** — `EndpointTests_OutOfProcess` (label `Endpoint`) is a
+   regular ctest entry: it starts its own server, runs the 59 OAuth2 + 52
+   admin endpoint scripts against it, then stops it
+   (`tests/CMakeLists.txt`). It reports `SKIP_RETURN_CODE=77` when its
+   environment (server binary / shell) is unusable.
+2. **Dual-config layer** — `test.bat` / `test.sh` run the *entire* ctest
+   suite **twice**: once with the standard `config.json` (PostgreSQL) and
+   once with `config.ci.json` (memory storage). This duplication is
+   intentional — it is the release-confidence signal that both storage
+   backends pass the same suite.
+3. **Manual endpoint layer** — the pipeline's own "start server → run the
+   endpoint scripts → stop server" steps. Since layer 1 already runs the
+   same scripts in the same standard configuration, this layer is skipped
+   automatically when the ctest run's JUnit report
+   (`build/<preset>/Testing/junit-config-standard.xml`, written by
+   `test.bat`/`test.sh`) proves `EndpointTests_OutOfProcess` ran green in
+   that invocation (#119). On any doubt — report missing, entry missing,
+   skipped, or unreadable — the manual layer runs as before, so
+   environments where the ctest entry bails out (77) keep their endpoint
+   coverage path.
+
+The same applies to the per-case `Contract.*` ctest entries: each is also
+executed as part of the `OAuth2Tests` binary run. Their individual ctest
+registrations exist only to provide a labeled entry point
+(`ctest -L Contract`); they do not add a second execution of those cases
+beyond the labeled entry.
+
 ---
 
 ## 4. Sample Test Output

--- a/scripts/backend/full-test-docker.sh
+++ b/scripts/backend/full-test-docker.sh
@@ -28,6 +28,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Exit 0 iff the JUnit report written by test.sh proves the out-of-process
+# endpoint suite ran green THIS invocation (see full-test.sh; #119 dedup).
+endpoint_junit_proves_green() {
+    local junit="$1"
+    [ -f "$junit" ] || return 1
+    awk '
+        /<testcase[^>]*name="EndpointTests_OutOfProcess"/ { inblock = 1 }
+        inblock && /status="run"/ { seen_run = 1 }
+        inblock && /<failure/     { bad = 1 }
+        inblock && /<skipped/     { bad = 1 }
+        inblock && /<\/testcase>/ { inblock = 0 }
+        END { exit (seen_run && !bad ? 0 : 1) }
+    ' "$junit"
+}
+
 echo ""
 echo "========================================"
 echo "One-Click Build and Test (Docker)"
@@ -116,6 +131,22 @@ bash "$SCRIPT_DIR/test.sh" "$BUILD_ARG"
 echo "[SUCCESS] All tests passed"
 echo ""
 
+# Step 5b: Endpoint dedup check (#119 layer 1)
+# Same rationale as full-test.sh: skip the manual endpoint layer (steps 6-9)
+# when test.sh's standard-config ctest run already executed the endpoint
+# suite green this invocation. Fail-safe: any doubt -> run the manual layer.
+ENDPOINT_JUNIT="$BUILD_ABS_DIR/$(resolve_cmake_preset "$BUILD_TYPE")/Testing/junit-config-standard.xml"
+SKIP_MANUAL_ENDPOINTS=0
+if endpoint_junit_proves_green "$ENDPOINT_JUNIT"; then
+    SKIP_MANUAL_ENDPOINTS=1
+    echo "[SKIP #119] Endpoint suite already ran green inside step 5"
+    echo "            (ctest EndpointTests_OutOfProcess, standard config);"
+    echo "            skipping the manual endpoint layer (steps 6-9)."
+    echo ""
+fi
+
+if [ "$SKIP_MANUAL_ENDPOINTS" -eq 0 ]; then
+
 # Step 6: Start Server
 echo "========================================"
 echo "Step 6: Starting OAuth2 server"
@@ -172,6 +203,8 @@ wait "$SERVER_PID" 2>/dev/null || true
 SERVER_PID=""
 echo "[SUCCESS] Server stopped"
 echo ""
+
+fi  # SKIP_MANUAL_ENDPOINTS
 
 # Step 10: Stop Docker
 echo "========================================"

--- a/scripts/backend/full-test.sh
+++ b/scripts/backend/full-test.sh
@@ -42,6 +42,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Exit 0 iff the JUnit report written by test.sh proves the out-of-process
+# endpoint suite ran green THIS invocation: testcase block present,
+# status="run", no <failure>, no <skipped>. Missing file/entry, skipped,
+# failed, or malformed XML all exit non-zero so callers fall back to the
+# manual endpoint layer (#119 dedup, fail-safe by construction).
+endpoint_junit_proves_green() {
+    local junit="$1"
+    [ -f "$junit" ] || return 1
+    awk '
+        /<testcase[^>]*name="EndpointTests_OutOfProcess"/ { inblock = 1 }
+        inblock && /status="run"/ { seen_run = 1 }
+        inblock && /<failure/     { bad = 1 }
+        inblock && /<skipped/     { bad = 1 }
+        inblock && /<\/testcase>/ { inblock = 0 }
+        END { exit (seen_run && !bad ? 0 : 1) }
+    ' "$junit"
+}
+
 echo ""
 echo "========================================"
 echo "One-Click Build and Test ($BUILD_TYPE)"
@@ -79,6 +97,26 @@ echo "========================================"
 bash "$SCRIPT_DIR/test.sh" "$BUILD_ARG"
 echo "[SUCCESS] All tests passed"
 echo ""
+
+# Step 4b: Endpoint dedup check (#119 layer 1)
+# test.sh's standard-config ctest run already contains the out-of-process
+# endpoint suite (EndpointTests_OutOfProcess, starts its own server). When
+# its JUnit report proves that test ran green this invocation, the manual
+# endpoint layer below (steps 5-8) is a pure duplicate -- skip it. On any
+# doubt (report missing, entry missing/skipped, unreadable) the manual
+# layer still runs, so environments where the ctest entry bails out keep
+# their coverage path.
+ENDPOINT_JUNIT="$BUILD_ABS_DIR/$(resolve_cmake_preset "$BUILD_TYPE")/Testing/junit-config-standard.xml"
+SKIP_MANUAL_ENDPOINTS=0
+if endpoint_junit_proves_green "$ENDPOINT_JUNIT"; then
+    SKIP_MANUAL_ENDPOINTS=1
+    echo "[SKIP #119] Endpoint suite already ran green inside step 4"
+    echo "            (ctest EndpointTests_OutOfProcess, standard config);"
+    echo "            skipping the manual endpoint layer (steps 5-8)."
+    echo ""
+fi
+
+if [ "$SKIP_MANUAL_ENDPOINTS" -eq 0 ]; then
 
 # Step 5: Start Server
 echo "========================================"
@@ -143,6 +181,8 @@ wait "$SERVER_PID" 2>/dev/null || true
 SERVER_PID=""
 echo "[SUCCESS] Server stopped"
 echo ""
+
+fi  # SKIP_MANUAL_ENDPOINTS
 
 if [ $FINAL_RESULT -ne 0 ]; then
     echo "========================================"

--- a/scripts/backend/full_test.bat
+++ b/scripts/backend/full_test.bat
@@ -108,6 +108,33 @@ echo [SUCCESS] All tests passed
 echo.
 
 REM ========================================
+REM Step 4b: Endpoint dedup check (#119)
+REM ========================================
+REM test.bat's standard-config ctest run already contains the out-of-process
+REM endpoint suite (EndpointTests_OutOfProcess starts its own server and runs
+REM the same 59+52 endpoint scripts). When its JUnit report proves that test
+REM ran green this invocation, the manual endpoint layer below (steps 5-8) is
+REM a pure duplicate -- skip it. On any doubt (report missing, entry
+REM missing/skipped, unreadable XML) the manual layer still runs, so
+REM environments where the ctest entry bails out keep their coverage path.
+set "SKIP_ENDPOINTS=0"
+set "S5=SKIPPED (#119: covered in step 4)"
+set "S6=SKIPPED (#119: covered in step 4)"
+set "S7=SKIPPED (#119: covered in step 4)"
+set "S8=SKIPPED (#119: covered in step 4)"
+if exist "%PRESET_DIR%\Testing\junit-config-standard.xml" (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$x=[xml](Get-Content -LiteralPath '%PRESET_DIR%\Testing\junit-config-standard.xml' -Raw); $t=@($x.testsuite.testcase)+@($x.testsuites.testsuite.testcase)|Where-Object{$_.name -eq 'EndpointTests_OutOfProcess'}; if(-not $t -or $t.failure -or $t.skipped -or $t.status -ne 'run'){exit 1}; exit 0" >nul 2>&1
+    if !errorlevel! equ 0 set "SKIP_ENDPOINTS=1"
+)
+if "%SKIP_ENDPOINTS%"=="1" (
+    echo [SKIP #119] Endpoint suite already ran green inside step 4
+    echo             ^(ctest EndpointTests_OutOfProcess, standard config^);
+    echo             skipping the manual endpoint layer ^(steps 5-8^).
+    echo.
+    goto success_summary
+)
+
+REM ========================================
 REM Step 5: Start Server
 REM ========================================
 echo ========================================
@@ -150,6 +177,7 @@ if !errorlevel! neq 0 (
     goto cleanup_and_exit
 )
 echo [SUCCESS] Server started
+set "S5=PASS"
 echo.
 
 REM ========================================
@@ -166,6 +194,7 @@ if !errorlevel! neq 0 (
     goto cleanup_and_exit
 )
 echo [SUCCESS] OAuth2 endpoint tests passed
+set "S6=PASS"
 echo.
 
 REM ========================================
@@ -182,6 +211,7 @@ if !errorlevel! neq 0 (
     goto cleanup_and_exit
 )
 echo [SUCCESS] Admin endpoint tests passed
+set "S7=PASS"
 echo.
 
 REM ========================================
@@ -192,11 +222,13 @@ echo Step 8: Stopping OAuth2 server
 echo ========================================
 taskkill /F /IM %SERVER_BINARY_NAME%.exe >nul 2>&1
 echo [SUCCESS] Server stopped
+set "S8=PASS"
 echo.
 
 REM ========================================
 REM Success Summary
 REM ========================================
+:success_summary
 echo ========================================
 echo ALL STEPS COMPLETED SUCCESSFULLY!
 echo ========================================
@@ -206,10 +238,10 @@ echo   [1/8] Database initialization    - PASS
 echo   [2/8] ORM model generation       - PASS
 echo   [3/8] Project build              - PASS
 echo   [4/8] Unit tests                 - PASS
-echo   [5/8] Server startup             - PASS
-echo   [6/8] OAuth2 endpoint tests      - PASS
-echo   [7/8] Admin endpoint tests       - PASS
-echo   [8/8] Server shutdown            - PASS
+echo   [5/8] Server startup             - !S5!
+echo   [6/8] OAuth2 endpoint tests      - !S6!
+echo   [7/8] Admin endpoint tests       - !S7!
+echo   [8/8] Server shutdown            - !S8!
 echo.
 
 :cleanup_and_exit

--- a/scripts/backend/test.bat
+++ b/scripts/backend/test.bat
@@ -59,7 +59,10 @@ cd /d "%PRESET_DIR%"
 REM --- Run 1: Standard config.json ---
 echo.
 echo [1/2] Running tests with standard %CONFIG_FILE%...
-ctest -C %BUILD_TYPE% %VERBOSE%
+REM The JUnit report feeds the full_test endpoint dedup (#119): full_test.bat
+REM skips its manual endpoint re-run when EndpointTests_OutOfProcess is proven
+REM green in this run.
+ctest -C %BUILD_TYPE% %VERBOSE% --output-junit "%PRESET_DIR%\Testing\junit-config-standard.xml"
 if !errorlevel! neq 0 (
     echo [FAIL] Tests failed with standard %CONFIG_FILE%
     exit /b 1
@@ -86,7 +89,7 @@ set "CI_CFG_SRC=!CI_CFG_SRC:/=\!"
 copy /Y "%TEST_CONFIG%" "%TEST_CONFIG%.bak" >nul
 copy /Y "!CI_CFG_SRC!" "%TEST_CONFIG%" >nul
 
-ctest -C %BUILD_TYPE% %VERBOSE%
+ctest -C %BUILD_TYPE% %VERBOSE% --output-junit "%PRESET_DIR%\Testing\junit-config-ci.xml"
 set "CI_EXIT=!errorlevel!"
 
 REM Restore original config immediately

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -43,7 +43,12 @@ cd "$PRESET_DIR"
 # Run 1: Standard config.json
 echo ""
 echo "[1/2] Running tests with standard $CONFIG_FILE..."
-ctest --build-config "$BUILD_TYPE" $VERBOSE
+# The JUnit report feeds the full-test endpoint dedup (#119): full-test.sh
+# skips its manual endpoint re-run when EndpointTests_OutOfProcess is proven
+# green in this run. Absolute path -- relative --output-junit paths resolve
+# against --test-dir/cwd and both ctest invocations below share one.
+ctest --build-config "$BUILD_TYPE" $VERBOSE \
+    --output-junit "$PRESET_DIR/Testing/junit-config-standard.xml"
 echo "[PASS] Standard config tests successful."
 
 # Run 2: config.ci.json
@@ -80,7 +85,8 @@ if [ -d "$TEST_WORK_DIR" ]; then
     cp "$CI_CONFIG" "$TEST_WORK_DIR/$CONFIG_FILE"
 
     CI_EXIT=0
-    ctest --build-config "$BUILD_TYPE" $VERBOSE || CI_EXIT=$?
+    ctest --build-config "$BUILD_TYPE" $VERBOSE \
+        --output-junit "$PRESET_DIR/Testing/junit-config-ci.xml" || CI_EXIT=$?
 
     # Restore original config
     mv "$TEST_WORK_DIR/$CONFIG_FILE.bak" "$TEST_WORK_DIR/$CONFIG_FILE"

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/testing-guide.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/contribute/testing-guide.md
@@ -137,6 +137,32 @@ cd build\windows-msvc\tests\Release
 .\manage.ps1 test-oauth2-endpoints
 ```
 
+### full-test 流水线的三层执行关系（以及去重了什么）
+
+`manage full-test`（由 `scripts/backend/full_test.bat` / `full-test.sh` /
+`full-test-docker.sh` 驱动）叠加了三层。理解它们的重叠关系，才能判断一次
+全量到底实际执行了什么：
+
+1. **ctest 层** —— `EndpointTests_OutOfProcess`（label `Endpoint`）是一条
+   普通 ctest 条目：它自己起服、对它跑 59 条 OAuth2 + 52 条管理端点脚本、
+   然后停服（见 `tests/CMakeLists.txt`）。当其运行环境（服务二进制 /
+   shell）不可用时，以 `SKIP_RETURN_CODE=77` 报告跳过。
+2. **双配置层** —— `test.bat` / `test.sh` 会把**整套** ctest 套件跑
+   **两遍**：一遍标准 `config.json`（PostgreSQL），一遍 `config.ci.json`
+   （memory 存储）。这层重复是有意设计 —— 两种存储后端通过同一套件是
+   发布信心的来源。
+3. **手动端点层** —— 流水线自己的“起服 → 跑端点脚本 → 停服”步骤。由于
+   第 1 层已经在同样的标准配置下跑过同一套脚本，当本次 ctest 运行的
+   JUnit 报告（`build/<preset>/Testing/junit-config-standard.xml`，由
+   `test.bat`/`test.sh` 写出）证明 `EndpointTests_OutOfProcess` 本次实际
+   跑绿时，这一层会自动跳过（#119）。任何不确定情形 —— 报告缺失、条目
+   缺失、被跳过、无法解析 —— 手动层照旧执行，因此 ctest 条目退出（77）
+   的环境仍保有端点覆盖路径。
+
+同理适用于逐条注册的 `Contract.*` ctest 条目：每一条也会随 `OAuth2Tests`
+二进制整体执行而跑到。它们单独注册成 ctest 条目只是为了提供标签化入口
+（`ctest -L Contract`）；在上述意义上不会构成对同一用例的第二遍执行。
+
 ---
 
 ## 4. 测试输出示例


### PR DESCRIPTION
Closes #106. Closes #113. Closes #119.

## Summary

Three independent non-functional batches (full triage table in the issue comments):

### 1. Community health files (#106)
- `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1), `SUPPORT.md` (channel routing), `GOVERNANCE.md` (minimal decision model), `MAINTAINERS.md`, `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md` (includes the repo's API-sync gate checklist), CONTRIBUTING cross-links.
- `FUNDING.yml` deliberately omitted — platform choice is a maintainer decision.

### 2. Vendor-neutral repo root (#113)
- `CLAUDE.md` / `CODEBUDDY.md` slimmed to thin pointers at `AGENTS.md` + `.claude/rules/`; their content lives canonically in CONTRIBUTING.md / docs/.
- The other #113 items were already resolved on master: compare links fixed (be8a4c72), internal planning docs removed (0 files in `docs/history/design/superpowers/plans` / `docs/productization-evolution/in-progress`), residual `authforge` references are intentional rename-history/ADR archive notes.

### 3. full-test endpoint dedup (#119 layer 1 + 3)
- `test.bat`/`test.sh` emit per-config JUnit reports; the three full-test entry points skip the manual endpoint layer (steps 5-8/6-9) when the standard-config report proves `EndpointTests_OutOfProcess` ran green in the same invocation. Fail-safe: any doubt (missing report/entry, skipped, unreadable) falls back to the manual layer — the no-DB / skip-77 coverage path is preserved.
- Layer 2 (dual-config full suite) intentionally unchanged (release-confidence by design).
- `docs/contribute/testing-guide.md` + zh-CN mirror document the three-layer execution model and the `Contract.*` entry relationship.

## Verification
- Skip predicate unit-tested against real ctest JUnit samples on both platforms (bash/awk + cmd/PowerShell): passed → skip, skipped/malformed/missing → run manual.
- Local `full_test.bat` full run (evidence in issue close comment).
- All relative links in new files validated.

## Type of change
- [x] Docs / tests / CI only