### PR TITLE
docs(issues): add internal tracking issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking.md
+++ b/.github/ISSUE_TEMPLATE/tracking.md
@@ -1,0 +1,31 @@
+---
+name: "Internal tracking item"
+description: Maintainer/agent use — audit findings, review follow-ups, tech-debt registrations (not user-facing bugs or features)
+labels: ["tracking"]
+---
+
+<!-- English only — issues are public-facing. This skeleton exists because
+     issue forms only apply in the web UI; CLI/API-created issues bypass
+     them, so tracking items follow this structure instead. -->
+
+## Problem
+
+<!-- What is wrong / missing, and why it matters. One or two paragraphs. -->
+
+## Evidence
+
+<!-- file:line pointers, logs, command output, or the PR/review comment
+     this was split from. Verifiable facts only. -->
+
+## Suggested fix
+
+<!-- Direction of the fix if known; "needs investigation" is acceptable. -->
+
+## Acceptance criteria
+
+- [ ] <!-- Observable condition that lets this issue close. -->
+
+## Out of scope / follow-ups
+
+<!-- Deliberately deferred items; register separate issues if they need
+     their own tracking. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,14 @@
 
 > 旧版 `TECH_SPECS.md` 曾把 `[this]` 列为全局禁令，与 controller 层实践冲突，已在本次精简中移除该条。
 
+## 跟踪类 issue 创建规范
+
+用 `gh`/API 创建跟踪类 issue（审计发现、评审遗留、技术债登记）时，**英文**填写并套用
+[`.github/ISSUE_TEMPLATE/tracking.md`](.github/ISSUE_TEMPLATE/tracking.md) 的骨架
+（Problem / Evidence / Suggested fix / Acceptance criteria / Out of scope）——
+issue forms 只在网页新建流程生效，CLI 会绕过，故以此模板对齐结构。
+面向用户的 bug/feature 仍走网页表单模板，不要用 tracking 骨架。
+
 ## 各 AI 工具目录的角色
 
 本仓库的规则与工作流资产以 `.claude/` 为**唯一权威源**（git 跟踪）：


### PR DESCRIPTION
## Summary

Tracking items (audit findings, review follow-ups, tech debt) are created via `gh`/API, which bypasses the web-only issue forms — every currently open tracking issue is freeform and some are mixed-language. This adds:

- `.github/ISSUE_TEMPLATE/tracking.md` — plain-markdown skeleton (Problem / Evidence / Suggested fix / Acceptance criteria / Out of scope, English), also usable as the third web-UI template choice for the maintainer.
- `AGENTS.md` — a short section pointing agent-created tracking issues at the skeleton.

Note: the template's front matter carries `labels: ["tracking"]`; GitHub applies it once that label exists in the repo (needs a one-time manual creation — current PAT cannot manage labels).

## Type of change

- [x] Docs / tests / CI only

## Checklist

- [x] Docs updated (no `docs/` or zh-CN mirror content changed — repo-root files only)
- N/A elsewhere (no code, API surface, or tests touched)