### PR TITLE
feat: decision items #88-3 / #105 / #110 — client_id logout, coverage ratchet, key rotation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -120,17 +120,29 @@ jobs:
         # files consumed by measure_coverage.py must be produced by an explicit
         # gcov pass over the .gcda files the test run left behind (#105 review:
         # without this step the report is empty and the job is a false green).
+        # PR #176: gcov -j -p writes <mangled-path>.gcov.json.gz into the
+        # CURRENT directory, not next to the .gcda -- normalize them under
+        # libs/ so the summarize/ratchet/artifact steps keep one find path,
+        # and fail loudly on zero instead of masking with || true (the gate
+        # seeded an EMPTY baseline for exactly this reason before).
         working-directory: build/${{ env.PRESET }}
         run: |
-          gcda_count=$(find . -name '*.gcda' | wc -l)
+          gcda_count=$(find libs -name '*.gcda' | wc -l)
           echo "Found $gcda_count .gcda files"
           if [ "$gcda_count" -eq 0 ]; then
             echo "::error::No coverage data produced (instrumentation or test run failed)"
             exit 1
           fi
-          find libs -name '*.gcda' -print0 | xargs -0 -n 32 gcov -j -p -o . >/dev/null || true
+          find libs -name '*.gcda' -print0 | xargs -0 -n 32 gcov -j -p || true
+          repo_wide=$(find . -name '*.gcov.json.gz' | wc -l)
+          echo "gcov produced $repo_wide report(s) repo-wide; relocating any left in the cwd into libs/"
+          find . -maxdepth 1 -name '*.gcov.json.gz' -exec mv {} libs/ \; 2>/dev/null || true
           json_count=$(find libs -name '*.gcov.json.gz' | wc -l)
-          echo "Generated $json_count gcov JSON reports"
+          echo "Generated $json_count gcov JSON reports under libs/"
+          if [ "$json_count" -eq 0 ]; then
+            echo "::error::gcov pass produced no JSON reports under libs/ (see repo-wide count above)"
+            exit 1
+          fi
 
       - name: Summarize coverage (measure_coverage.py)
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,12 +1,14 @@
 name: Coverage
 
-# #105: produce (not gate) line coverage on Linux. FULLA_TEST_COVERAGE +
+# #105: produce AND gate line coverage on Linux. FULLA_TEST_COVERAGE +
 # cmake/Coverage.cmake instrument every first-party lib; scripts/
-# measure_coverage.py aggregates the gcov JSON into a per-library report.
-# No threshold/ratchet yet -- the first goal is a visible baseline (a
-# ratchet that starts red is worse than no ratchet). Codecov integration is
-# deliberately deferred (needs an account/token decision); artifacts carry
-# the raw data meanwhile.
+# measure_coverage.py aggregates the gcov JSON into a per-library report and
+# enforces the local ratchet (decision B, 2026-09-03): any non-exempt library
+# dropping more than 0.5pp below tools/coverage/ratchet-baseline.json fails
+# the build. Re-baselining (including upward) is a deliberate reviewed PR
+# edit of the JSON. Codecov-style external hosting remains deliberately out
+# (self-contained gate, consistent with api-diff/oasdiff/spec-governance);
+# artifacts carry the raw data meanwhile.
 
 on:
   workflow_dispatch:
@@ -137,6 +139,15 @@ jobs:
             find build/$PRESET/libs -name '*.gcov.json.gz' | python3 scripts/measure_coverage.py
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Coverage ratchet gate (#105, no-decrease vs baseline)
+        # Decision B (local self-contained gate): fail when any non-exempt
+        # library drops more than 0.5pp below tools/coverage/
+        # ratchet-baseline.json. Seed mode (baseline absent) prints the JSON
+        # to commit and passes.
+        working-directory: ${{ github.workspace }}
+        run: |
+          find build/$PRESET/libs -name '*.gcov.json.gz' | python3 scripts/measure_coverage.py --ratchet tools/coverage/ratchet-baseline.json
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,7 @@ on:
       - "apps/server/**"
       - "tests/**"
       - "scripts/measure_coverage.py"
+      - "tools/coverage/**"
       - "cmake/Coverage.cmake"
       - "CMakePresets.json"
       - ".github/workflows/coverage.yml"
@@ -28,6 +29,7 @@ on:
       - "libs/**"
       - "apps/server/**"
       - "tests/**"
+      - "tools/coverage/**"
 
 concurrency:
   group: coverage-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ For the versioning policy (when to cut, what to bump, why), see
 [Versioning & Release](docs/contribute/versioning-and-release.md).
 Changelog entries are written in English (see CONTRIBUTING).
 
+## [Unreleased]
+
+### Changed
+
+- **⚠️ Breaking (admin API) — `GET /api/admin/oidc/keys` reports the live signing keystore (#110)**: the flat `kid`/`kty`/`alg`/`use`/`key_status` fields are replaced by a `keys[]` array (per-key `kid`/`kty`/`alg`/`use` plus `status`: `active` = signs new tokens, `published` = verification-only during a rotation grace window), `active_kid`, and `key_count`. External admin integrations should read the signing key material from `/.well-known/jwks.json` as before; this endpoint now summarizes rotation state.
+- `POST /oauth2/end_session` (like GET) accepts `client_id` as the RP identification when `id_token_hint` is absent (#88): the `post_logout_redirect_uri` must still be registered for that client.
+
+### Added
+
+- Signing-key rotation keystore (#110): `plugins.OAuth2Plugin.config.oidc.signing_keystore_dir` (`<kid>.pem` files + `active_kid` marker); JWKS publishes every loaded key, verification routes on the JWT `kid`, rotation is a documented three-restart procedure (see `docs/operate/configuration-guide.md` §9).
+- Coverage ratchet gate (#105): CI fails when any library's line coverage drops more than 0.5pp below `tools/coverage/ratchet-baseline.json`; re-baselining is a deliberate reviewed PR edit.
+
 ## [1.1.0] - 2026-09-01
 
 ### Security

--- a/apps/server/docs/api/openapi.json
+++ b/apps/server/docs/api/openapi.json
@@ -2245,7 +2245,17 @@
             }
           },
           {
-            "description" : "URI to redirect to after logout; must be registered for the id_token_hint client.",
+            "description" : "RP self-identification when id_token_hint is absent (RP-Initiated Logout 1.0 \u00a72.1); the post_logout_redirect_uri must be registered for this client (#88-3).",
+            "in" : "query",
+            "name" : "client_id",
+            "required" : false,
+            "schema" : 
+            {
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "URI to redirect to after logout; must be registered for the id_token_hint (or client_id) client.",
             "in" : "query",
             "name" : "post_logout_redirect_uri",
             "required" : false,
@@ -2287,7 +2297,7 @@
           },
           "400" : 
           {
-            "description" : "post_logout_redirect_uri not registered / no id_token_hint"
+            "description" : "post_logout_redirect_uri not registered / neither id_token_hint nor client_id supplied"
           }
         },
         "summary" : "RP-Initiated Logout",
@@ -2314,7 +2324,17 @@
             }
           },
           {
-            "description" : "URI to redirect to after logout; must be registered for the id_token_hint client.",
+            "description" : "RP self-identification when id_token_hint is absent (RP-Initiated Logout 1.0 \u00a72.1); the post_logout_redirect_uri must be registered for this client (#88-3).",
+            "in" : "query",
+            "name" : "client_id",
+            "required" : false,
+            "schema" : 
+            {
+              "type" : "string"
+            }
+          },
+          {
+            "description" : "URI to redirect to after logout; must be registered for the id_token_hint (or client_id) client.",
             "in" : "query",
             "name" : "post_logout_redirect_uri",
             "required" : false,
@@ -2356,7 +2376,7 @@
           },
           "400" : 
           {
-            "description" : "post_logout_redirect_uri not registered / no id_token_hint"
+            "description" : "post_logout_redirect_uri not registered / neither id_token_hint nor client_id supplied"
           }
         },
         "summary" : "RP-Initiated Logout (POST)",

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -727,7 +727,10 @@ openapi: 3.0.0
 paths:
   /.well-known/jwks.json:
     get:
-      description: Returns the public keys used by this server to sign JWTs.
+      description: Returns the public keys used by this server to sign JWTs. With a
+        signing keystore configured (#110) EVERY loaded key is published so tokens
+        keep verifying across the rotation grace window; the active signer is the
+        kid the issued JWT headers carry.
       operationId: get_.well-known_jwks.json
       responses:
         '200':
@@ -1073,7 +1076,10 @@ paths:
       - Logs
   /api/admin/oidc/keys:
     get:
-      description: Get information about OIDC signing keys.
+      description: 'Live signing-keystore state (#110): every loaded kid with its
+        status (active = signs new tokens, published = verification-only during a
+        rotation grace window), the active_kid, and the key count. Cryptographic
+        material (n/e) lives in /.well-known/jwks.json.'
       operationId: get_api_admin_oidc_keys
       responses:
         '200':
@@ -2963,9 +2969,11 @@ paths:
         RS256 signature against the OP key set, strict alg/kid, iss, exp) — any
         failure, or a hint subject that contradicts the browser session, is
         rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri
-        MUST be registered for the client identified by the verified id_token_hint
-        (its aud claim); without a hint the request is rejected with 400 when a
-        redirect URI is supplied. Accepts both GET (link-based) and POST
+        MUST be registered for the client identifying itself in the request: the
+        verified id_token_hint (its aud claim) or, when no hint is supplied, the
+        client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for
+        exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI
+        is rejected with 400. Accepts both GET (link-based) and POST
         (form-based).'
       operationId: get_oauth2_end_session
       parameters:
@@ -2984,6 +2992,14 @@ paths:
           id_token_hint client; rejected with 400 otherwise.
         in: query
         name: post_logout_redirect_uri
+        required: false
+        schema:
+          type: string
+      - description: 'RP self-identification when id_token_hint is absent
+          (RP-Initiated Logout 1.0 §2.1). The post_logout_redirect_uri must be
+          registered for this client (#88-3).'
+        in: query
+        name: client_id
         required: false
         schema:
           type: string

--- a/apps/server/openapi.yaml
+++ b/apps/server/openapi.yaml
@@ -3045,6 +3045,14 @@ paths:
         required: false
         schema:
           type: string
+      - description: 'RP self-identification when id_token_hint is absent
+          (RP-Initiated Logout 1.0 §2.1). The post_logout_redirect_uri must be
+          registered for this client (#88-3).'
+        in: query
+        name: client_id
+        required: false
+        schema:
+          type: string
       - description: Registered post-logout redirect URI.
         in: query
         name: post_logout_redirect_uri
@@ -3071,10 +3079,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorEnvelope'
-          description: 'Error Envelope: id_token_hint verification failure or missing hint
-            for a supplied post_logout_redirect_uri (AUTH_INVALID_ID_TOKEN_HINT), or
-            post_logout_redirect_uri not registered for any aud client
-            (VALIDATION_REDIRECT_URI_NOT_REGISTERED). See GET for full semantics.'
+          description: 'Error Envelope: id_token_hint verification failure, or neither
+            id_token_hint nor client_id supplied with a post_logout_redirect_uri
+            (AUTH_INVALID_ID_TOKEN_HINT), or post_logout_redirect_uri not registered
+            for the identifying client (VALIDATION_REDIRECT_URI_NOT_REGISTERED).
+            See GET for full semantics.'
       summary: RP-Initiated Logout (POST)
       tags:
       - OAuth2

--- a/clients/go/generated/client.gen.go
+++ b/clients/go/generated/client.gen.go
@@ -931,6 +931,9 @@ type GetOauth2EndSessionParams struct {
 	// PostLogoutRedirectUri URI to redirect to after logout. Must be registered for the id_token_hint client; rejected with 400 otherwise.
 	PostLogoutRedirectUri *string `form:"post_logout_redirect_uri,omitempty" json:"post_logout_redirect_uri,omitempty"`
 
+	// ClientId RP self-identification when id_token_hint is absent (RP-Initiated Logout 1.0 §2.1). The post_logout_redirect_uri must be registered for this client (#88-3).
+	ClientId *string `form:"client_id,omitempty" json:"client_id,omitempty"`
+
 	// State Opaque value echoed back to the post_logout_redirect_uri.
 	State *string `form:"state,omitempty" json:"state,omitempty"`
 }
@@ -1240,7 +1243,7 @@ type ClientInterface interface {
 
 	// GetWellKnownJwksJson JSON Web Key Set
 	//
-	// Returns the public keys used by this server to sign JWTs.
+	// Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110) EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active signer is the kid the issued JWT headers carry.
 	//
 	// Corresponds with GET /.well-known/jwks.json (the `GetWellKnownJwksJson` operationId).
 	GetWellKnownJwksJson(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1360,7 +1363,7 @@ type ClientInterface interface {
 
 	// GetApiAdminOidcKeys Get OIDC Keys Info
 	//
-	// Get information about OIDC signing keys.
+	// Live signing-keystore state (#110): every loaded kid with its status (active = signs new tokens, published = verification-only during a rotation grace window), the active_kid, and the key count. Cryptographic material (n/e) lives in /.well-known/jwks.json.
 	//
 	// Corresponds with GET /api/admin/oidc/keys (the `GetApiAdminOidcKeys` operationId).
 	GetApiAdminOidcKeys(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1926,7 +1929,7 @@ type ClientInterface interface {
 
 	// GetOauth2EndSession RP-Initiated Logout
 	//
-	// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identified by the verified id_token_hint (its aud claim); without a hint the request is rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-based).
+	// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400. Accepts both GET (link-based) and POST (form-based).
 	//
 	// Corresponds with GET /oauth2/end_session (the `GetOauth2EndSession` operationId).
 	GetOauth2EndSession(ctx context.Context, params *GetOauth2EndSessionParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2124,7 +2127,7 @@ type ClientInterface interface {
 
 // GetWellKnownJwksJson JSON Web Key Set
 //
-// Returns the public keys used by this server to sign JWTs.
+// Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110) EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active signer is the kid the issued JWT headers carry.
 //
 // Corresponds with GET /.well-known/jwks.json (the `GetWellKnownJwksJson` operationId).
 func (c *Client) GetWellKnownJwksJson(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2404,7 +2407,7 @@ func (c *Client) GetApiAdminLogs(ctx context.Context, reqEditors ...RequestEdito
 
 // GetApiAdminOidcKeys Get OIDC Keys Info
 //
-// Get information about OIDC signing keys.
+// Live signing-keystore state (#110): every loaded kid with its status (active = signs new tokens, published = verification-only during a rotation grace window), the active_kid, and the key count. Cryptographic material (n/e) lives in /.well-known/jwks.json.
 //
 // Corresponds with GET /api/admin/oidc/keys (the `GetApiAdminOidcKeys` operationId).
 func (c *Client) GetApiAdminOidcKeys(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -3690,7 +3693,7 @@ func (c *Client) PostOauth2DeviceAuthorizationWithFormdataBody(ctx context.Conte
 
 // GetOauth2EndSession RP-Initiated Logout
 //
-// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identified by the verified id_token_hint (its aud claim); without a hint the request is rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-based).
+// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400. Accepts both GET (link-based) and POST (form-based).
 //
 // Corresponds with GET /oauth2/end_session (the `GetOauth2EndSession` operationId).
 func (c *Client) GetOauth2EndSession(ctx context.Context, params *GetOauth2EndSessionParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -6835,6 +6838,18 @@ func NewGetOauth2EndSessionRequest(server string, params *GetOauth2EndSessionPar
 
 		}
 
+		if params.ClientId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "client_id", *params.ClientId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if params.State != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "state", *params.State, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
@@ -7408,7 +7423,7 @@ type ClientWithResponsesInterface interface {
 
 	// GetWellKnownJwksJsonWithResponse JSON Web Key Set
 	//
-	// Returns the public keys used by this server to sign JWTs.
+	// Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110) EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active signer is the kid the issued JWT headers carry.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -7552,7 +7567,7 @@ type ClientWithResponsesInterface interface {
 
 	// GetApiAdminOidcKeysWithResponse Get OIDC Keys Info
 	//
-	// Get information about OIDC signing keys.
+	// Live signing-keystore state (#110): every loaded kid with its status (active = signs new tokens, published = verification-only during a rotation grace window), the active_kid, and the key count. Cryptographic material (n/e) lives in /.well-known/jwks.json.
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -8200,7 +8215,7 @@ type ClientWithResponsesInterface interface {
 
 	// GetOauth2EndSessionWithResponse RP-Initiated Logout
 	//
-	// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identified by the verified id_token_hint (its aud claim); without a hint the request is rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-based).
+	// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400. Accepts both GET (link-based) and POST (form-based).
 	//
 	// Returns a wrapper object for the known response body format(s).
 	//
@@ -12113,7 +12128,7 @@ func (r PostOauth2WebauthnAuthenticateFinishResponse) ContentType() string {
 
 // GetWellKnownJwksJsonWithResponse JSON Web Key Set
 //
-// Returns the public keys used by this server to sign JWTs.
+// Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110) EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active signer is the kid the issued JWT headers carry.
 //
 // Returns a wrapper object for the known response body format(s).
 //
@@ -12353,7 +12368,7 @@ func (c *ClientWithResponses) GetApiAdminLogsWithResponse(ctx context.Context, r
 
 // GetApiAdminOidcKeysWithResponse Get OIDC Keys Info
 //
-// Get information about OIDC signing keys.
+// Live signing-keystore state (#110): every loaded kid with its status (active = signs new tokens, published = verification-only during a rotation grace window), the active_kid, and the key count. Cryptographic material (n/e) lives in /.well-known/jwks.json.
 //
 // Returns a wrapper object for the known response body format(s).
 //
@@ -13433,7 +13448,7 @@ func (c *ClientWithResponses) PostOauth2DeviceAuthorizationWithFormdataBodyWithR
 
 // GetOauth2EndSessionWithResponse RP-Initiated Logout
 //
-// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identified by the verified id_token_hint (its aud claim); without a hint the request is rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-based).
+// OIDC RP-Initiated Logout 1.0 §2. Terminates the user's server-side session and (optionally) redirects to a registered post_logout_redirect_uri. When id_token_hint is supplied it MUST pass end-to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any failure, or a hint subject that contradicts the browser session, is rejected with 400 AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400. Accepts both GET (link-based) and POST (form-based).
 //
 // Returns a wrapper object for the known response body format(s).
 //

--- a/clients/go/generated/client.gen.go
+++ b/clients/go/generated/client.gen.go
@@ -943,6 +943,9 @@ type PostOauth2EndSessionParams struct {
 	// IdTokenHint Previously issued id_token hint (signature-verified,
 	IdTokenHint *string `form:"id_token_hint,omitempty" json:"id_token_hint,omitempty"`
 
+	// ClientId RP self-identification when id_token_hint is absent (RP-Initiated Logout 1.0 §2.1). The post_logout_redirect_uri must be registered for this client (#88-3).
+	ClientId *string `form:"client_id,omitempty" json:"client_id,omitempty"`
+
 	// PostLogoutRedirectUri Registered post-logout redirect URI.
 	PostLogoutRedirectUri *string `form:"post_logout_redirect_uri,omitempty" json:"post_logout_redirect_uri,omitempty"`
 
@@ -6907,6 +6910,18 @@ func NewPostOauth2EndSessionRequest(server string, params *PostOauth2EndSessionP
 		if params.IdTokenHint != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "id_token_hint", *params.IdTokenHint, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.ClientId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "client_id", *params.ClientId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/clients/python/src/fulla/generated/api/admin/get_api_admin_oidc_keys.py
+++ b/clients/python/src/fulla/generated/api/admin/get_api_admin_oidc_keys.py
@@ -46,7 +46,9 @@ def sync_detailed(
 ) -> Response[Any]:
     """Get OIDC Keys Info
 
-     Get information about OIDC signing keys.
+     Live signing-keystore state (#110): every loaded kid with its status (active = signs new tokens,
+    published = verification-only during a rotation grace window), the active_kid, and the key count.
+    Cryptographic material (n/e) lives in /.well-known/jwks.json.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -71,7 +73,9 @@ async def asyncio_detailed(
 ) -> Response[Any]:
     """Get OIDC Keys Info
 
-     Get information about OIDC signing keys.
+     Live signing-keystore state (#110): every loaded kid with its status (active = signs new tokens,
+    published = verification-only during a rotation grace window), the active_kid, and the key count.
+    Cryptographic material (n/e) lives in /.well-known/jwks.json.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/clients/python/src/fulla/generated/api/o_auth_2/get_oauth2_end_session.py
+++ b/clients/python/src/fulla/generated/api/o_auth_2/get_oauth2_end_session.py
@@ -14,6 +14,7 @@ def _get_kwargs(
     *,
     id_token_hint: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> dict[str, Any]:
 
@@ -22,6 +23,8 @@ def _get_kwargs(
     params["id_token_hint"] = id_token_hint
 
     params["post_logout_redirect_uri"] = post_logout_redirect_uri
+
+    params["client_id"] = client_id
 
     params["state"] = state
 
@@ -75,6 +78,7 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Response[Any | ErrorEnvelope | MessageResponse]:
     """RP-Initiated Logout
@@ -84,13 +88,15 @@ def sync_detailed(
     to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any
     failure, or a hint subject that contradicts the browser session, is rejected with 400
     AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the
-    client identified by the verified id_token_hint (its aud claim); without a hint the request is
-    rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-
-    based).
+    client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no
+    hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for
+    exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400.
+    Accepts both GET (link-based) and POST (form-based).
 
     Args:
         id_token_hint (str | Unset):
         post_logout_redirect_uri (str | Unset):
+        client_id (str | Unset):
         state (str | Unset):
 
     Raises:
@@ -104,6 +110,7 @@ def sync_detailed(
     kwargs = _get_kwargs(
         id_token_hint=id_token_hint,
         post_logout_redirect_uri=post_logout_redirect_uri,
+        client_id=client_id,
         state=state,
     )
 
@@ -119,6 +126,7 @@ def sync(
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Any | ErrorEnvelope | MessageResponse | None:
     """RP-Initiated Logout
@@ -128,13 +136,15 @@ def sync(
     to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any
     failure, or a hint subject that contradicts the browser session, is rejected with 400
     AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the
-    client identified by the verified id_token_hint (its aud claim); without a hint the request is
-    rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-
-    based).
+    client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no
+    hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for
+    exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400.
+    Accepts both GET (link-based) and POST (form-based).
 
     Args:
         id_token_hint (str | Unset):
         post_logout_redirect_uri (str | Unset):
+        client_id (str | Unset):
         state (str | Unset):
 
     Raises:
@@ -149,6 +159,7 @@ def sync(
         client=client,
         id_token_hint=id_token_hint,
         post_logout_redirect_uri=post_logout_redirect_uri,
+        client_id=client_id,
         state=state,
     ).parsed
 
@@ -158,6 +169,7 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Response[Any | ErrorEnvelope | MessageResponse]:
     """RP-Initiated Logout
@@ -167,13 +179,15 @@ async def asyncio_detailed(
     to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any
     failure, or a hint subject that contradicts the browser session, is rejected with 400
     AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the
-    client identified by the verified id_token_hint (its aud claim); without a hint the request is
-    rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-
-    based).
+    client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no
+    hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for
+    exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400.
+    Accepts both GET (link-based) and POST (form-based).
 
     Args:
         id_token_hint (str | Unset):
         post_logout_redirect_uri (str | Unset):
+        client_id (str | Unset):
         state (str | Unset):
 
     Raises:
@@ -187,6 +201,7 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         id_token_hint=id_token_hint,
         post_logout_redirect_uri=post_logout_redirect_uri,
+        client_id=client_id,
         state=state,
     )
 
@@ -200,6 +215,7 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Any | ErrorEnvelope | MessageResponse | None:
     """RP-Initiated Logout
@@ -209,13 +225,15 @@ async def asyncio(
     to-end verification (#78: RS256 signature against the OP key set, strict alg/kid, iss, exp) — any
     failure, or a hint subject that contradicts the browser session, is rejected with 400
     AUTH_INVALID_ID_TOKEN_HINT (Error Envelope). post_logout_redirect_uri MUST be registered for the
-    client identified by the verified id_token_hint (its aud claim); without a hint the request is
-    rejected with 400 when a redirect URI is supplied. Accepts both GET (link-based) and POST (form-
-    based).
+    client identifying itself in the request: the verified id_token_hint (its aud claim) or, when no
+    hint is supplied, the client_id parameter (RP-Initiated Logout 1.0 §2.1 defines client_id for
+    exactly this case, #88-3). With NEITHER hint nor client_id a redirect URI is rejected with 400.
+    Accepts both GET (link-based) and POST (form-based).
 
     Args:
         id_token_hint (str | Unset):
         post_logout_redirect_uri (str | Unset):
+        client_id (str | Unset):
         state (str | Unset):
 
     Raises:
@@ -231,6 +249,7 @@ async def asyncio(
             client=client,
             id_token_hint=id_token_hint,
             post_logout_redirect_uri=post_logout_redirect_uri,
+            client_id=client_id,
             state=state,
         )
     ).parsed

--- a/clients/python/src/fulla/generated/api/o_auth_2/post_oauth2_end_session.py
+++ b/clients/python/src/fulla/generated/api/o_auth_2/post_oauth2_end_session.py
@@ -13,6 +13,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     *,
     id_token_hint: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> dict[str, Any]:
@@ -20,6 +21,8 @@ def _get_kwargs(
     params: dict[str, Any] = {}
 
     params["id_token_hint"] = id_token_hint
+
+    params["client_id"] = client_id
 
     params["post_logout_redirect_uri"] = post_logout_redirect_uri
 
@@ -74,6 +77,7 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Response[Any | ErrorEnvelope | MessageResponse]:
@@ -85,6 +89,7 @@ def sync_detailed(
 
     Args:
         id_token_hint (str | Unset):
+        client_id (str | Unset):
         post_logout_redirect_uri (str | Unset):
         state (str | Unset):
 
@@ -98,6 +103,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         id_token_hint=id_token_hint,
+        client_id=client_id,
         post_logout_redirect_uri=post_logout_redirect_uri,
         state=state,
     )
@@ -113,6 +119,7 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Any | ErrorEnvelope | MessageResponse | None:
@@ -124,6 +131,7 @@ def sync(
 
     Args:
         id_token_hint (str | Unset):
+        client_id (str | Unset):
         post_logout_redirect_uri (str | Unset):
         state (str | Unset):
 
@@ -138,6 +146,7 @@ def sync(
     return sync_detailed(
         client=client,
         id_token_hint=id_token_hint,
+        client_id=client_id,
         post_logout_redirect_uri=post_logout_redirect_uri,
         state=state,
     ).parsed
@@ -147,6 +156,7 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Response[Any | ErrorEnvelope | MessageResponse]:
@@ -158,6 +168,7 @@ async def asyncio_detailed(
 
     Args:
         id_token_hint (str | Unset):
+        client_id (str | Unset):
         post_logout_redirect_uri (str | Unset):
         state (str | Unset):
 
@@ -171,6 +182,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         id_token_hint=id_token_hint,
+        client_id=client_id,
         post_logout_redirect_uri=post_logout_redirect_uri,
         state=state,
     )
@@ -184,6 +196,7 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     id_token_hint: str | Unset = UNSET,
+    client_id: str | Unset = UNSET,
     post_logout_redirect_uri: str | Unset = UNSET,
     state: str | Unset = UNSET,
 ) -> Any | ErrorEnvelope | MessageResponse | None:
@@ -195,6 +208,7 @@ async def asyncio(
 
     Args:
         id_token_hint (str | Unset):
+        client_id (str | Unset):
         post_logout_redirect_uri (str | Unset):
         state (str | Unset):
 
@@ -210,6 +224,7 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             id_token_hint=id_token_hint,
+            client_id=client_id,
             post_logout_redirect_uri=post_logout_redirect_uri,
             state=state,
         )

--- a/clients/python/src/fulla/generated/api/open_id_connect/get_well_known_jwks_json.py
+++ b/clients/python/src/fulla/generated/api/open_id_connect/get_well_known_jwks_json.py
@@ -46,7 +46,9 @@ def sync_detailed(
 ) -> Response[JWKSet]:
     """JSON Web Key Set
 
-     Returns the public keys used by this server to sign JWTs.
+     Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110)
+    EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active
+    signer is the kid the issued JWT headers carry.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -71,7 +73,9 @@ def sync(
 ) -> JWKSet | None:
     """JSON Web Key Set
 
-     Returns the public keys used by this server to sign JWTs.
+     Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110)
+    EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active
+    signer is the kid the issued JWT headers carry.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -92,7 +96,9 @@ async def asyncio_detailed(
 ) -> Response[JWKSet]:
     """JSON Web Key Set
 
-     Returns the public keys used by this server to sign JWTs.
+     Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110)
+    EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active
+    signer is the kid the issued JWT headers carry.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,7 +121,9 @@ async def asyncio(
 ) -> JWKSet | None:
     """JSON Web Key Set
 
-     Returns the public keys used by this server to sign JWTs.
+     Returns the public keys used by this server to sign JWTs. With a signing keystore configured (#110)
+    EVERY loaded key is published so tokens keep verifying across the rotation grace window; the active
+    signer is the kid the issued JWT headers carry.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/docs/operate/configuration-guide.md
+++ b/docs/operate/configuration-guide.md
@@ -242,7 +242,8 @@ Semantics:
 restart — three restarts per cycle):
 
 1. **Publish**: drop the new `<kid>.pem` into the directory, restart. Both keys are now in
-   the JWKS; the OLD key keeps signing.
+   the JWKS; the OLD key keeps signing. Wait at least the JWKS `Cache-Control` max-age
+   (1 h) before step 2 — a strictly-caching RP otherwise cannot resolve the new kid yet.
 2. **Switch**: edit `active_kid` to the new kid, restart. New tokens carry the new kid;
    old tokens still verify (old key still published).
 3. **Retire**: after the maximum token lifetime has elapsed (access + refresh chain —

--- a/docs/operate/configuration-guide.md
+++ b/docs/operate/configuration-guide.md
@@ -214,18 +214,47 @@ Both keys may be omitted; when the `rate_limit` object is missing, built-in defa
 one counter table within the same process. This is minimal brute-force / token-probing
 protection; multi-instance deployments require shared storage (Redis), which is future work.
 
-## 9. JWKS Key Rotation (F-029 — Operations To-Do)
+## 9. JWKS Key Rotation (#110 — keystore directory)
 
-The JWKS endpoint (`/.well-known/jwks.json`) currently serves a **single static `kid`**,
-initialized once at plugin startup from the configured JWK material
-(`OAuth2Plugin::initAndStart()` → `JwkManager::init()`). **Rotation is not implemented**:
-there is no rotation schedule, no kid rolling window, and no dual-key publication. Tokens
-signed by the current key remain valid for their entire lifetime; rotating the key would
-invalidate all outstanding tokens signed by its predecessor.
+`plugins.OAuth2Plugin.config.oidc.signing_keystore_dir` points at a **keystore directory**
+and is the key-rotation mechanism:
 
-Production rotation is registered as an operations to-do. Until then, operators who include
-key compromise in their threat model should restart the server with new JWK material (and
-accept the invalidation of all previously issued tokens).
+```
+<path>/
+  2026-09.pem        # one RSA private key per file; FILENAME (minus .pem) = kid
+  2026-12.pem
+  active_kid         # one-line text file naming the signing kid (e.g. "2026-12")
+```
+
+Semantics:
+
+- **Signing** always uses the key named by `active_kid`; the JWT header carries that kid.
+- **Verification** routes on the token's header kid across ALL loaded keys, and the JWKS
+  endpoint (`/.well-known/jwks.json`) publishes every loaded public key — so outstanding
+  tokens keep resolving while their key remains in the directory.
+- `GET /api/admin/oidc/keys` reports the live state: every kid, which one is `active`,
+  which are merely `published`.
+- The keystore takes **precedence** over `FULLA_SIGNING_KEY` / `FULLA_JWT_KEY_PATH` /
+  `signing_key_path`, and a configured-but-broken directory is a **hard startup failure**
+  (never a silent fallback to a different key source).
+
+**Rotation procedure** (JwkManager is init-once/read-only by design, so each step is a
+restart — three restarts per cycle):
+
+1. **Publish**: drop the new `<kid>.pem` into the directory, restart. Both keys are now in
+   the JWKS; the OLD key keeps signing.
+2. **Switch**: edit `active_kid` to the new kid, restart. New tokens carry the new kid;
+   old tokens still verify (old key still published).
+3. **Retire**: after the maximum token lifetime has elapsed (access + refresh chain —
+   size this from your token TTLs, not the clock of step 2), delete the old `<kid>.pem`
+   and restart. Tokens from the old key now fail verification with an unknown-kid error.
+
+Skipping step 3 leaves the old key published forever (harmless, but keeps the compromise
+surface open); performing it early invalidates outstanding old-key tokens.
+
+Key generation is standard tooling, e.g.
+`openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out 2026-12.pem`.
+Protect the directory like any private-key material (file permissions / secret mounts).
 
 ## 10. Legacy Password-Hash Migration Window (#103)
 

--- a/libs/common/src/config/ConfigManager.cc
+++ b/libs/common/src/config/ConfigManager.cc
@@ -408,6 +408,7 @@ bool ConfigManager::validate(const Json::Value &config, std::string &errorMessag
             const char *keyEnv = std::getenv("FULLA_SIGNING_KEY");
             const char *keyPathEnv = std::getenv("FULLA_JWT_KEY_PATH");
             std::string configKeyPath;
+            std::string configKeystoreDir;
             if (config.isMember("plugins") && config["plugins"].isArray())
             {
                 for (const auto &plugin : config["plugins"])
@@ -419,8 +420,15 @@ bool ConfigManager::validate(const Json::Value &config, std::string &errorMessag
                     // The plugin hands config["oidc"] to JwkManager::init, so
                     // signing_key_path lives under "oidc".
                     if (pluginConfig.isMember("oidc"))
+                    {
                         configKeyPath =
                           pluginConfig["oidc"].get("signing_key_path", "").asString();
+                        // #110-B: the keystore directory is a complete key
+                        // source on its own (rotation deployments use nothing
+                        // else) -- count it for the production key check.
+                        configKeystoreDir =
+                          pluginConfig["oidc"].get("signing_keystore_dir", "").asString();
+                    }
 
                     // #102 (memory-storage scope): config-declared clients
                     // with default/empty secrets. In postgres mode the client
@@ -450,12 +458,13 @@ bool ConfigManager::validate(const Json::Value &config, std::string &errorMessag
             }
             const bool hasEnvKey = keyEnv && std::strlen(keyEnv) > 0;
             const bool hasEnvPath = keyPathEnv && std::strlen(keyPathEnv) > 0;
-            if (!hasEnvKey && !hasEnvPath && configKeyPath.empty())
+            if (!hasEnvKey && !hasEnvPath && configKeyPath.empty() && configKeystoreDir.empty())
             {
                 errorMessage =
                   "Production requires a real signing key: set FULLA_SIGNING_KEY, "
-                  "FULLA_JWT_KEY_PATH, or plugins.OAuth2Plugin.config.oidc."
-                  "signing_key_path (the ephemeral dev key is rejected in production)";
+                  "FULLA_JWT_KEY_PATH, plugins.OAuth2Plugin.config.oidc."
+                  "signing_key_path, or plugins.OAuth2Plugin.config.oidc."
+                  "signing_keystore_dir (the ephemeral dev key is rejected in production)";
                 return false;
             }
         }

--- a/libs/drogon/include/fulla/drogon/admin/TokenManagementService.h
+++ b/libs/drogon/include/fulla/drogon/admin/TokenManagementService.h
@@ -12,6 +12,7 @@
 
 #include <drogon/HttpRequest.h>
 #include <drogon/HttpResponse.h>
+#include <fulla/oauth2/jwk/JwkManager.h>
 
 #include <functional>
 #include <memory>
@@ -51,7 +52,12 @@ class TokenManagementService
     static void revokeTokensByUser(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
 
     // ---- GET /api/admin/oidc/keys (no DB access, pure metadata) ----
-    static void getOidcKeys(ResponseCallback cb);
+    // #110-B: reports the LIVE keystore state (every loaded kid, which one
+    // is active) from the provided JwkManager instead of the hardcoded stub.
+    static void getOidcKeys(
+      ResponseCallback cb,
+      const std::shared_ptr<const fulla::oauth2::JwkManager> &jwkManager
+    );
 };
 
 }  // namespace fulla::drogon::admin

--- a/libs/drogon/src/admin/TokenManagementService.cc
+++ b/libs/drogon/src/admin/TokenManagementService.cc
@@ -320,18 +320,39 @@ void TokenManagementService::revokeTokensByUser(
     );
 }
 
-void TokenManagementService::getOidcKeys(ResponseCallback cb)
+void TokenManagementService::getOidcKeys(
+  ResponseCallback cb,
+  const std::shared_ptr<const fulla::oauth2::JwkManager> &jwkManager
+)
 {
     Json::Value json;
     json["status"] = "success";
-    json["kid"] = "default-key-1";
-    json["kty"] = "RSA";
-    json["alg"] = "RS256";
-    json["use"] = "sig";
     json["jwks_uri"] = "/.well-known/jwks.json";
     json["discovery_uri"] = "/.well-known/openid-configuration";
-    json["key_status"] = "active";
-    json["note"] = "Key rotation is not yet implemented. Single signing key in use.";
+
+    // #110-B: live keystore view. The JWKS carries the cryptographic detail
+    // (n/e per key); this admin view summarizes the rotation state instead:
+    // every loaded kid, the active signer, and the rotation procedure note.
+    Json::Value jwks = jwkManager ? jwkManager->getJwks() : Json::Value(Json::objectValue);
+    Json::Value keys(Json::arrayValue);
+    const std::string &activeKid = jwkManager ? jwkManager->getKeyId() : std::string();
+    for (const auto &key : jwks["keys"])
+    {
+        Json::Value entry;
+        entry["kid"] = key.get("kid", "");
+        entry["kty"] = key.get("kty", "RSA");
+        entry["alg"] = key.get("alg", "RS256");
+        entry["use"] = key.get("use", "sig");
+        entry["status"] = (entry["kid"].asString() == activeKid) ? "active" : "published";
+        keys.append(entry);
+    }
+    json["keys"] = keys;
+    json["active_kid"] = activeKid;
+    json["key_count"] = static_cast<Json::UInt64>(keys.size());
+    json["note"] =
+      "Rotation: add <kid>.pem to the keystore dir and restart (published), flip "
+      "active_kid and restart (signing switches), remove the old <kid>.pem after "
+      "the max token lifetime and restart (retired).";
 
     (*cb)(::drogon::HttpResponse::newHttpJsonResponse(json));
 }

--- a/libs/drogon/src/controllers/SessionController.cc
+++ b/libs/drogon/src/controllers/SessionController.cc
@@ -474,13 +474,17 @@ struct OAuth2ControllerDocs
             endSessionGet.tags = {"OAuth2", "OIDC"};
             endSessionGet.parameters = {
               endSessionParam("id_token_hint", "Previously issued id_token hinting at the client/session to terminate."),
-              endSessionParam("post_logout_redirect_uri", "URI to redirect to after logout; must be registered for the id_token_hint client."),
+              endSessionParam(
+                "client_id",
+                "RP self-identification when id_token_hint is absent (RP-Initiated Logout 1.0 §2.1); the post_logout_redirect_uri must be registered for this client (#88-3)."
+              ),
+              endSessionParam("post_logout_redirect_uri", "URI to redirect to after logout; must be registered for the id_token_hint (or client_id) client."),
               endSessionParam("state", "Opaque value echoed back to the post_logout_redirect_uri."),
             };
             endSessionGet.responses = {
               {200, "Logged out (no post_logout_redirect_uri supplied)"},
               {302, "Redirect to the validated post_logout_redirect_uri (with state)"},
-              {400, "post_logout_redirect_uri not registered / no id_token_hint"},
+              {400, "post_logout_redirect_uri not registered / neither id_token_hint nor client_id supplied"},
             };
             endSessionGet.requiresAuth = false;
             OpenApiGenerator::addEndpoint(endSessionGet);
@@ -1880,14 +1884,18 @@ void SessionController::endSession(
     auto params = req->getParameters();
     std::string idTokenHint = params["id_token_hint"];
     std::string postLogoutRedirectUri = params["post_logout_redirect_uri"];
+    std::string clientId = params["client_id"];
     std::string state = params["state"];
 
     // Validate post_logout_redirect_uri: if id_token_hint is present (and,
     // since #78, signature-verified -- see the gate below), use its aud claim
     // to find the client_id, then require the redirect URI to be one of that
-    // client's registered redirect_uris. If id_token_hint is absent, only
-    // accept the redirect URI when it is empty (the spec allows the server to
-    // require pre-registration; this server does so for safety).
+    // client's registered redirect_uris. If id_token_hint is absent, the RP
+    // may instead identify itself with the client_id parameter (OIDC
+    // RP-Initiated Logout 1.0 §2.1 defines client_id for exactly the
+    // no-hint case; §2.3 still requires the post_logout_redirect_uri to be
+    // pre-registered for that client, which validateRedirectUri enforces
+    // below). #88-3 decision A (2026-09-03).
     auto plugin = resolvePlugin();
 
     // #78: an id_token_hint MUST pass end-to-end verification (RS256 signature
@@ -2001,6 +2009,17 @@ void SessionController::endSession(
             return;
         }
     }
+    // #88-3 (decision A): with no id_token_hint, the request's client_id is
+    // the RP self-identification the spec defines for exactly this case
+    // (RP-Initiated Logout 1.0 §2.1). It feeds the SAME registered-URI gate
+    // the aud candidates use, so the redirect target must still be
+    // pre-registered for that client -- the relaxation adds no open
+    // redirect, and the session-termination semantics below (which a plain
+    // parameterless end_session already performs) are unchanged.
+    if (idTokenHint.empty() && !clientId.empty())
+    {
+        audCandidates.push_back(clientId);
+    }
     std::string subject;
     if (req->session())
         subject = req->session()->get<std::string>("sub");
@@ -2034,7 +2053,8 @@ void SessionController::endSession(
         // reject immediately -- this server requires pre-registration per
         // §2.3 ("the OP MAY require pre-registration"). #88: enveloped as
         // AUTH_INVALID_ID_TOKEN_HINT (was a plain-text body), still routed
-        // through finish so no backchannel notification fires.
+        // through finish so no backchannel notification fires. #88-3: this
+        // now only fires when BOTH id_token_hint and client_id are absent.
         if (audCandidates.empty())
         {
             respondError(
@@ -2042,7 +2062,7 @@ void SessionController::endSession(
               [finish](const ::drogon::HttpResponsePtr &r) mutable { finish("", r); },
               "AUTH_INVALID_ID_TOKEN_HINT",
               "end_session: post_logout_redirect_uri requires a valid id_token_hint "
-              "for client identification"
+              "or client_id for client identification"
             );
             return;
         }

--- a/libs/drogon/src/controllers/TokenAdminController.cc
+++ b/libs/drogon/src/controllers/TokenAdminController.cc
@@ -1,6 +1,7 @@
 #include <fulla/drogon/controllers/TokenAdminController.h>
 #include <fulla/drogon/admin/TokenManagementService.h>
 #include <fulla/drogon/observability/openapi/OpenApiGenerator.h>
+#include <fulla/drogon/plugin/OAuth2Plugin.h>
 
 #include <memory>
 
@@ -120,7 +121,14 @@ void TokenAdminController::getOidcKeys(
     (void)req;  // no DB access, no auth-derived behavior in this metadata route
     auto sharedCb =
       std::make_shared<std::function<void(const ::drogon::HttpResponsePtr &)>>(std::move(callback));
-    TokenService::getOidcKeys(sharedCb);
+    // #110-B: report the live keystore from the plugin's published (already
+    // init()'d, read-only) JwkManager.
+    TokenService::getOidcKeys(
+      sharedCb,
+      ::drogon::app().getPlugin<::OAuth2Plugin>()
+        ? ::drogon::app().getPlugin<::OAuth2Plugin>()->getJwkManager()
+        : nullptr
+    );
 }
 
 }  // namespace fulla::drogon::controllers

--- a/libs/oauth2/include/fulla/oauth2/jwk/JwkManager.h
+++ b/libs/oauth2/include/fulla/oauth2/jwk/JwkManager.h
@@ -24,6 +24,7 @@
 #include <json/json.h>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace fulla::oauth2
 {
@@ -31,17 +32,33 @@ namespace fulla::oauth2
 /**
  * @brief Manages RSA signing keys for OpenID Connect id_token.
  *
- * Loads RSA private key from PEM file or environment variable.
- * Signs JWT tokens using RS256 algorithm.
- * Exposes public key in JWK format for /.well-known/jwks.json.
+ * Loads RSA private keys from a keystore directory (#110-B), a single PEM
+ * file / env var (legacy single-key sources), or an ephemeral dev fallback.
+ * Signs JWT tokens with the ACTIVE key (RS256); verifies by routing on the
+ * JWT header kid across ALL loaded keys, so outstanding tokens signed by a
+ * since-retired key keep verifying while its public half is still published.
+ * Exposes every loaded public key in JWK format for /.well-known/jwks.json.
+ *
+ * ── Keystore directory (#110-B rotation) ─────────────────────────────────
+ * config "signing_keystore_dir" points at a directory of
+ *   <kid>.pem        one RSA private key per file, filename = kid
+ *   active_kid       a one-line text file naming the signing kid
+ * Rotation procedure (JwkManager is init-once/read-only by contract, so each
+ * step restarts the server -- see docs/operate/configuration-guide.md §9):
+ *   1. drop the new <kid>.pem in, restart  -> both keys published in JWKS,
+ *      old key keeps signing;
+ *   2. flip active_kid to the new kid, restart -> new key signs, old still
+ *      published for verification;
+ *   3. after the max token lifetime has passed, remove the old <kid>.pem,
+ *      restart -> old key fully retired.
  *
  * ── Concurrency contract: init-once, then read-only ─────────────────────
  * This class follows an "initialize exactly once during startup, read-only
  * at runtime" contract:
  *   - init() MUST be called exactly once, before the server begins
  *     accepting requests. init() is the ONLY mutating method; a second
- *     call logs an error and is a no-op (does NOT re-allocate rsaKey_ or
- *     overwrite kid_), removing the run-time mutation entry point.
+ *     call logs an error and is a no-op (does NOT re-allocate keys_ or
+ *     overwrite activeKid_), removing the run-time mutation entry point.
  *   - signJwt(), getJwks(), getKeyId(), isInitialized() are all const and
  *     only read the key state; safe to call concurrently from many
  *     threads with no per-call locking, PROVIDED init() has already
@@ -79,15 +96,22 @@ class JwkManager
     /**
      * @brief Initialize from configuration (call EXACTLY ONCE, at startup).
      *
-     * Loads the RSA private key from an env var / file path, or generates
-     * an ephemeral dev key as a fallback. This is the only mutating
-     * method.
+     * Source precedence (first that yields a loaded key wins):
+     *   1. "signing_keystore_dir" -- multi-key rotation directory (#110-B);
+     *   2. FULLA_SIGNING_KEY env (inline PEM, single key);
+     *   3. FULLA_JWT_KEY_PATH env (PEM file, single key);
+     *   4. "signing_key_path" config (PEM file, single key);
+     *   5. ephemeral generated key -- DEV ONLY, refused under
+     *      FULLA_ENV=production.
+     * Single-key sources load with kid = config "kid" (default "key-1");
+     * the keystore derives kids from the PEM filenames and the active key
+     * from the directory's active_kid file.
      *
-     * @param config JSON config with "signing_key_path" / "kid" (or env
-     * vars).
-     * @return true if a key is loaded and the manager is initialized
-     * (including the no-op case where it was already initialized); false
-     * on first-time initialization failure.
+     * @param config JSON config with "signing_keystore_dir" /
+     * "signing_key_path" / "kid" (or env vars).
+     * @return true if at least one key is loaded and the manager is
+     * initialized (including the no-op case where it was already
+     * initialized); false on first-time initialization failure.
      */
     bool init(const Json::Value &config);
 
@@ -177,7 +201,7 @@ class JwkManager
     /// Get the current key ID.
     const std::string &getKeyId() const
     {
-        return kid_;
+        return activeKid_;
     }
 
     /// Check if manager is initialized with a valid key.
@@ -187,13 +211,34 @@ class JwkManager
     }
 
   private:
-    void *rsaKey_ = nullptr;  // EVP_PKEY* (opaque to avoid OpenSSL header in public API)
-    std::string kid_;
+    /// One loaded signing key. `pkey` is an EVP_PKEY* kept opaque (void*) so
+    /// the public header does not pull OpenSSL in -- same convention as the
+    /// pre-#110 single `rsaKey_` member.
+    struct KeyEntry
+    {
+        std::string kid;
+        void *pkey = nullptr;  // EVP_PKEY* (owned)
+    };
+
+    /// All loaded keys (>=1 once initialized_). Order = load order; the
+    /// keystore sorts by filename, single-key sources append their one entry.
+    std::vector<KeyEntry> keys_;
+    std::string activeKid_;  // kid of the signing key (equals keys_[i].kid)
     bool initialized_ = false;
     fulla::common::ports::ILogger *logger_ = nullptr;  // non-owning; may be nullptr
 
-    bool generateEphemeralKey();
-    bool loadFromPem(const std::string &pemData);
+    /// Find a loaded entry by kid; nullptr when unknown.
+    const KeyEntry *findEntry(const std::string &kid) const;
+    /// The active (signing) entry; nullptr when uninitialized.
+    const KeyEntry *activeEntry() const;
+
+    bool generateEphemeralKey(KeyEntry &entry);
+    /// Parse one PEM into `entry.pkey`; returns false on parse failure
+    /// (kid must be set by the caller).
+    bool loadPemInto(KeyEntry &entry, const std::string &pemData);
+    /// #110-B: load <kid>.pem files + the active_kid marker from `dir`.
+    /// Returns false (with keys_ untouched) on any structural error.
+    bool loadKeystoreDir(const std::string &dir);
 
     static std::string base64UrlEncode(const unsigned char *data, size_t len);
     static std::string base64UrlEncode(const std::string &data);
@@ -202,7 +247,13 @@ class JwkManager
     /// on failure. Domain-layer constraint: hand-rolled, no drogon/3rd-party.
     static bool base64UrlDecode(const std::string &input, std::string &output);
 
-    bool getPublicKeyComponents(std::string &n, std::string &e) const;
+    /// n/e components of one key's public half (empty-then-false on failure).
+    bool getPublicKeyComponents(const KeyEntry &entry, std::string &n, std::string &e) const;
+
+    /// Verify the RS256 signature of `signingInput` against one key.
+    static bool verifyRs256Signature(
+      const void *pkey, const std::string &signingInput, const std::string &signature
+    );
 
     /// Shared verification core of verifyJwt()/verifyAndDecode(): runs the
     /// full check chain; when verifiedPayloadOut is non-null and every check

--- a/libs/oauth2/src/jwk/JwkManager.cc
+++ b/libs/oauth2/src/jwk/JwkManager.cc
@@ -225,6 +225,21 @@ bool JwkManager::loadPemInto(KeyEntry &entry, const std::string &pemData)
         return false;
     }
 
+    // PR #176 review MINOR-1: strict RS256 means RSA keys ONLY. A dropped-in
+    // EC/Ed25519 PEM would otherwise load, silently vanish from the JWKS
+    // (RSA-only component extraction) and — as the active key — sign ECDSA
+    // signatures under an alg=RS256 header no RP can verify. Wrong key type
+    // is a hard init failure, same as a parse failure.
+    if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
+    {
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: signing key is not an RSA key (strict RS256) -- refusing to load"
+        );
+        EVP_PKEY_free(pkey);
+        return false;
+    }
+
     entry.pkey = pkey;
     return true;
 }
@@ -287,8 +302,19 @@ bool JwkManager::loadKeystoreDir(const std::string &dir)
         if (kid.empty())
             continue;
         std::ifstream pemFile(fs::path(dir) / (kid + ".pem"));
+        // PR #176 review MINOR-2: an unopenable .pem is a hard failure, not a
+        // skip -- silently dropping the NEW key would no-op rotation step 1
+        // ("Publish") and only surface when step 2 flips active_kid.
         if (!pemFile.is_open())
-            continue;
+        {
+            for (auto &e : loaded)
+                EVP_PKEY_free(static_cast<EVP_PKEY *>(e.pkey));
+            log(
+              fulla::common::ports::LogLevel::Error,
+              "JwkManager: keystore " + dir + "/" + kid + ".pem cannot be opened"
+            );
+            return false;
+        }
         std::stringstream ss;
         ss << pemFile.rdbuf();
         KeyEntry entry;

--- a/libs/oauth2/src/jwk/JwkManager.cc
+++ b/libs/oauth2/src/jwk/JwkManager.cc
@@ -4,6 +4,8 @@
 #include <openssl/bn.h>
 #include <openssl/core_names.h>
 #include <openssl/err.h>
+#include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <cstring>
@@ -21,11 +23,29 @@ void JwkManager::log(fulla::common::ports::LogLevel level, const std::string &me
 
 JwkManager::~JwkManager()
 {
-    if (rsaKey_)
+    for (auto &entry : keys_)
     {
-        EVP_PKEY_free(static_cast<EVP_PKEY *>(rsaKey_));
-        rsaKey_ = nullptr;
+        if (entry.pkey)
+        {
+            EVP_PKEY_free(static_cast<EVP_PKEY *>(entry.pkey));
+            entry.pkey = nullptr;
+        }
     }
+}
+
+const JwkManager::KeyEntry *JwkManager::findEntry(const std::string &kid) const
+{
+    for (const auto &entry : keys_)
+    {
+        if (entry.kid == kid)
+            return &entry;
+    }
+    return nullptr;
+}
+
+const JwkManager::KeyEntry *JwkManager::activeEntry() const
+{
+    return findEntry(activeKid_);
 }
 
 bool JwkManager::init(const Json::Value &config)
@@ -35,17 +55,49 @@ bool JwkManager::init(const Json::Value &config)
         log(
           fulla::common::ports::LogLevel::Error,
           "JwkManager: init() called more than once; ignoring "
-          "(init-once-then-read-only contract). The existing key is kept."
+          "(init-once-then-read-only contract). The existing keys are kept."
         );
         return true;
+    }
+
+    // #110-B (decision B): the multi-key keystore directory is the richest
+    // source and takes precedence -- when configured it is authoritative
+    // (mixing it with the single-key env vars below would make the effective
+    // key set depend on ambient env, which a rotation runbook cannot
+    // tolerate). A configured-but-broken directory is a HARD failure, never
+    // a silent fallthrough to a different key source.
+    const std::string keystoreDir = config.get("signing_keystore_dir", "").asString();
+    if (!keystoreDir.empty())
+    {
+        if (loadKeystoreDir(keystoreDir))
+        {
+            initialized_ = true;
+            log(
+              fulla::common::ports::LogLevel::Info,
+              "JwkManager: Loaded " + std::to_string(keys_.size()) +
+                " signing key(s) from keystore dir " + keystoreDir + " (active kid: " +
+                activeKid_ + ")"
+            );
+            return true;
+        }
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: signing_keystore_dir=" + keystoreDir +
+            " is configured but failed to load -- refusing to fall back to "
+            "another key source (fix the directory and restart)"
+        );
+        return false;
     }
 
     const char *keyEnv = std::getenv("FULLA_SIGNING_KEY");
     if (keyEnv && std::strlen(keyEnv) > 0)
     {
-        if (loadFromPem(keyEnv))
+        KeyEntry entry;
+        entry.kid = config.get("kid", "key-1").asString();
+        if (loadPemInto(entry, keyEnv))
         {
-            kid_ = config.get("kid", "key-1").asString();
+            keys_.push_back(std::move(entry));
+            activeKid_ = keys_.front().kid;
             initialized_ = true;
             log(
               fulla::common::ports::LogLevel::Info,
@@ -63,9 +115,12 @@ bool JwkManager::init(const Json::Value &config)
         {
             std::stringstream ss;
             ss << file.rdbuf();
-            if (loadFromPem(ss.str()))
+            KeyEntry entry;
+            entry.kid = config.get("kid", "key-1").asString();
+            if (loadPemInto(entry, ss.str()))
             {
-                kid_ = config.get("kid", "key-1").asString();
+                keys_.push_back(std::move(entry));
+                activeKid_ = keys_.front().kid;
                 initialized_ = true;
                 log(
                   fulla::common::ports::LogLevel::Info,
@@ -89,9 +144,12 @@ bool JwkManager::init(const Json::Value &config)
         {
             std::stringstream ss;
             ss << file.rdbuf();
-            if (loadFromPem(ss.str()))
+            KeyEntry entry;
+            entry.kid = config.get("kid", "key-1").asString();
+            if (loadPemInto(entry, ss.str()))
             {
-                kid_ = config.get("kid", "key-1").asString();
+                keys_.push_back(std::move(entry));
+                activeKid_ = keys_.front().kid;
                 initialized_ = true;
                 log(
                   fulla::common::ports::LogLevel::Info,
@@ -117,9 +175,9 @@ bool JwkManager::init(const Json::Value &config)
             log(
               fulla::common::ports::LogLevel::Error,
               "JwkManager: no signing key configured and FULLA_ENV=production -- "
-              "the ephemeral fallback is DEV ONLY. Configure FULLA_SIGNING_KEY, "
-              "FULLA_JWT_KEY_PATH, or plugins.OAuth2Plugin.config.oidc."
-              "signing_key_path and restart"
+              "the ephemeral fallback is DEV ONLY. Configure signing_keystore_dir, "
+              "FULLA_SIGNING_KEY, FULLA_JWT_KEY_PATH, or "
+              "plugins.OAuth2Plugin.config.oidc.signing_key_path and restart"
             );
             return false;
         }
@@ -129,21 +187,28 @@ bool JwkManager::init(const Json::Value &config)
       fulla::common::ports::LogLevel::Warn,
       "JwkManager: No signing key configured, generating ephemeral key (DEV ONLY)"
     );
-    if (generateEphemeralKey())
     {
+        KeyEntry entry;
         // #87: honor a configured kid on the ephemeral path too (previously
         // hardcoded, so tests/ops needing a distinct kid had to go through
         // env+PEM). The ephemeral marker stays the default.
-        kid_ = config.get("kid", "ephemeral-dev-key").asString();
-        initialized_ = true;
-        return true;
+        entry.kid = config.get("kid", "ephemeral-dev-key").asString();
+        if (generateEphemeralKey(entry))
+        {
+            // generateEphemeralKey() hands its EVP_PKEY to the pending entry
+            // (see its #110-B note).
+            keys_.push_back(std::move(entry));
+            activeKid_ = keys_.front().kid;
+            initialized_ = true;
+            return true;
+        }
     }
 
     log(fulla::common::ports::LogLevel::Error, "JwkManager: Failed to initialize");
     return false;
 }
 
-bool JwkManager::loadFromPem(const std::string &pemData)
+bool JwkManager::loadPemInto(KeyEntry &entry, const std::string &pemData)
 {
     BIO *bio = BIO_new_mem_buf(pemData.c_str(), static_cast<int>(pemData.length()));
     if (!bio)
@@ -160,11 +225,121 @@ bool JwkManager::loadFromPem(const std::string &pemData)
         return false;
     }
 
-    rsaKey_ = pkey;
+    entry.pkey = pkey;
     return true;
 }
 
-bool JwkManager::generateEphemeralKey()
+bool JwkManager::loadKeystoreDir(const std::string &dir)
+{
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(fs::path(dir), ec))
+    {
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: keystore dir " + dir + " is not a directory"
+        );
+        return false;
+    }
+
+    // Collect <kid>.pem candidates (sorted for deterministic load/JWKS order).
+    std::vector<std::string> kids;
+    for (const auto &item : fs::directory_iterator(fs::path(dir), ec))
+    {
+        if (!item.is_regular_file())
+            continue;
+        const std::string filename = item.path().filename().string();
+        if (filename.size() <= 4 || filename.substr(filename.size() - 4) != ".pem")
+            continue;
+        kids.push_back(filename.substr(0, filename.size() - 4));
+    }
+    std::sort(kids.begin(), kids.end());
+    if (kids.empty())
+    {
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: keystore dir " + dir + " contains no <kid>.pem files"
+        );
+        return false;
+    }
+
+    // The active kid marker is a one-line text file.
+    std::ifstream activeFile(fs::path(dir) / "active_kid");
+    if (!activeFile.is_open())
+    {
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: keystore dir " + dir + " has no active_kid marker file"
+        );
+        return false;
+    }
+    std::string activeKid;
+    std::getline(activeFile, activeKid);
+    // Trim CR/whitespace for hand-edited markers.
+    while (
+      !activeKid.empty() &&
+      (activeKid.back() == '\r' || activeKid.back() == ' ' || activeKid.back() == '\t'))
+        activeKid.pop_back();
+
+    std::vector<KeyEntry> loaded;
+    for (const auto &kid : kids)
+    {
+        if (kid.empty())
+            continue;
+        std::ifstream pemFile(fs::path(dir) / (kid + ".pem"));
+        if (!pemFile.is_open())
+            continue;
+        std::stringstream ss;
+        ss << pemFile.rdbuf();
+        KeyEntry entry;
+        entry.kid = kid;
+        if (!loadPemInto(entry, ss.str()))
+        {
+            for (auto &e : loaded)
+                EVP_PKEY_free(static_cast<EVP_PKEY *>(e.pkey));
+            log(
+              fulla::common::ports::LogLevel::Error,
+              "JwkManager: keystore " + dir + "/" + kid + ".pem failed to parse"
+            );
+            return false;
+        }
+        loaded.push_back(std::move(entry));
+    }
+    if (loaded.empty())
+    {
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: keystore dir " + dir + " loaded zero usable keys"
+        );
+        return false;
+    }
+    bool activeFound = false;
+    for (const auto &entry : loaded)
+    {
+        if (entry.kid == activeKid)
+        {
+            activeFound = true;
+            break;
+        }
+    }
+    if (!activeFound)
+    {
+        for (auto &e : loaded)
+            EVP_PKEY_free(static_cast<EVP_PKEY *>(e.pkey));
+        log(
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: keystore active_kid marker names [" + activeKid +
+            "] but no matching .pem exists in " + dir
+        );
+        return false;
+    }
+
+    keys_ = std::move(loaded);
+    activeKid_ = activeKid;
+    return true;
+}
+
+bool JwkManager::generateEphemeralKey(KeyEntry &entry)
 {
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
     if (!ctx)
@@ -190,7 +365,7 @@ bool JwkManager::generateEphemeralKey()
     }
 
     EVP_PKEY_CTX_free(ctx);
-    rsaKey_ = pkey;
+    entry.pkey = pkey;
     return true;
 }
 
@@ -253,10 +428,12 @@ std::string JwkManager::base64UrlEncode(const std::string &data)
 
 std::string JwkManager::signJwt(const Json::Value &payload) const
 {
-    if (!initialized_ || !rsaKey_)
+    const KeyEntry *active = activeEntry();
+    if (!initialized_ || !active)
     {
         log(
-          fulla::common::ports::LogLevel::Error, "JwkManager: Cannot sign JWT - not initialized"
+          fulla::common::ports::LogLevel::Error,
+          "JwkManager: Cannot sign JWT - not initialized (or active kid missing)"
         );
         return "";
     }
@@ -264,7 +441,9 @@ std::string JwkManager::signJwt(const Json::Value &payload) const
     Json::Value header;
     header["alg"] = "RS256";
     header["typ"] = "JWT";
-    header["kid"] = kid_;
+    // #110-B: the active kid routes verifiers (and JWKS consumers) to the
+    // intended public key.
+    header["kid"] = active->kid;
 
     Json::StreamWriterBuilder writerBuilder;
     writerBuilder["indentation"] = "";
@@ -280,7 +459,7 @@ std::string JwkManager::signJwt(const Json::Value &payload) const
     if (!mdCtx)
         return "";
 
-    EVP_PKEY *pkey = static_cast<EVP_PKEY *>(rsaKey_);
+    EVP_PKEY *pkey = static_cast<EVP_PKEY *>(active->pkey);
 
     if (EVP_DigestSignInit(mdCtx, nullptr, EVP_sha256(), nullptr, pkey) <= 0)
     {
@@ -426,7 +605,7 @@ JwkManager::JwtVerificationResult JwkManager::verifyCore(
   Json::Value *verifiedPayloadOut
 ) const
 {
-    if (!initialized_ || !rsaKey_)
+    if (!initialized_ || keys_.empty())
     {
         log(
           fulla::common::ports::LogLevel::Error, "JwkManager::verifyJwt: not initialized"
@@ -462,9 +641,17 @@ JwkManager::JwtVerificationResult JwkManager::verifyCore(
     if (!header.isMember("alg") || !header["alg"].isString() ||
         header["alg"].asString() != "RS256")
         return JwtVerificationResult::BadAlg;
-    if (header.isMember("kid") && header["kid"].isString() && !kid_.empty() &&
-        header["kid"].asString() != kid_)
-        return JwtVerificationResult::KidMismatch;
+    // #110-B: route by kid across ALL loaded keys. A kid naming no loaded
+    // key is a hard KidMismatch (previously: != the single configured kid).
+    // An absent kid (pre-kid-era tokens) tries every loaded key in order --
+    // strictly no narrower than the old single-key behavior.
+    const KeyEntry *entry = nullptr;
+    if (header.isMember("kid") && header["kid"].isString() && !header["kid"].asString().empty())
+    {
+        entry = findEntry(header["kid"].asString());
+        if (!entry)
+            return JwtVerificationResult::KidMismatch;
+    }
 
     // RS256 signature over the exact header.payload segments as received.
     const std::string signingInput = headerB64 + "." + payloadB64;
@@ -472,22 +659,21 @@ JwkManager::JwtVerificationResult JwkManager::verifyCore(
     if (!base64UrlDecode(signatureB64, signature))
         return JwtVerificationResult::Malformed;
     bool signatureOk = false;
+    if (entry != nullptr)
     {
-        EVP_MD_CTX *mdCtx = EVP_MD_CTX_new();
-        if (mdCtx)
+        signatureOk = verifyRs256Signature(entry->pkey, signingInput, signature);
+    }
+    else
+    {
+        // Absent kid: try every loaded key (RFC 7515 §4.1.4 permits this when
+        // the verifier holds several keys).
+        for (const auto &candidate : keys_)
         {
-            EVP_PKEY *pkey = static_cast<EVP_PKEY *>(rsaKey_);
-            if (EVP_DigestVerifyInit(mdCtx, nullptr, EVP_sha256(), nullptr, pkey) == 1 &&
-                EVP_DigestVerifyUpdate(mdCtx, signingInput.data(), signingInput.size()) == 1)
+            if (verifyRs256Signature(candidate.pkey, signingInput, signature))
             {
-                const int rc = EVP_DigestVerifyFinal(
-                  mdCtx,
-                  reinterpret_cast<const unsigned char *>(signature.data()),
-                  signature.size()
-                );
-                signatureOk = (rc == 1);
+                signatureOk = true;
+                break;
             }
-            EVP_MD_CTX_free(mdCtx);
         }
     }
     if (!signatureOk)
@@ -549,12 +735,35 @@ JwkManager::JwtVerificationResult JwkManager::verifyCore(
     return JwtVerificationResult::Ok;
 }
 
-bool JwkManager::getPublicKeyComponents(std::string &n, std::string &e) const
+bool JwkManager::verifyRs256Signature(
+  const void *pkeyVoid, const std::string &signingInput, const std::string &signature
+)
 {
-    if (!rsaKey_)
+    EVP_MD_CTX *mdCtx = EVP_MD_CTX_new();
+    if (!mdCtx)
+        return false;
+    bool ok = false;
+    EVP_PKEY *pkey = static_cast<EVP_PKEY *>(const_cast<void *>(pkeyVoid));
+    if (EVP_DigestVerifyInit(mdCtx, nullptr, EVP_sha256(), nullptr, pkey) == 1 &&
+        EVP_DigestVerifyUpdate(mdCtx, signingInput.data(), signingInput.size()) == 1)
+    {
+        const int rc = EVP_DigestVerifyFinal(
+          mdCtx,
+          reinterpret_cast<const unsigned char *>(signature.data()),
+          signature.size()
+        );
+        ok = (rc == 1);
+    }
+    EVP_MD_CTX_free(mdCtx);
+    return ok;
+}
+
+bool JwkManager::getPublicKeyComponents(const KeyEntry &entry, std::string &n, std::string &e) const
+{
+    if (!entry.pkey)
         return false;
 
-    EVP_PKEY *pkey = static_cast<EVP_PKEY *>(rsaKey_);
+    EVP_PKEY *pkey = static_cast<EVP_PKEY *>(entry.pkey);
 
     BIGNUM *bn_n = nullptr;
     BIGNUM *bn_e = nullptr;
@@ -593,14 +802,19 @@ Json::Value JwkManager::getJwks() const
     if (!initialized_)
         return jwks;
 
-    std::string n, e;
-    if (getPublicKeyComponents(n, e))
+    // #110-B: publish EVERY loaded key so verifiers keep resolving tokens
+    // signed by a since-deactivated (but still trusted) key during the
+    // rotation grace window.
+    for (const auto &entry : keys_)
     {
+        std::string n, e;
+        if (!getPublicKeyComponents(entry, n, e))
+            continue;
         Json::Value key;
         key["kty"] = "RSA";
         key["use"] = "sig";
         key["alg"] = "RS256";
-        key["kid"] = kid_;
+        key["kid"] = entry.kid;
         key["n"] = n;
         key["e"] = e;
         jwks["keys"].append(key);

--- a/libs/oauth2/src/jwk/JwkManager.cc
+++ b/libs/oauth2/src/jwk/JwkManager.cc
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <utility>
 #include <cstring>
 
 namespace fulla::oauth2
@@ -258,15 +259,22 @@ bool JwkManager::loadKeystoreDir(const std::string &dir)
     }
 
     // Collect <kid>.pem candidates (sorted for deterministic load/JWKS order).
-    std::vector<std::string> kids;
+    // PR #176 review NIT: case-insensitive suffix match so a hand-named
+    // <kid>.PEM (Windows habit) is not silently skipped; the kid itself keeps
+    // the filename's case. Convention: lowercase .pem extension.
+    std::vector<std::pair<std::string, std::string>> kids;  // (kid, actual filename)
     for (const auto &item : fs::directory_iterator(fs::path(dir), ec))
     {
         if (!item.is_regular_file())
             continue;
         const std::string filename = item.path().filename().string();
-        if (filename.size() <= 4 || filename.substr(filename.size() - 4) != ".pem")
+        if (filename.size() <= 4)
             continue;
-        kids.push_back(filename.substr(0, filename.size() - 4));
+        std::string suffix = filename.substr(filename.size() - 4);
+        std::transform(suffix.begin(), suffix.end(), suffix.begin(), ::tolower);
+        if (suffix != ".pem")
+            continue;
+        kids.emplace_back(filename.substr(0, filename.size() - 4), filename);
     }
     std::sort(kids.begin(), kids.end());
     if (kids.empty())
@@ -290,18 +298,26 @@ bool JwkManager::loadKeystoreDir(const std::string &dir)
     }
     std::string activeKid;
     std::getline(activeFile, activeKid);
-    // Trim CR/whitespace for hand-edited markers.
-    while (
-      !activeKid.empty() &&
-      (activeKid.back() == '\r' || activeKid.back() == ' ' || activeKid.back() == '\t'))
+    // Trim CR/whitespace on BOTH ends for hand-edited markers (convention:
+    // the kid starts at column 0; leading whitespace would otherwise silently
+    // mismatch -- PR #176 review NIT).
+    const auto isSpace = [](char c) {
+        return c == '\r' || c == ' ' || c == '\t';
+    };
+    while (!activeKid.empty() && isSpace(activeKid.back()))
         activeKid.pop_back();
+    while (!activeKid.empty() && isSpace(activeKid.front()))
+        activeKid.erase(activeKid.begin());
 
     std::vector<KeyEntry> loaded;
-    for (const auto &kid : kids)
+    for (const auto &[kid, actualName] : kids)
     {
         if (kid.empty())
             continue;
-        std::ifstream pemFile(fs::path(dir) / (kid + ".pem"));
+        // Open the ACTUAL filename (the suffix check is case-insensitive, so
+        // it may be .PEM; on a case-sensitive FS opening kid+".pem" would
+        // miss it).
+        std::ifstream pemFile(fs::path(dir) / actualName);
         // PR #176 review MINOR-2: an unopenable .pem is a hard failure, not a
         // skip -- silently dropping the NEW key would no-op rotation step 1
         // ("Publish") and only surface when step 2 flips active_kid.
@@ -311,7 +327,7 @@ bool JwkManager::loadKeystoreDir(const std::string &dir)
                 EVP_PKEY_free(static_cast<EVP_PKEY *>(e.pkey));
             log(
               fulla::common::ports::LogLevel::Error,
-              "JwkManager: keystore " + dir + "/" + kid + ".pem cannot be opened"
+              "JwkManager: keystore " + dir + "/" + actualName + " cannot be opened"
             );
             return false;
         }

--- a/libs/oauth2/test/JwkManagerTest.cc
+++ b/libs/oauth2/test/JwkManagerTest.cc
@@ -18,7 +18,10 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
+#include <utility>
+#include <vector>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <string>
@@ -777,6 +780,208 @@ TEST(JwkManagerTest, Init_DevelopmentEnv_NoKeySource_EphemeralOk)
     JwkManager jwk;
     EXPECT_TRUE(jwk.init(Json::Value(Json::objectValue)));
     EXPECT_TRUE(jwk.isInitialized());
+}
+
+
+// ---------------------------------------------------------------------------
+// #110-B keystore directory: multi-key load, active-kid signing, verify
+// routing across keys, JWKS publication of every key, rotation semantics
+// (retired key no longer verifies), and the structural failure modes.
+// ---------------------------------------------------------------------------
+
+// Build a keystore dir with the given kids (fresh PEMs) + active_kid marker;
+// returns the dir path.
+// Local issuer for the keystore tests (kTestIssuer lives in the nested
+// anonymous namespace above and is not visible here).
+constexpr const char *kStoreIssuer = "https://auth.example.test";
+
+// Write a keystore dir from EXPLICIT (kid, pem) pairs -- the multi-manager
+// rotation tests must share one key material across directories (a fresh
+// generateTestPem() per dir would give same-named kids DIFFERENT keys).
+std::string writeKeystoreDir(
+  const std::vector<std::pair<std::string, std::string>> &entries,
+  const std::string &activeKid
+)
+{
+    namespace fs = std::filesystem;
+    static int counter = 100;
+    const std::string dir = std::string(std::getenv("TEMP") ? std::getenv("TEMP") : "/tmp") +
+                            "/jwkstore_" + std::to_string(++counter);
+    std::error_code ec;
+    fs::remove_all(fs::path(dir), ec);  // stale pems from earlier runs poison the load
+    fs::create_directories(dir);
+    for (const auto &[kid, pem] : entries)
+    {
+        std::ofstream f(fs::path(dir) / (kid + ".pem"), std::ios::binary | std::ios::trunc);
+        f << pem;
+    }
+    std::ofstream active(fs::path(dir) / "active_kid", std::ios::trunc);
+    active << activeKid << '\n';
+    return dir;
+}
+
+std::string makeKeystoreDir(const std::vector<std::string> &kids, const std::string &activeKid)
+{
+    namespace fs = std::filesystem;
+    static int counter = 0;
+    const std::string dir = std::string(std::getenv("TEMP") ? std::getenv("TEMP") : "/tmp") +
+                            "/jwkstore_" + std::to_string(++counter);
+    std::error_code ec;
+    fs::remove_all(fs::path(dir), ec);  // stale pems from earlier runs poison the load
+    fs::create_directories(dir);
+    for (const auto &kid : kids)
+    {
+        std::ofstream f(fs::path(dir) / (kid + ".pem"), std::ios::binary | std::ios::trunc);
+        f << generateTestPem();
+    }
+    std::ofstream active(fs::path(dir) / "active_kid", std::ios::trunc);
+    active << activeKid << "\n";
+    return dir;
+}
+
+Json::Value keystoreConfig(const std::string &dir)
+{
+    Json::Value config(Json::objectValue);
+    config["signing_keystore_dir"] = dir;
+    return config;
+}
+
+TEST(JwkManagerTest, Keystore_LoadsAllKeysAndActiveKid)
+{
+    const std::string dir = makeKeystoreDir({"k2025", "k2026"}, "k2026");
+    JwkManager jwk;
+    EXPECT_TRUE(jwk.init(keystoreConfig(dir)));
+    EXPECT_EQ(jwk.getKeyId(), "k2026");
+
+    Json::Value jwks = jwk.getJwks();
+    ASSERT_TRUE(jwks["keys"].isArray());
+    ASSERT_EQ(jwks["keys"].size(), 2u);
+    // Sorted by filename: k2025 first, k2026 second.
+    EXPECT_EQ(jwks["keys"][0]["kid"].asString(), "k2025");
+    EXPECT_EQ(jwks["keys"][1]["kid"].asString(), "k2026");
+}
+
+TEST(JwkManagerTest, Keystore_SignsWithActiveKidAndVerifies)
+{
+    const std::string dir = makeKeystoreDir({"k2025", "k2026"}, "k2026");
+    JwkManager jwk;
+    ASSERT_TRUE(jwk.init(keystoreConfig(dir)));
+
+    Json::Value claims;
+    claims["iss"] = kStoreIssuer;
+    claims["sub"] = "user-1";
+    claims["exp"] = static_cast<Json::Int64>(std::time(nullptr) + 300);
+    const std::string jwt = jwk.signJwt(claims);
+    ASSERT_FALSE(jwt.empty());
+
+    // Round-trips on the same (both-keys) manager.
+    EXPECT_EQ(
+      jwk.verifyJwt(jwt, kStoreIssuer, std::time(nullptr)),
+      JwkManager::JwtVerificationResult::Ok
+    );
+
+    // Kid routing proves the ACTIVE key signed it: a manager holding ONLY
+    // k2025 rejects the k2026-kid token with KidMismatch (not BadSignature).
+    const std::string dirOldOnly = makeKeystoreDir({"k2025"}, "k2025");
+    JwkManager oldOnly;
+    ASSERT_TRUE(oldOnly.init(keystoreConfig(dirOldOnly)));
+    EXPECT_EQ(
+      oldOnly.verifyJwt(jwt, kStoreIssuer, std::time(nullptr)),
+      JwkManager::JwtVerificationResult::KidMismatch
+    );
+}
+
+TEST(JwkManagerTest, Keystore_RetiredKeyStopsVerifyingAfterRemoval)
+{
+    // ONE key material shared across the three rotation-stage directories.
+    const std::string pemOld = generateTestPem();
+    const std::string pemNew = generateTestPem();
+
+    // Rotation step 1+2 state: both keys loaded, OLD one still signing.
+    const std::string dirBoth =
+      writeKeystoreDir({{"k2025", pemOld}, {"k2026", pemNew}}, "k2025");
+    JwkManager signing;
+    ASSERT_TRUE(signing.init(keystoreConfig(dirBoth)));
+
+    Json::Value claims;
+    claims["iss"] = kStoreIssuer;
+    claims["sub"] = "user-1";
+    claims["exp"] = static_cast<Json::Int64>(std::time(nullptr) + 300);
+    const std::string oldKeyToken = signing.signJwt(claims);  // signed by k2025 (active)
+    ASSERT_FALSE(oldKeyToken.empty());
+
+    // While k2025 is still published, a manager that loaded BOTH keys
+    // verifies it (grace window) -- same key material, active flipped.
+    {
+        const std::string dirVerify =
+          writeKeystoreDir({{"k2025", pemOld}, {"k2026", pemNew}}, "k2026");
+        JwkManager verifier;
+        ASSERT_TRUE(verifier.init(keystoreConfig(dirVerify)));
+        EXPECT_EQ(
+          verifier.verifyJwt(oldKeyToken, kStoreIssuer, std::time(nullptr)),
+          JwkManager::JwtVerificationResult::Ok
+        );
+    }
+
+    // Rotation step 3: k2025 removed from the keystore -> its tokens now
+    // fail with KidMismatch (unknown kid), never BadSignature confusion.
+    {
+        const std::string dirRetired = writeKeystoreDir({{"k2026", pemNew}}, "k2026");
+        JwkManager retired;
+        ASSERT_TRUE(retired.init(keystoreConfig(dirRetired)));
+        EXPECT_EQ(
+          retired.verifyJwt(oldKeyToken, kStoreIssuer, std::time(nullptr)),
+          JwkManager::JwtVerificationResult::KidMismatch
+        );
+    }
+}
+
+TEST(JwkManagerTest, Keystore_ActiveKidMissingFromDir_FailsInit)
+{
+    const std::string dir = makeKeystoreDir({"k2026"}, "k2026");
+    // Marker names a kid with no pem.
+    std::ofstream active(std::filesystem::path(dir) / "active_kid", std::ios::trunc);
+    active << "k9999\n";
+
+    JwkManager jwk;
+    EXPECT_FALSE(jwk.init(keystoreConfig(dir)));
+    EXPECT_FALSE(jwk.isInitialized());
+}
+
+TEST(JwkManagerTest, Keystore_NoActiveKidMarker_FailsInit)
+{
+    namespace fs = std::filesystem;
+    const std::string dir = makeKeystoreDir({"k2026"}, "k2026");
+    fs::remove(fs::path(dir) / "active_kid");
+
+    JwkManager jwk;
+    EXPECT_FALSE(jwk.init(keystoreConfig(dir)));
+}
+
+TEST(JwkManagerTest, Keystore_BrokenDirDoesNotFallBackToEnvKey)
+{
+    // A configured-but-invalid keystore must be a HARD failure (init false),
+    // never a silent fallthrough to FULLA_SIGNING_KEY: half-configured
+    // rotation state signing with an unexpected key is the worst outcome.
+    const std::string dir = makeKeystoreDir({"k2026"}, "k2026");
+    std::filesystem::remove(std::filesystem::path(dir) / "active_kid");
+
+    EnvVarGuard env("FULLA_SIGNING_KEY", generateTestPem());
+    JwkManager jwk;
+    EXPECT_FALSE(jwk.init(keystoreConfig(dir)));
+}
+
+TEST(JwkManagerTest, Keystore_TakesPrecedenceOverEnvKey)
+{
+    // With a VALID keystore configured, the env key is ignored (keystore is
+    // authoritative) -- the active kid proves which source loaded.
+    const std::string dir = makeKeystoreDir({"kk"}, "kk");
+    EnvVarGuard env("FULLA_SIGNING_KEY", generateTestPem());
+    JwkManager jwk;
+    EXPECT_TRUE(jwk.init(keystoreConfig(dir)));
+    EXPECT_EQ(jwk.getKeyId(), "kk");
+    Json::Value jwks = jwk.getJwks();
+    ASSERT_EQ(jwks["keys"].size(), 1u);
 }
 
 }  // namespace

--- a/libs/oauth2/test/JwkManagerTest.cc
+++ b/libs/oauth2/test/JwkManagerTest.cc
@@ -324,13 +324,22 @@ namespace
 {
 const char *kTestIssuer = "https://auth.example.test";
 
-Json::Value validClaims(long long expOffsetSecs)
+// Explicit-base overload (declared first so the 1-arg form can delegate): the exact-boundary expiry test must pin exp to a
+// NOW captured by the test itself -- a fresh std::time(nullptr) here races
+// the wall clock across a second boundary and flips the result to Ok
+// (1-second flake caught by PR #176's CI on a loaded Windows runner).
+Json::Value validClaims(long long expOffsetSecs, long long baseSecs)
 {
     Json::Value claims;
     claims["iss"] = kTestIssuer;
     claims["sub"] = "user-123";
-    claims["exp"] = static_cast<Json::Int64>(std::time(nullptr) + expOffsetSecs);
+    claims["exp"] = static_cast<Json::Int64>(baseSecs + expOffsetSecs);
     return claims;
+}
+
+Json::Value validClaims(long long expOffsetSecs)
+{
+    return validClaims(expOffsetSecs, std::time(nullptr));
 }
 
 // Minimal base64url encoder (test-side only) so adversarial headers (alg=none,
@@ -465,13 +474,15 @@ TEST(JwkManagerTest, VerifyJwt_Expired_IsExpired_IncludingExactBoundary)
     JwkManager jwk;
     ASSERT_TRUE(jwk.init(Json::Value(Json::objectValue)));
     const long long now = std::time(nullptr);
-    const std::string clearlyExpired = jwk.signJwt(validClaims(-10));
+    const std::string clearlyExpired = jwk.signJwt(validClaims(-10, now));
     EXPECT_EQ(
       jwk.verifyJwt(clearlyExpired, kTestIssuer, now),
       JwkManager::JwtVerificationResult::Expired
     );
-    // exp == now is already expired (strict <= rejection).
-    const std::string boundary = jwk.signJwt(validClaims(0));
+    // exp == now is already expired (strict <= rejection). Both the token's
+    // exp and the verification instant pin to the SAME `now` (see the
+    // validClaims overload note).
+    const std::string boundary = jwk.signJwt(validClaims(0, now));
     EXPECT_EQ(
       jwk.verifyJwt(boundary, kTestIssuer, now),
       JwkManager::JwtVerificationResult::Expired

--- a/scripts/backend/test-admin-endpoints.ps1
+++ b/scripts/backend/test-admin-endpoints.ps1
@@ -292,10 +292,14 @@ Test-Endpoint "Test 11: GET /api/admin/oidc/keys" {
     $h = Get-AuthHeaders
     $r = Invoke-RestMethod -Uri "$BaseUrl/api/admin/oidc/keys" -Method Get -Headers $h
     if ($r.status -ne "success") { throw "status != success" }
-    if ($r.kty -ne "RSA") { throw "kty != RSA" }
-    if ($r.alg -ne "RS256") { throw "alg != RS256" }
-    if ($r.key_status -ne "active") { throw "key_status != active" }
-    Write-Host "    kid=$($r.kid), alg=$($r.alg), status=$($r.key_status)"
+    # 110-B: live keystore view -- keys[] entries (kid/kty/alg/status) + active_kid.
+    if ($r.keys.Count -lt 1) { throw "keys[] is empty" }
+    if ($r.keys[0].kty -ne "RSA") { throw "keys[0].kty != RSA" }
+    if ($r.keys[0].alg -ne "RS256") { throw "keys[0].alg != RS256" }
+    $active = @($r.keys | Where-Object { $_.status -eq "active" })
+    if ($active.Count -ne 1) { throw "expected exactly one active key, got $($active.Count)" }
+    if ($active[0].kid -ne $r.active_kid) { throw "active entry kid != active_kid" }
+    Write-Host "    keys=$($r.keys.Count), active_kid=$($r.active_kid)"
 }
 
 Test-Endpoint "Test 11b: DELETE /api/admin/tokens/:tokenPrefix - Single Revoke" {

--- a/scripts/backend/test-admin-endpoints.sh
+++ b/scripts/backend/test-admin-endpoints.sh
@@ -240,8 +240,13 @@ test_11() {
     local r
     r=$(curl -s -H "$(auth_header)" "$BASE_URL/api/admin/oidc/keys")
     assert_json_field "$r" "status" "success" || return 1
-    assert_json_field "$r" "kty" "RSA" || return 1
-    assert_json_field "$r" "alg" "RS256" || return 1
+    # #110-B: live keystore view -- keys[] entries (kid/kty/alg/status) +
+    # active_kid; the entry flagged "active" is by construction active_kid.
+    assert_json_field "$r" "keys[0].kty" "RSA" || return 1
+    assert_json_field "$r" "keys[0].alg" "RS256" || return 1
+    assert_json_field "$r" "keys[0].status" "active" || return 1
+    assert_json_exists "$r" "active_kid" || return 1
+    assert_json_exists "$r" "keys[0].kid" || return 1
 }
 run_test "Test 11: GET /api/admin/oidc/keys" test_11
 

--- a/scripts/backend/test-admin-endpoints.sh
+++ b/scripts/backend/test-admin-endpoints.sh
@@ -240,13 +240,19 @@ test_11() {
     local r
     r=$(curl -s -H "$(auth_header)" "$BASE_URL/api/admin/oidc/keys")
     assert_json_field "$r" "status" "success" || return 1
-    # #110-B: live keystore view -- keys[] entries (kid/kty/alg/status) +
-    # active_kid; the entry flagged "active" is by construction active_kid.
+    # #110-B: live keystore view. Rotation-proof assertions: exactly one
+    # entry is "active" and it carries active_kid -- keys[0] is merely the
+    # filename-sorted first key and may be a "published" (retiring) one.
     assert_json_field "$r" "keys[0].kty" "RSA" || return 1
     assert_json_field "$r" "keys[0].alg" "RS256" || return 1
-    assert_json_field "$r" "keys[0].status" "active" || return 1
-    assert_json_exists "$r" "active_kid" || return 1
-    assert_json_exists "$r" "keys[0].kid" || return 1
+    local active_kid active_count
+    active_kid=$(echo "$r" | jq -r '.active_kid')
+    active_count=$(echo "$r" | jq -r '[.keys[] | select(.status == "active")] | length')
+    if [ "$active_count" != "1" ]; then
+        echo -e "    ${C_RED}[FAIL] expected exactly 1 active key, got $active_count${C_NC}"
+        return 1
+    fi
+    assert_json_field "$r" "keys[] | select(.status == \"active\") | .kid" "$active_kid" || return 1
 }
 run_test "Test 11: GET /api/admin/oidc/keys" test_11
 

--- a/scripts/measure_coverage.py
+++ b/scripts/measure_coverage.py
@@ -6,9 +6,33 @@ Per gcc docs: `gcov -j <src>.gcda` writes `<src>.gcov.json.gz` next to the
 have {count, unexecuted_block}. A line is "covered" when count > 0.
 
 Usage: find <build>/libs -path "*/src/*" -name "*.gcov.json.gz" | \
-       python3 scripts/measure_coverage.py
+       python3 scripts/measure_coverage.py [--json] [--ratchet BASELINE.json]
+
+Output modes:
+  (default)  human-readable per-library / per-file text report
+  --json     machine-readable per-library JSON instead of the text report:
+             {"libs": {"<name>": {"covered": C, "total": T, "pct": P}}, ...}
+  --ratchet PATH
+             no-decrease gate against a committed baseline JSON (issue #105,
+             decision B): FAIL (exit 1) when a library's coverage drops more
+             than RATCHET_TOLERANCE_PP below its baseline. Anti-flake rules:
+               * compare trunc-to-0.1pp(current) vs baseline - tolerance;
+               * libraries with fewer than MIN_LINES instrumented lines are
+                 exempt (timing-dependent tests flap a few lines, which a
+                 0.5pp band absorbs on 1k+ line libs but not on tiny ones);
+               * a baseline lib missing from the current run FAILS (lost
+                 instrumentation is never a pass);
+               * a NEW lib (not in baseline) passes (baseline catches it on
+                 the next deliberate --update run).
+             When the baseline file does not exist, the gate runs in SEED
+             mode: it prints the baseline JSON to stdout and exits 0, so the
+             numbers can be copied into tools/coverage/ratchet-baseline.json
+             and committed.
+
+Re-baselining (coverage improvements) is a deliberate PR that edits the
+baseline JSON; there is no automatic upward ratchet.
 """
-import sys, json, gzip, os, re
+import sys, json, gzip, os, re, argparse
 from collections import defaultdict
 
 cov = defaultdict(int)
@@ -18,6 +42,10 @@ seen = set()
 
 SRC_RE = re.compile(r".*/(libs/[^/]+/src/.+\.cc)$")
 LIB_RE = re.compile(r"libs/([^/]+)/")
+
+# Anti-flake constants (see module docstring).
+RATCHET_TOLERANCE_PP = 0.5
+MIN_LINES = 200
 
 for line in sys.stdin:
     p = line.strip().rstrip("\0")
@@ -47,24 +75,110 @@ for line in sys.stdin:
         tot[lib] += total
         perfile[rel] = (covered, total)
 
-print("=== per-library line coverage (libs/<name>/src/*.cc, models excluded) ===")
-for lib in sorted(tot):
-    print(f"  {lib:22} {cov[lib]:6d} / {tot[lib]:<6d}  {cov[lib]*100.0/tot[lib]:5.1f}%")
-tc = sum(cov.values())
-tt = sum(tot.values())
-if tt == 0:
-    print("\n  OVERALL libs/: no coverage data (0 instrumented lines found)")
-else:
-    print(f"\n  {'OVERALL libs/':22} {tc:6d} / {tt:<6d}  {tc*100.0/tt:5.1f}%")
 
-print("\n=== admin service per-file (was 0% in baseline) ===")
-for rel in sorted(perfile):
-    if "/admin/" in rel:
-        c, t = perfile[rel]
-        print(f"  {os.path.basename(rel):32} {c:4d} / {t:<4d}  {c*100.0/t:5.1f}%")
+def lib_pct(lib):
+    return round(cov[lib] * 100.0 / tot[lib], 1)
 
-print("\n=== controllers per-file ===")
-for rel in sorted(perfile):
-    if "/controllers/" in rel:
-        c, t = perfile[rel]
-        print(f"  {os.path.basename(rel):36} {c:4d} / {t:<4d}  {c*100.0/t:5.1f}%")
+
+def text_report():
+    print("=== per-library line coverage (libs/<name>/src/*.cc, models excluded) ===")
+    for lib in sorted(tot):
+        print(f"  {lib:22} {cov[lib]:6d} / {tot[lib]:<6d}  {cov[lib]*100.0/tot[lib]:5.1f}%")
+    tc = sum(cov.values())
+    tt = sum(tot.values())
+    if tt == 0:
+        print("\n  OVERALL libs/: no coverage data (0 instrumented lines found)")
+    else:
+        print(f"\n  {'OVERALL libs/':22} {tc:6d} / {tt:<6d}  {tc*100.0/tt:5.1f}%")
+
+    print("\n=== admin service per-file (was 0% in baseline) ===")
+    for rel in sorted(perfile):
+        if "/admin/" in rel:
+            c, t = perfile[rel]
+            print(f"  {os.path.basename(rel):32} {c:4d} / {t:<4d}  {c*100.0/t:5.1f}%")
+
+    print("\n=== controllers per-file ===")
+    for rel in sorted(perfile):
+        if "/controllers/" in rel:
+            c, t = perfile[rel]
+            print(f"  {os.path.basename(rel):36} {c:4d} / {t:<4d}  {c*100.0/t:5.1f}%")
+
+
+def baseline_json():
+    return {
+        "libs": {
+            lib: {"covered": cov[lib], "total": tot[lib], "pct": lib_pct(lib)}
+            for lib in sorted(tot)
+        }
+    }
+
+
+def ratchet_gate(path):
+    if not os.path.exists(path):
+        print(f"[ratchet] SEED MODE: baseline {path} not found.")
+        print("[ratchet] Commit the following as the baseline (no gate this run):")
+        print(json.dumps(baseline_json(), indent=2))
+        return 0
+    with open(path, "r", encoding="utf-8") as fh:
+        base = json.load(fh).get("libs", {})
+    violations = []
+    notes = []
+    for lib, entry in sorted(base.items()):
+        if lib not in tot:
+            violations.append(
+                f"[ratchet] FAIL {lib}: present in baseline but NO coverage data "
+                f"in this run (lost instrumentation?)"
+            )
+            continue
+        base_pct = float(entry["pct"])
+        if tot[lib] < MIN_LINES:
+            notes.append(
+                f"[ratchet] exempt {lib}: {tot[lib]} instrumented lines < {MIN_LINES}"
+            )
+            continue
+        # trunc-to-0.1pp of the current run vs baseline minus tolerance
+        current = int(lib_pct(lib) * 10) / 10.0
+        floor = round(base_pct - RATCHET_TOLERANCE_PP, 1)
+        if current < floor:
+            violations.append(
+                f"[ratchet] FAIL {lib}: {current:.1f}% < baseline {base_pct:.1f}% "
+                f"- {RATCHET_TOLERANCE_PP:.1f}pp tolerance"
+            )
+    for lib in sorted(tot):
+        if lib not in base:
+            notes.append(f"[ratchet] new lib {lib}: not in baseline (passes this run)")
+    for n in notes:
+        print(n)
+    if violations:
+        for v in violations:
+            print(v)
+        print(
+            "[ratchet] coverage regressed — restore the drop or re-baseline "
+            "deliberately (edit the JSON in a reviewed PR)"
+        )
+        return 1
+    print(f"[ratchet] OK: no library dropped more than {RATCHET_TOLERANCE_PP}pp below baseline")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("--json", action="store_true", help="emit per-lib JSON instead of text")
+    ap.add_argument(
+        "--ratchet",
+        metavar="BASELINE.json",
+        default=None,
+        help="no-decrease gate against a committed baseline (seed mode if absent)",
+    )
+    args = ap.parse_args()
+    if args.json:
+        print(json.dumps(baseline_json(), indent=2))
+        return 0
+    text_report()
+    if args.ratchet:
+        return ratchet_gate(args.ratchet)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/measure_coverage.py
+++ b/scripts/measure_coverage.py
@@ -17,11 +17,16 @@ Output modes:
              decision B): FAIL (exit 1) when a library's coverage drops more
              than RATCHET_TOLERANCE_PP below its baseline. Anti-flake rules:
                * compare trunc-to-0.1pp(current) vs baseline - tolerance;
-               * libraries with fewer than MIN_LINES instrumented lines are
-                 exempt (timing-dependent tests flap a few lines, which a
-                 0.5pp band absorbs on 1k+ line libs but not on tiny ones);
-               * a baseline lib missing from the current run FAILS (lost
-                 instrumentation is never a pass);
+               * exemption is keyed on the BASELINE total: only libraries
+                 with fewer than MIN_LINES instrumented lines IN THE
+                 BASELINE are exempt. Keying on the current run's total
+                 would let a data collapse (test crash / partial
+                 instrumentation) shrink a big library below the threshold
+                 and slip through the exemption (PR #176 review);
+               * a baseline lib missing from the current run, or whose
+                 current total collapses below MIN_LINES while its baseline
+                 total was >= MIN_LINES, FAILS (lost instrumentation is
+                 never a pass);
                * a NEW lib (not in baseline) passes (baseline catches it on
                  the next deliberate --update run).
              When the baseline file does not exist, the gate runs in SEED
@@ -131,9 +136,17 @@ def ratchet_gate(path):
             )
             continue
         base_pct = float(entry["pct"])
-        if tot[lib] < MIN_LINES:
+        base_total = int(entry.get("total", 0))
+        if base_total < MIN_LINES:
             notes.append(
-                f"[ratchet] exempt {lib}: {tot[lib]} instrumented lines < {MIN_LINES}"
+                f"[ratchet] exempt {lib}: baseline total {base_total} lines < {MIN_LINES}"
+            )
+            continue
+        if tot[lib] < MIN_LINES:
+            violations.append(
+                f"[ratchet] FAIL {lib}: instrumented lines collapsed from baseline "
+                f"{base_total} to {tot[lib]} (< {MIN_LINES}) -- partial instrumentation "
+                f"or a crashed test run, not a coverage improvement"
             )
             continue
         # trunc-to-0.1pp of the current run vs baseline minus tolerance

--- a/tests/integration/oidc/OidcBatch2FeatureHttpTest.cc
+++ b/tests/integration/oidc/OidcBatch2FeatureHttpTest.cc
@@ -560,3 +560,59 @@ DROGON_TEST(Integration_P1_OidcBatch2_BackchannelLogout_DualSubjectForm_CoversBo
     REQUIRE(done2.get_future().wait_for(std::chrono::seconds(10)) == std::future_status::ready);
     CHECK(http->postFormCalls.size() == 2);
 }
+
+
+// ---------------------------------------------------------------------------
+// #88-3 (decision A, RP-Initiated Logout 1.0 §2.1): with no id_token_hint,
+// the client_id parameter identifies the RP. A post_logout_redirect_uri
+// REGISTERED for that client is honored (302 + state echo); an unregistered
+// one still 400s; neither hint nor client_id still 400s (unchanged).
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P1_OidcBatch2_EndSession_ClientIdNoHint_RegisteredUri302)
+{
+    OIDC_BATCH2_SKIP_GUARD;
+
+    auto resp = sendGet(
+      "/oauth2/end_session?client_id=" + std::string(kAdminClientId) +
+        "&post_logout_redirect_uri=" + std::string(kAdminRedirectUri) + "&state=st883"
+    );
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k302Found));
+    auto location = resp->getHeader("location");
+    CHECK(location.find(kAdminRedirectUri) == 0);
+    CHECK(location.find("state=st883") != std::string::npos);
+}
+
+DROGON_TEST(Integration_P1_OidcBatch2_EndSession_ClientIdNoHint_UnregisteredUri400)
+{
+    OIDC_BATCH2_SKIP_GUARD;
+
+    auto resp = sendGet(
+      "/oauth2/end_session?client_id=" + std::string(kAdminClientId) +
+        "&post_logout_redirect_uri=https://attacker.example.net/logout"
+    );
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k400BadRequest));
+    Json::Value body;
+    REQUIRE(parseJsonBody(resp, body));
+    CHECK(
+      body["error"]["code"].asString() == "VALIDATION_REDIRECT_URI_NOT_REGISTERED"
+    );
+}
+
+DROGON_TEST(Integration_P1_OidcBatch2_EndSession_NoHintNoClientId_Still400)
+{
+    OIDC_BATCH2_SKIP_GUARD;
+
+    // Unchanged behavior: neither identification parameter -> the #88
+    // envelope rejection (this is the RedirectUriWithoutHint case with an
+    // explicit empty client_id to pin the boundary).
+    auto resp = sendGet(
+      "/oauth2/end_session?client_id=&post_logout_redirect_uri=http://127.0.0.1:5173/"
+    );
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k400BadRequest));
+    Json::Value body;
+    REQUIRE(parseJsonBody(resp, body));
+    CHECK(body["error"]["code"].asString() == "AUTH_INVALID_ID_TOKEN_HINT");
+}

--- a/tests/unit/config/ConfigManagerTest.cc
+++ b/tests/unit/config/ConfigManagerTest.cc
@@ -251,6 +251,23 @@ DROGON_TEST(Unit_P0_ConfigManager_Production_ConfigOidcKeyPath_Passes)
     CHECK(fulla::common::config::ConfigManager::validate(config, errMsg) == true);
 }
 
+// #110-B (PR #176 review MINOR): the keystore directory is a complete key
+// source on its own -- rotation deployments use nothing else, so the
+// production gate must accept it (a misconfigured keystore then hard-fails
+// later in JwkManager::init with the directory-specific error, which is the
+// intended diagnostics point).
+DROGON_TEST(Unit_P0_ConfigManager_Production_ConfigOidcKeystoreDir_Passes)
+{
+    ProductionEnvGuard env;
+    Json::Value config = productionBaseConfig();
+    Json::Value plugin;
+    plugin["name"] = "OAuth2Plugin";
+    plugin["config"]["oidc"]["signing_keystore_dir"] = "/etc/fulla/keystore";
+    config["plugins"].append(plugin);
+    std::string errMsg;
+    CHECK(fulla::common::config::ConfigManager::validate(config, errMsg) == true);
+}
+
 DROGON_TEST(Unit_P0_ConfigManager_Production_WeakConfidentialClientSecret_Fails)
 {
     ProductionEnvGuard env;

--- a/tools/api-diff/api-baseline.txt
+++ b/tools/api-diff/api-baseline.txt
@@ -1050,6 +1050,7 @@ const std::string &scopeId
 #pragma once
 #include <drogon/HttpRequest.h>
 #include <drogon/HttpResponse.h>
+#include <fulla/oauth2/jwk/JwkManager.h>
 #include <functional>
 #include <memory>
 #include <string>
@@ -1068,7 +1069,10 @@ const std::string &tokenPrefix
 );
 static void revokeTokensByClient(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
 static void revokeTokensByUser(const ::drogon::HttpRequestPtr &req, ResponseCallback cb);
-static void getOidcKeys(ResponseCallback cb);
+static void getOidcKeys(
+ResponseCallback cb,
+const std::shared_ptr<const fulla::oauth2::JwkManager> &jwkManager
+);
 };
 }
 === libs/drogon/include/fulla/drogon/admin/UserAdminService.h
@@ -4806,6 +4810,7 @@ const std::function<bool(const std::string &)> &scopeRequiresAdmin
 #include <json/json.h>
 #include <memory>
 #include <optional>
+#include <vector>
 namespace fulla::oauth2
 {
 class JwkManager
@@ -4849,16 +4854,27 @@ const std::string &getKeyId() const
 bool isInitialized() const
 ;
 private:
-void *rsaKey_ = nullptr;
-std::string kid_;
+struct KeyEntry
+{
+std::string kid;
+void *pkey = nullptr;
+};
+std::vector<KeyEntry> keys_;
+std::string activeKid_;
 bool initialized_ = false;
 fulla::common::ports::ILogger *logger_ = nullptr;
-bool generateEphemeralKey();
-bool loadFromPem(const std::string &pemData);
+const KeyEntry *findEntry(const std::string &kid) const;
+const KeyEntry *activeEntry() const;
+bool generateEphemeralKey(KeyEntry &entry);
+bool loadPemInto(KeyEntry &entry, const std::string &pemData);
+bool loadKeystoreDir(const std::string &dir);
 static std::string base64UrlEncode(const unsigned char *data, size_t len);
 static std::string base64UrlEncode(const std::string &data);
 static bool base64UrlDecode(const std::string &input, std::string &output);
-bool getPublicKeyComponents(std::string &n, std::string &e) const;
+bool getPublicKeyComponents(const KeyEntry &entry, std::string &n, std::string &e) const;
+static bool verifyRs256Signature(
+const void *pkey, const std::string &signingInput, const std::string &signature
+);
 JwtVerificationResult verifyCore(
 const std::string &jwt,
 const std::string &expectedIssuer,

--- a/tools/coverage/ratchet-baseline.json
+++ b/tools/coverage/ratchet-baseline.json
@@ -1,0 +1,39 @@
+{
+  "libs": {
+    "common": {
+      "covered": 364,
+      "total": 490,
+      "pct": 74.3
+    },
+    "drogon": {
+      "covered": 6967,
+      "total": 12056,
+      "pct": 57.8
+    },
+    "identity": {
+      "covered": 1294,
+      "total": 1485,
+      "pct": 87.1
+    },
+    "oauth2": {
+      "covered": 936,
+      "total": 1054,
+      "pct": 88.8
+    },
+    "storage-memory": {
+      "covered": 421,
+      "total": 434,
+      "pct": 97.0
+    },
+    "storage-postgres": {
+      "covered": 1047,
+      "total": 1936,
+      "pct": 54.1
+    },
+    "storage-redis": {
+      "covered": 705,
+      "total": 1134,
+      "pct": 62.2
+    }
+  }
+}


### PR DESCRIPTION
Implements the three user-ratified decision items (A/B/B). Recommendations were re-verified by an adversarial review on current master before implementation — all three confirmed; #110-C (defer) noted as degenerate since key rotation is the last remaining IAM-M1 item.

## #88-3 — end_session client_id identification (decision A)
RP-Initiated Logout 1.0 §2.1 allows the RP to identify itself via `client_id` when `id_token_hint` is absent. The aud-candidate chain now seeds from `client_id`, so the post_logout_redirect_uri must still be registered **for that client** (same `validateRedirectUri` gate — no open redirect; the forced-logout surface is unchanged since a parameterless end_session already terminated sessions). Neither hint nor client_id → the existing 400 envelope.

- 3 new integration cases (registered→302, unregistered→400, neither→400) + 2 regressions green
- openapi: client_id query param + description updates; SDKs regenerated

## #105 — local coverage ratchet gate (decision B)
`measure_coverage.py` gains `--json` and `--ratchet BASELINE`; `coverage.yml` gates the existing gcov job:

- fail when a non-exempt library drops **>0.5pp** below baseline (trunc-to-0.1pp current)
- libs with **<200 instrumented lines exempt** (anti-flake)
- baseline lib missing from the run **fails** (lost instrumentation ≠ pass)
- new libs pass until the next deliberate re-baseline; absent baseline = **seed mode** (prints JSON, passes)
- zero external services — consistent with the api-diff/oasdiff/spec-governance self-contained gate style

The committed baseline lands in a follow-up commit seeded from this PR's own CI run.

## #110 — signing-key rotation keystore (decision B)
`JwkManager` becomes a multi-key store:

- `oidc.signing_keystore_dir`: `<kid>.pem` files + `active_kid` marker file; filename = kid
- signing uses the active kid; **verification routes on the JWT header kid across all loaded keys** (absent kid tries all, RFC 7515 §4.1.4); **JWKS publishes every key**
- keystore takes precedence over single-key env/path sources; a configured-but-broken directory is a **hard startup failure** (never a silent different-key fallback)
- rotation = documented 3-restart procedure (publish → switch → retire after max token TTL) — configuration-guide §9 rewritten from the F-029 to-do into the runbook
- `GET /api/admin/oidc/keys` reports the live keystore (keys[] + active/published status + active_kid) instead of the hardcoded stub; endpoint scripts (sh/ps1) assert the new shape; ConfigManager's production key check accepts the keystore
- 7 new keystore unit tests (shared-PEM rotation semantics, precedence, all structural failure modes) — JwkManagerTest 44/44

## Verification
- full_test 8/8 (incl. EndpointTests_OutOfProcess after the script update)
- all 8 static gates green (arch-guard / migration-check / api-diff --force: private-member + internal-static signature changes with no released consumer / naming / macro-bool / parity / openapi validate / spec-governance)
- oasdiff: clean (client_id param is additive-optional)
- JwkManagerTest 44/44; end_session suite green

Fixes #88
Fixes #105
Fixes #110