### PR TITLE
fix: browser-e2e 2026-09-08 bug tranche — device approval crash, readiness hang, OAuth flow resume, blank-username deletion + 5 more

### DIFF
--- a/.claude/skills/orm-gen/SKILL.md
+++ b/.claude/skills/orm-gen/SKILL.md
@@ -113,8 +113,8 @@ echo "✅ Models backed up to $backup_dir"
 
 ```powershell
 # Windows PowerShell
-# 进入 ORM 模型源码目录（.cc 所在）
-cd d:\work\development\Repos\cpp\projects\fulla\libs\storage-postgres\src\models
+# 进入 ORM 模型源码目录（.cc 所在，从仓库根目录出发）
+cd libs\storage-postgres\src\models
 
 # 创建 models 目录（如果不存在）
 if (!(Test-Path "models")) {

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -20,7 +20,7 @@
                 "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING"
             ],
             "windowsSdkVersion": "10.0.26100.0",
-            "compilerPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe",
+            "compilerPath": "${env:ProgramFiles}/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe",
             "cStandard": "c17",
             "cppStandard": "c++17",
             "intelliSenseMode": "windows-msvc-x64",

--- a/apps/server/config/config.dev.json
+++ b/apps/server/config/config.dev.json
@@ -35,7 +35,7 @@
             "db": 0,
             "is_fast": false,
             "number_of_connections": 5,
-            "timeout": -1.0
+            "timeout": 2.0
         }
     ],
     "app": {
@@ -167,11 +167,18 @@
                         "client_type": "PUBLIC",
                         "secret": "123456",
                         "redirect_uri": "http://127.0.0.1:5173/callback,http://localhost:5173/callback,http://127.0.0.1:8080/callback,http://localhost:8080/callback",
-                        "allowed_scopes": ["openid", "profile", "email"]
+                        "allowed_scopes": [
+                            "openid",
+                            "profile",
+                            "email"
+                        ]
                     }
                 },
                 "admin_users": {
-                    "admin": ["admin", "user"]
+                    "admin": [
+                        "admin",
+                        "user"
+                    ]
                 },
                 "tokens": {
                     "auth_code_ttl": 600,
@@ -225,11 +232,13 @@
             "register_path": "/register"
         },
         "webauthn": {
-        "rp_id": "localhost",
-        "rp_name": "OAuth2 Server",
-        "rp_origins": ["http://localhost:5173"]
-    },
-    "external_auth": {
+            "rp_id": "localhost",
+            "rp_name": "OAuth2 Server",
+            "rp_origins": [
+                "http://localhost:5173"
+            ]
+        },
+        "external_auth": {
             "github": {
                 "client_id": "YOUR_GITHUB_CLIENT_ID",
                 "client_secret": "YOUR_GITHUB_CLIENT_SECRET"

--- a/apps/server/config/config.dev.json
+++ b/apps/server/config/config.dev.json
@@ -166,7 +166,7 @@
                     "vue-client": {
                         "client_type": "PUBLIC",
                         "secret": "123456",
-                        "redirect_uri": "http://127.0.0.1:5173/callback,http://127.0.0.1:8080/callback",
+                        "redirect_uri": "http://127.0.0.1:5173/callback,http://localhost:5173/callback,http://127.0.0.1:8080/callback,http://localhost:8080/callback",
                         "allowed_scopes": ["openid", "profile", "email"]
                     }
                 },

--- a/apps/server/config/config.json
+++ b/apps/server/config/config.json
@@ -35,7 +35,7 @@
             "db": 0,
             "is_fast": false,
             "number_of_connections": 10,
-            "timeout": -1.0
+            "timeout": 2.0
         }
     ],
     "app": {
@@ -162,11 +162,18 @@
                         "client_type": "PUBLIC",
                         "secret": "123456",
                         "redirect_uri": "http://127.0.0.1:5173/callback,http://localhost:5173/callback,http://127.0.0.1:8080/callback,http://localhost:8080/callback",
-                        "allowed_scopes": ["openid", "profile", "email"]
+                        "allowed_scopes": [
+                            "openid",
+                            "profile",
+                            "email"
+                        ]
                     }
                 },
                 "admin_users": {
-                    "admin": ["admin", "user"]
+                    "admin": [
+                        "admin",
+                        "user"
+                    ]
                 },
                 "tokens": {
                     "auth_code_ttl": 600,
@@ -219,12 +226,14 @@
             "url": "http://localhost:5173",
             "register_path": "/register"
         },
-    "webauthn": {
-        "rp_id": "localhost",
-        "rp_name": "OAuth2 Server",
-        "rp_origins": ["http://localhost:5173"]
-    },
-    "external_auth": {
+        "webauthn": {
+            "rp_id": "localhost",
+            "rp_name": "OAuth2 Server",
+            "rp_origins": [
+                "http://localhost:5173"
+            ]
+        },
+        "external_auth": {
             "github": {
                 "client_id": "",
                 "client_secret": ""

--- a/apps/server/config/config.json
+++ b/apps/server/config/config.json
@@ -161,7 +161,7 @@
                     "vue-client": {
                         "client_type": "PUBLIC",
                         "secret": "123456",
-                        "redirect_uri": "http://127.0.0.1:5173/callback,http://127.0.0.1:8080/callback",
+                        "redirect_uri": "http://127.0.0.1:5173/callback,http://localhost:5173/callback,http://127.0.0.1:8080/callback,http://localhost:8080/callback",
                         "allowed_scopes": ["openid", "profile", "email"]
                     }
                 },

--- a/apps/server/config/config.prod.json
+++ b/apps/server/config/config.prod.json
@@ -207,9 +207,11 @@
                     }
                 },
                 "clients": {
+                    // PUBLIC client authenticates with authorization code + PKCE and carries no
+                    // secret; ConfigManager's production non-default-secret check skips PUBLIC
+                    // clients for exactly this reason.
                     "vue-client": {
                         "client_type": "PUBLIC",
-                        "secret": "123456",
                         "redirect_uri": "http://127.0.0.1:5173/callback,http://127.0.0.1:8080/callback",
                         "allowed_scopes": ["openid", "profile", "email"]
                     }

--- a/apps/server/migrations/V030__backfill_generated_usernames.sql
+++ b/apps/server/migrations/V030__backfill_generated_usernames.sql
@@ -1,0 +1,26 @@
+-- Migration: V030__backfill_generated_usernames
+-- Created: 2026-09-09
+-- Purpose: U-2 (browser-e2e 2026-09-08) — the registration form promised
+--          "leave the username blank and one is generated", but the server
+--          stored NULL instead. Every such account read back username=''
+--          (Drogon maps NULL columns to the type default), which defeated
+--          the account-center Danger Zone confirm guard ('' === '' with
+--          zero typing) and rendered the "Type <username> to confirm" hint
+--          blank. Registration now generates user_<8 lowercase hex> at
+--          insert time (identity AuthService + legacy fallback, both with
+--          a collision retry); this migration backfills the same shape for
+--          existing NULL rows so they get the same protection and a real
+--          display name. md5(id || random()) gives every row a distinct
+--          input; collision with a pre-existing username would fail the
+--          unique constraint loudly (migration transaction aborts) rather
+--          than silently leaving NULLs.
+
+-- === UP ===
+UPDATE users
+SET username = 'user_' || substr(md5(id::text || random()::text), 1, 8)
+WHERE username IS NULL;
+
+-- === DOWN ===
+-- Rollback intentionally restores nothing: NULL usernames are the defective
+-- state this migration eliminates, and generated names may since have been
+-- used as login identifiers.

--- a/apps/server/migrations/V031__normalize_user_emails.sql
+++ b/apps/server/migrations/V031__normalize_user_emails.sql
@@ -1,0 +1,24 @@
+-- Migration: V031__normalize_user_emails
+-- Created: 2026-09-09
+-- Purpose: PR #180 review M7 — the legacy registration path stores the
+--          canonical (lowercased) email and the legacy login normalizes the
+--          identifier before lookup, but the wired identity path did NEITHER,
+--          so mixed-case registrants were stored verbatim and only matched
+--          exact-case input. Registration and login now canonicalize on both
+--          paths; this migration lowercases existing rows so every stored
+--          email agrees with the canonical form. Idempotent: the WHERE clause
+--          leaves already-lowercase rows untouched.
+
+-- === UP ===
+-- A case-variant pair (Alice@x.com + alice@x.com) can coexist under the
+-- case-sensitive unique index (V019); collapsing them violates
+-- idx_users_email_unique and aborts the migration transaction loudly —
+-- that is deliberate: such rows need manual dedup, not a silent merge.
+UPDATE users
+SET email = lower(email)
+WHERE email <> lower(email);
+
+-- === DOWN ===
+-- Rollback intentionally restores nothing: the original mixed-case spellings
+-- are unrecoverable after normalization, and re-widening the stored forms
+-- would reintroduce the lookup mismatch this migration removes.

--- a/apps/server/seed/dev_vue_client.sql
+++ b/apps/server/seed/dev_vue_client.sql
@@ -1,6 +1,11 @@
 -- DEV ONLY: Sample OAuth2 client for Vue frontend development
 -- DO NOT use in production!
 
+-- U-6 (browser-e2e 2026-09-08): both loopback HOST spellings are registered.
+-- The user portal's .env uses VITE_REDIRECT_URI=http://localhost:5173/callback
+-- while this seed used to register only 127.0.0.1 — the MFA verify leg
+-- strictly validates redirect_uri, so the drift locked every MFA-enabled
+-- user out with a misleading "incorrect username or password".
 INSERT INTO oauth2_clients (client_id, client_type, client_secret, salt, name, redirect_uris, allowed_grant_types, token_endpoint_auth_method)
 VALUES (
     'vue-client',
@@ -8,7 +13,7 @@ VALUES (
     '42a121b66fb9f1d4f73125788f42eb6799110c6aeae5a9a12a2fed5307a0088d',
     'random_salt',
     'Vue Front-end Client',
-    'http://127.0.0.1:5173/callback,http://127.0.0.1:8080/callback',
+    'http://127.0.0.1:5173/callback,http://localhost:5173/callback,http://127.0.0.1:8080/callback,http://localhost:8080/callback',
     'authorization_code,refresh_token',
     'none'
 )

--- a/benchmarks/competitors/results/GC_JITTER_ROOT_CAUSE_ANALYSIS.md
+++ b/benchmarks/competitors/results/GC_JITTER_ROOT_CAUSE_ANALYSIS.md
@@ -99,7 +99,7 @@ bash run-gc-jitter.sh \
 
 ### 4.2 WSL2 配置调优
 
-`C:\Users\vilas\.wslconfig` 新增：
+`%USERPROFILE%\.wslconfig` 新增：
 
 ```ini
 autoMemoryReclaim=disabled  # 阻止周期性内存回收停顿

--- a/frontends/admin/src/pages/dashboard/DashboardPage.vue
+++ b/frontends/admin/src/pages/dashboard/DashboardPage.vue
@@ -23,10 +23,11 @@ const errorText = computed(() => {
 
 // GET /health/ready value domains (HealthController): status ∈ {ok, degraded,
 // unhealthy}, database ∈ {connected, not_configured, disconnected,
-// unavailable}, redis ∈ {connected, not_configured, disconnected}.
+// unavailable}, redis ∈ {connected, not_configured, disconnected, timeout}.
 // Gap-fix E3: the old template hardcoded green dots and a 'Connected'
 // fallback, rendering disconnected/degraded components as healthy.
 // not_configured is a healthy state (the backend reports status=ok with it).
+// 'timeout' is the backend's 2s Redis-ping guard (A-1) — degraded, red dot.
 function componentDotClass(value: string | undefined): string {
   if (!value || value === 'connected' || value === 'not_configured') return 'bg-success-500'
   return 'bg-error-500'
@@ -40,20 +41,33 @@ const overall = computed(() => {
 })
 
 onMounted(async () => {
-  try {
-    const [healthResp, statsResp] = await Promise.all([
-      axios.get('/health/ready'),
-      axios.get('/api/admin/dashboard/stats'),
-    ])
-    health.value = healthResp.data
-    stats.value = statsResp.data
-  } catch (e) {
-    const normalized = normalizeError(e)
-    errorMessage.value = normalized
-    health.value = { status: 'error' }
-  } finally {
-    loading.value = false
+  // A-1 (browser-e2e 2026-09-08): /health/ready can hang when Redis is
+  // configured but unreachable (backend now self-times-out at 2s, but the
+  // frontend must not chain the two requests either). allSettled + explicit
+  // timeouts let the stats cards render even when readiness never answers;
+  // health failure only degrades the health card, not the whole dashboard.
+  const [healthResult, statsResult] = await Promise.allSettled([
+    // Accept the probe's own 503 (degraded) body so the health card can show
+    // WHICH component is down; only transport failures/timeouts reject.
+    axios.get('/health/ready', {
+      timeout: 8000,
+      validateStatus: (s: number) => (s >= 200 && s < 300) || s === 503,
+    }),
+    axios.get('/api/admin/dashboard/stats', { timeout: 8000 }),
+  ])
+  if (statsResult.status === 'fulfilled') {
+    stats.value = statsResult.value.data
+  } else {
+    errorMessage.value = normalizeError(statsResult.reason)
   }
+  if (healthResult.status === 'fulfilled') {
+    health.value = healthResult.value.data
+  } else {
+    // Readiness did not answer in time: show the health card in error state
+    // without a page-level banner — stats (if fulfilled) are still accurate.
+    health.value = { status: 'error' }
+  }
+  loading.value = false
 })
 </script>
 

--- a/frontends/user/package-lock.json
+++ b/frontends/user/package-lock.json
@@ -14,6 +14,7 @@
         "@fontsource/noto-sans-sc": "^5.3.0",
         "axios": "^1.20.0",
         "pinia": "^4.0.3",
+        "qrcode.vue": "^3.11.0",
         "vue": "^3.5.42",
         "vue-i18n": "^11.4.10",
         "vue-router": "^5.3.0"
@@ -4883,6 +4884,15 @@
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/qrcode.vue": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-3.11.0.tgz",
+      "integrity": "sha512-PnaO9yqcEVsH9euUmo4Nn0JZMkNwk4u6fDUosKjDTXv2Cgv7rHZhr2D8Iq54clBvSycOESwgUE/rw/tBRBjIVg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/quansync": {
       "version": "0.2.11",

--- a/frontends/user/package.json
+++ b/frontends/user/package.json
@@ -20,6 +20,7 @@
     "@fontsource/noto-sans-sc": "^5.3.0",
     "axios": "^1.20.0",
     "pinia": "^4.0.3",
+    "qrcode.vue": "^3.11.0",
     "vue": "^3.5.42",
     "vue-i18n": "^11.4.10",
     "vue-router": "^5.3.0"

--- a/frontends/user/src/i18n/en.ts
+++ b/frontends/user/src/i18n/en.ts
@@ -79,7 +79,11 @@ export default {
         subtitle: 'Enter the 6-digit code from your authenticator app',
         verify: 'Verify Code',
         back: 'Back to sign in',
+        codeLabel: 'Verification code',
       },
+      // U-1: shown on /login after a self-service password change (all
+      // sessions were revoked; a fresh sign-in is required).
+      passwordChangedNotice: 'Password changed. Sign in again with your new password.',
       // #145: forced first-login password change (must_change_password flag)
       passwordChange: {
         title: 'Change Your Password',
@@ -164,6 +168,10 @@ export default {
       errorTitle: 'Authentication Error',
       noCode: 'No authorization code received',
       completing: 'Completing sign in...',
+      // U-4: landed here with a code for a flow this SPA did not initiate
+      // (no local PKCE verifier) — do not touch the code.
+      externalFlow: 'Authorization complete',
+      externalFlowHint: 'You can close this page and return to the application that sent you here.',
     },
     github: {
       errorTitle: 'GitHub Login Failed',
@@ -242,6 +250,10 @@ export default {
         add: '+ Add Passkey',
         cancelled: 'Passkey registration cancelled',
         timedOut: 'Passkey registration was cancelled or timed out',
+        // M-3: distinguish WebAuthn failures from network failures (they used
+        // to surface as "Network connection failed" via the error adapter).
+        alreadyRegistered: 'This browser already has a passkey registered for your account.',
+        registrationFailed: 'Passkey registration failed. Please try again.',
         success: 'Passkey registered successfully!',
       },
       social: {

--- a/frontends/user/src/i18n/zh-CN.ts
+++ b/frontends/user/src/i18n/zh-CN.ts
@@ -78,7 +78,10 @@ export default {
         subtitle: '请输入验证器应用中的 6 位验证码',
         verify: '验证',
         back: '返回登录',
+        codeLabel: '验证码',
       },
+      // U-1：自助改密后跳回 /login 时提示（所有会话已被吊销，需重新登录）。
+      passwordChangedNotice: '密码已修改，请使用新密码重新登录。',
       // #145：首登强制改密（must_change_password 标记）
       passwordChange: {
         title: '修改密码',
@@ -162,6 +165,10 @@ export default {
       errorTitle: '认证失败',
       noCode: '未收到授权码',
       completing: '正在完成登录…',
+      // U-4：携带授权码落地但本 SPA 并非流程发起方（本地无 PKCE
+      // verifier）—— 不动这个 code。
+      externalFlow: '授权完成',
+      externalFlowHint: '你可以关闭此页，返回发起授权的应用。',
     },
     github: {
       errorTitle: 'GitHub 登录失败',
@@ -236,6 +243,9 @@ export default {
         add: '+ 添加安全密钥',
         cancelled: '安全密钥注册已取消',
         timedOut: '安全密钥注册已取消或超时',
+        // M-3：区分 WebAuthn 失败与网络失败（此前经错误适配器一律显示"网络连接失败"）。
+        alreadyRegistered: '此浏览器已为该账户注册过安全密钥。',
+        registrationFailed: '安全密钥注册失败，请重试。',
         success: '安全密钥注册成功',
       },
       social: {

--- a/frontends/user/src/pages/account/SecurityPage.vue
+++ b/frontends/user/src/pages/account/SecurityPage.vue
@@ -5,6 +5,7 @@ import http from '../../services/http'
 import { userService } from '../../services/userService'
 import { normalizeError, type NormalizedError } from '../../services/errorAdapter'
 import { getErrorMessage } from '../../services/messages'
+import { useAuthStore } from '../../stores/auth'
 import { base64UrlEncode, base64UrlDecode } from '../../utils/pkce'
 import type { SocialLink } from '../../types'
 import AppAlert from '../../components/ui/AppAlert.vue'
@@ -12,8 +13,12 @@ import AppBadge from '../../components/ui/AppBadge.vue'
 import AppCard from '../../components/ui/AppCard.vue'
 import AppModal from '../../components/ui/AppModal.vue'
 import DData from '../../components/ui/DData.vue'
+// U-5: renders the backend-provided otpauth:// URI as a scannable QR code
+// (the setup panel's copy promised a QR but only showed the manual key).
+import QrcodeVue from 'qrcode.vue'
 
 const { t } = useI18n()
+const auth = useAuthStore()
 const loading = ref(true)
 const profile = ref<any>(null)
 const success = ref('')
@@ -117,8 +122,14 @@ async function changePassword() {
   changingPassword.value = true
   try {
     await http.put('/api/me/password', { old_password: oldPassword.value, new_password: newPassword.value }, { headers: { 'Content-Type': 'application/json' } })
-    showSuccess(t('account.security.passwordChanged'))
+    // U-1: the server revoked every token for this account as part of the
+    // change (response note: "All existing sessions have been revoked").
+    // Drop the local session and land on /login with a notice — keeping the
+    // stale token left the SPA in a zombie state (guest guard bounced the
+    // user off /login into a broken dashboard full of 401s).
+    auth.logoutLocal()
     oldPassword.value = ''; newPassword.value = ''; confirmNewPassword.value = ''
+    window.location.href = '/login?pw_changed=1'
   } catch (e: unknown) {
     showError(normalizeError(e))
   } finally { changingPassword.value = false }
@@ -272,6 +283,15 @@ async function registerPasskey() {
   } catch (e: any) {
     if (e.name === 'NotAllowedError') {
       showError(t('account.security.passkeys.timedOut'))
+    } else if (e.name === 'InvalidStateError') {
+      // excludeCredentials hit: this browser already holds a passkey for
+      // the account.
+      showError(t('account.security.passkeys.alreadyRegistered'))
+    } else if (!e.response) {
+      // M-3: WebAuthn DOMExceptions and local throws carry no axios
+      // response; normalizeError would misreport them all as "network
+      // connection failed".
+      showError(t('account.security.passkeys.registrationFailed'))
     } else {
       showError(normalizeError(e))
     }
@@ -281,7 +301,12 @@ async function registerPasskey() {
 const webauthnSupported = typeof window !== 'undefined' && !!window.PublicKeyCredential
 
 async function deleteAccount() {
-  if (deleteConfirmUsername.value !== profile.value?.username) {
+  // U-2: the empty-string check is load-bearing. A blank-username account
+  // (or any future state where profile.username === '') would otherwise
+  // pass '' === '' with zero typing — the exact one-click self-deletion
+  // path found in browser-e2e. The backend now generates usernames on
+  // registration, but this guard protects any pre-backfill/edge state.
+  if (!deleteConfirmUsername.value || deleteConfirmUsername.value !== profile.value?.username) {
     showError(t('account.security.danger.usernameMismatch'))
     return
   }
@@ -341,8 +366,12 @@ onMounted(fetchProfile)
           @submit.prevent="changePassword"
         >
           <div>
-            <label class="block text-sm font-medium text-neutral-700 mb-1">{{ $t('account.security.currentPassword') }}</label>
+            <label
+              class="block text-sm font-medium text-neutral-700 mb-1"
+              for="current-password-input"
+            >{{ $t('account.security.currentPassword') }}</label>
             <input
+              id="current-password-input"
               v-model="oldPassword"
               type="password"
               required
@@ -351,8 +380,12 @@ onMounted(fetchProfile)
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-neutral-700 mb-1">{{ $t('common.newPassword') }}</label>
+            <label
+              class="block text-sm font-medium text-neutral-700 mb-1"
+              for="new-password-input"
+            >{{ $t('common.newPassword') }}</label>
             <input
+              id="new-password-input"
               v-model="newPassword"
               type="password"
               required
@@ -361,8 +394,12 @@ onMounted(fetchProfile)
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-neutral-700 mb-1">{{ $t('common.confirmNewPassword') }}</label>
+            <label
+              class="block text-sm font-medium text-neutral-700 mb-1"
+              for="confirm-password-input"
+            >{{ $t('common.confirmNewPassword') }}</label>
             <input
+              id="confirm-password-input"
               v-model="confirmNewPassword"
               type="password"
               required
@@ -405,9 +442,11 @@ onMounted(fetchProfile)
             </p>
             <div class="flex gap-2 max-w-md">
               <input
+                id="mfa-disable-password-input"
                 v-model="disablePassword"
                 type="password"
                 :placeholder="$t('account.security.mfa.disablePlaceholder')"
+                :aria-label="$t('common.password')"
                 class="flex-1 px-3 py-2 border border-neutral-300 rounded-ctl text-sm"
               >
               <button
@@ -428,6 +467,19 @@ onMounted(fetchProfile)
           <p class="text-sm text-neutral-600">
             {{ $t('account.security.mfa.scanQr') }}
           </p>
+          <!-- U-5: QR of the backend-provided otpauth:// URI (MfaController
+               returns otpauth_uri alongside the secret). -->
+          <div
+            v-if="mfaSetupData.otpauth_uri"
+            class="bg-surface p-4 rounded-ctl border border-neutral-200 inline-block mx-auto"
+            data-testid="mfa-setup-qr"
+          >
+            <QrcodeVue
+              :value="mfaSetupData.otpauth_uri"
+              :size="180"
+              level="M"
+            />
+          </div>
           <div class="bg-neutral-50 p-4 rounded-ctl text-center">
             <p class="text-xs text-neutral-500 mb-2">
               {{ $t('account.security.mfa.manualKey') }}
@@ -435,8 +487,12 @@ onMounted(fetchProfile)
             <code class="text-sm font-mono bg-surface px-3 py-1 rounded border select-all">{{ mfaSetupData.secret }}</code>
           </div>
           <div class="max-w-xs">
-            <label class="block text-sm font-medium text-neutral-700 mb-1">{{ $t('account.security.mfa.verificationCode') }}</label>
+            <label
+              class="block text-sm font-medium text-neutral-700 mb-1"
+              for="mfa-verify-code-input"
+            >{{ $t('account.security.mfa.verificationCode') }}</label>
             <input
+              id="mfa-verify-code-input"
               v-model="mfaVerifyCode"
               type="text"
               inputmode="numeric"
@@ -519,9 +575,11 @@ onMounted(fetchProfile)
 
         <div class="flex flex-col sm:flex-row gap-2">
           <input
+            id="passkey-name-input"
             v-model="passkeyName"
             type="text"
             :placeholder="$t('account.security.passkeys.namePlaceholder')"
+            :aria-label="$t('account.security.passkeys.namePlaceholder')"
             class="flex-1 px-3 py-2 text-sm rounded-ctl border border-neutral-300 focus:outline-none focus:ring-2 focus:ring-brand-500/20 focus:border-brand-500"
           >
           <button
@@ -596,10 +654,14 @@ onMounted(fetchProfile)
         </p>
         <div class="space-y-3 max-w-md">
           <div>
-            <label class="block text-sm font-medium text-neutral-700 mb-1">
+            <label
+              class="block text-sm font-medium text-neutral-700 mb-1"
+              for="delete-confirm-username"
+            >
               {{ $t('account.security.danger.typePrefix') }} <strong>{{ profile?.username }}</strong> {{ $t('account.security.danger.typeSuffix') }}
             </label>
             <input
+              id="delete-confirm-username"
               v-model="deleteConfirmUsername"
               type="text"
               autocomplete="off"
@@ -608,7 +670,7 @@ onMounted(fetchProfile)
             >
           </div>
           <button
-            :disabled="deletingAccount || deleteConfirmUsername !== profile?.username"
+            :disabled="deletingAccount || !deleteConfirmUsername || deleteConfirmUsername !== profile?.username"
             class="px-4 py-2 bg-error-600 text-white rounded-ctl text-sm hover:bg-error-700 disabled:opacity-50 disabled:cursor-not-allowed"
             @click="deleteAccount"
           >

--- a/frontends/user/src/pages/account/SecurityPage.vue
+++ b/frontends/user/src/pages/account/SecurityPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import http from '../../services/http'
 import { userService } from '../../services/userService'
@@ -19,6 +20,7 @@ import QrcodeVue from 'qrcode.vue'
 
 const { t } = useI18n()
 const auth = useAuthStore()
+const router = useRouter()
 const loading = ref(true)
 const profile = ref<any>(null)
 const success = ref('')
@@ -126,10 +128,12 @@ async function changePassword() {
     // change (response note: "All existing sessions have been revoked").
     // Drop the local session and land on /login with a notice — keeping the
     // stale token left the SPA in a zombie state (guest guard bounced the
-    // user off /login into a broken dashboard full of 401s).
+    // user off /login into a broken dashboard full of 401s). SPA navigation
+    // rather than a full page load (PR #180 review M9): logoutLocal() has
+    // already cleared the state, and router keeps the base prefix.
     auth.logoutLocal()
     oldPassword.value = ''; newPassword.value = ''; confirmNewPassword.value = ''
-    window.location.href = '/login?pw_changed=1'
+    await router.replace({ path: '/login', query: { pw_changed: '1' } })
   } catch (e: unknown) {
     showError(normalizeError(e))
   } finally { changingPassword.value = false }

--- a/frontends/user/src/pages/auth/LoginPage.vue
+++ b/frontends/user/src/pages/auth/LoginPage.vue
@@ -45,6 +45,48 @@ if (route.query.must_change_password === '1') {
   showPasswordChange.value = true
 }
 
+// U-1: the security page redirects here with pw_changed=1 after a successful
+// self-service password change (the server revoked every session; a fresh
+// login is required).
+const passwordChangedNotice = route.query.pw_changed === '1'
+
+// U-3 (browser-e2e 2026-09-08): /oauth2/authorize redirects anonymous users
+// to /login with the OAuth parameters FLATTENED onto the query (client_id,
+// redirect_uri, state, ... — there is no `redirect` param). After a successful
+// login the authorization flow must RESUME: rebuild the authorize URL from
+// those parameters (whitelisted keys only, values passed through verbatim —
+// the server re-validates redirect_uri against the client registration) and
+// navigate with a full page load. Before this, such users landed on the
+// dashboard and the relying party never received its authorization code.
+const AUTHORIZE_CARRY_KEYS = [
+  'client_id', 'redirect_uri', 'scope', 'state', 'response_type',
+  'code_challenge', 'code_challenge_method', 'nonce',
+] as const
+
+function resumeAuthorizeFlow(): boolean {
+  const q = route.query
+  const clientId = typeof q.client_id === 'string' ? q.client_id : ''
+  const responseType = typeof q.response_type === 'string' ? q.response_type : ''
+  if (!clientId || !responseType) return false
+  const params = new URLSearchParams()
+  for (const key of AUTHORIZE_CARRY_KEYS) {
+    const v = q[key]
+    if (typeof v === 'string' && v !== '') params.set(key, v)
+  }
+  window.location.href = `/oauth2/authorize?${params.toString()}`
+  return true
+}
+
+function navigateAfterLogin() {
+  const redirect = route.query.redirect
+  if (typeof redirect === 'string' && redirect) {
+    router.push(redirect)
+    return
+  }
+  if (resumeAuthorizeFlow()) return
+  router.push('/')
+}
+
 async function handleLogin() {
   const result = await auth.login(username.value, password.value)
   if (result.mfaRequired) {
@@ -55,14 +97,14 @@ async function handleLogin() {
     password.value = ''
     showPasswordChange.value = true
   } else if (result.success) {
-    router.push((route.query.redirect as string) || '/')
+    navigateAfterLogin()
   }
 }
 
 async function handleMfa() {
   const result = await auth.verifyMfa(mfaToken.value, mfaCode.value)
   if (result.success) {
-    router.push((route.query.redirect as string) || '/')
+    navigateAfterLogin()
   }
 }
 
@@ -101,6 +143,15 @@ async function handlePasswordChange() {
         </router-link>
       </p>
     </div>
+
+    <AppAlert
+      v-if="passwordChangedNotice"
+      type="success"
+      class="mb-6"
+      data-testid="password-changed-notice"
+    >
+      {{ $t('auth.login.passwordChangedNotice') }}
+    </AppAlert>
 
     <AppAlert
       v-if="auth.errorText"
@@ -217,6 +268,7 @@ async function handlePasswordChange() {
           inputmode="numeric"
           maxlength="6"
           autocomplete="one-time-code"
+          :aria-label="$t('auth.login.mfa.codeLabel')"
           class="block w-full px-4 py-4 text-center text-2xl tracking-[0.42em] font-mono tabular-nums border border-neutral-300 rounded-ctl bg-surface
                  focus:outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus:border-brand-700"
           placeholder="000000"

--- a/frontends/user/src/pages/oauth/CallbackPage.vue
+++ b/frontends/user/src/pages/oauth/CallbackPage.vue
@@ -3,6 +3,7 @@ import { onMounted, computed, ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '../../stores/auth'
+import { authService } from '../../services/authService'
 import { normalizeError, type NormalizedError } from '../../services/errorAdapter'
 import { getErrorMessage } from '../../services/messages'
 
@@ -22,6 +23,10 @@ const errorText = computed(() => {
 // Secondary detail: the raw error_description from the redirect, kept only
 // when it exists and adds something the catalog-resolved message lacks.
 const errorDetail = ref('')
+// U-4: the code belongs to a flow this SPA did not initiate (external app
+// drove the user through authorize with its own PKCE verifier) — show the
+// completion notice instead of trying to redeem.
+const externalFlow = ref(false)
 
 onMounted(async () => {
   const code = route.query.code as string
@@ -48,6 +53,16 @@ onMounted(async () => {
 
   if (!code) {
     error.value = t('oauth.callback.noCode')
+    return
+  }
+
+  // U-4 (browser-e2e 2026-09-08): redeeming a code without OUR PKCE verifier
+  // always fails (PKCE is force-enabled server-side) and consumes the
+  // one-time code that the flow's initiator still needs. Only redeem when
+  // this SPA stashed a verifier for the flow; otherwise this landing is on
+  // behalf of an external application.
+  if (!authService.hasStashedVerifier()) {
+    externalFlow.value = true
     return
   }
 
@@ -85,6 +100,30 @@ onMounted(async () => {
         >
           {{ $t('common.backToLogin') }}
         </router-link>
+      </div>
+      <div v-else-if="externalFlow">
+        <div class="w-14 h-14 rounded-2xl bg-success-50 flex items-center justify-center mx-auto mb-4">
+          <svg
+            class="w-7 h-7 text-success-600"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <p
+          class="text-neutral-900 font-medium"
+          data-testid="callback-external-flow"
+        >
+          {{ $t('oauth.callback.externalFlow') }}
+        </p>
+        <p class="text-neutral-500 text-sm mt-2">
+          {{ $t('oauth.callback.externalFlowHint') }}
+        </p>
       </div>
       <div v-else>
         <div class="animate-spin w-8 h-8 border-4 border-brand-600 border-t-transparent rounded-full mx-auto" />

--- a/frontends/user/src/pages/oauth/CallbackPage.vue
+++ b/frontends/user/src/pages/oauth/CallbackPage.vue
@@ -56,18 +56,20 @@ onMounted(async () => {
     return
   }
 
-  // U-4 (browser-e2e 2026-09-08): redeeming a code without OUR PKCE verifier
-  // always fails (PKCE is force-enabled server-side) and consumes the
-  // one-time code that the flow's initiator still needs. Only redeem when
-  // this SPA stashed a verifier for the flow; otherwise this landing is on
-  // behalf of an external application.
-  if (!authService.hasStashedVerifier()) {
+  // U-4 (browser-e2e 2026-09-08; state binding per PR #180 review M6):
+  // redeeming a code without OUR verifier for THIS flow always fails (PKCE
+  // is force-enabled server-side) and consumes the one-time code that the
+  // flow's initiator still needs. The verifier stash is state-correlated,
+  // so a stale stash from an abandoned login cannot qualify an external
+  // landing either.
+  const state = typeof route.query.state === 'string' ? route.query.state : ''
+  if (!authService.hasVerifierForState(state)) {
     externalFlow.value = true
     return
   }
 
   try {
-    await auth.exchangeCode(code)
+    await auth.exchangeCode(code, state)
     router.replace('/')
   } catch (e: unknown) {
     error.value = normalizeError(e)

--- a/frontends/user/src/router/index.ts
+++ b/frontends/user/src/router/index.ts
@@ -94,22 +94,26 @@ const router = createRouter({
 router.beforeEach(async (to, _from, next) => {
   const auth = useAuthStore()
 
-  // Try to restore session on first navigation to protected route
+  // Try to restore session on first navigation to protected route. The
+  // restore is a cached singleton promise (stores/auth) — awaiting it here
+  // joins the store-init restore rather than racing it. The decision uses
+  // the CURRENT isAuthenticated, never the promise result: the cached
+  // result may predate a logout/token revocation.
   if (to.meta.auth && !auth.isAuthenticated) {
-    const restored = await auth.restoreSession()
-    if (restored) {
+    await auth.restoreSession()
+    if (auth.isAuthenticated) {
       next()
       return
     }
     next({ name: 'login', query: { redirect: to.fullPath } })
   } else if (to.meta.guest) {
-    // U-1 (browser-e2e 2026-09-08): isAuthenticated starts OPTIMISTICALLY true
-    // whenever a refresh_token sits in localStorage. If the token was revoked
-    // server-side (e.g. password changed elsewhere), that optimistic flag
-    // used to bounce the user off /login into a zombie dashboard of 401s.
-    // Restore first — restoreSession() clears the flag when the refresh
-    // token is dead — then decide.
-    if (!auth.sessionRestored) await auth.restoreSession()
+    // U-1 (browser-e2e 2026-09-08): isAuthenticated starts OPTIMISTICALLY
+    // true whenever a refresh_token sits in localStorage. If the token was
+    // revoked server-side (e.g. password changed elsewhere), that optimistic
+    // flag used to bounce the user off /login into a zombie dashboard of
+    // 401s. Await the restore — it clears the flag when the refresh token
+    // is dead — then decide on the live value.
+    await auth.restoreSession()
     if (auth.isAuthenticated) {
       next({ name: 'dashboard' })
     } else {

--- a/frontends/user/src/router/index.ts
+++ b/frontends/user/src/router/index.ts
@@ -93,7 +93,7 @@ const router = createRouter({
 
 router.beforeEach(async (to, _from, next) => {
   const auth = useAuthStore()
-  
+
   // Try to restore session on first navigation to protected route
   if (to.meta.auth && !auth.isAuthenticated) {
     const restored = await auth.restoreSession()
@@ -102,8 +102,19 @@ router.beforeEach(async (to, _from, next) => {
       return
     }
     next({ name: 'login', query: { redirect: to.fullPath } })
-  } else if (to.meta.guest && auth.isAuthenticated) {
-    next({ name: 'dashboard' })
+  } else if (to.meta.guest) {
+    // U-1 (browser-e2e 2026-09-08): isAuthenticated starts OPTIMISTICALLY true
+    // whenever a refresh_token sits in localStorage. If the token was revoked
+    // server-side (e.g. password changed elsewhere), that optimistic flag
+    // used to bounce the user off /login into a zombie dashboard of 401s.
+    // Restore first — restoreSession() clears the flag when the refresh
+    // token is dead — then decide.
+    if (!auth.sessionRestored) await auth.restoreSession()
+    if (auth.isAuthenticated) {
+      next({ name: 'dashboard' })
+    } else {
+      next()
+    }
   } else {
     next()
   }

--- a/frontends/user/src/services/authService.ts
+++ b/frontends/user/src/services/authService.ts
@@ -17,6 +17,17 @@ const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI || window.location.origin
 const PKCE_VERIFIER_KEY = 'pkce_code_verifier'
 
 export const authService = {
+  /**
+   * U-4 (browser-e2e 2026-09-08): true when THIS SPA holds the PKCE verifier
+   * for the flow that produced a /callback landing. PKCE is force-enabled
+   * server-side, so without our verifier a code cannot be redeemed here —
+   * attempting it only burns the one-time code that belongs to the flow's
+   * real initiator (an external app that drove the user through authorize).
+   * CallbackPage uses this to decide exchange vs. "return to your app".
+   */
+  hasStashedVerifier(): boolean {
+    return sessionStorage.getItem(PKCE_VERIFIER_KEY) !== null
+  },
   async login(username: string, password: string, scope = 'openid profile email'): Promise<LoginResult> {
     // PKCE (RFC 7636): generate a verifier/challenge pair so the backend's
     // `require_pkce_for_public` enforcement (F-011) does not reject the login.

--- a/frontends/user/src/services/authService.ts
+++ b/frontends/user/src/services/authService.ts
@@ -6,27 +6,63 @@ const CLIENT_ID = import.meta.env.VITE_CLIENT_ID || 'vue-client'
 const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI || window.location.origin + '/callback'
 
 /**
- * Session-storage key for the PKCE code_verifier in the browser-redirect flow.
+ * Session-storage key for the PKCE code_verifier of the SPA's own login
+ * flow, stored as JSON `{ state, verifier }`.
  *
- * The SPA POST-login flow (authService.login) keeps the verifier in a closure
- * across the two-step login+exchange, so it never needs to persist. But when a
- * third-party app initiates `/oauth2/authorize` → browser redirect → CallbackPage,
- * the page reloads and the verifier must survive it. The authorize redirect is
- * the only place this key is written/read.
+ * The plain POST-login flow (authService.login) keeps the verifier in a
+ * closure across the two-step login+exchange, so it normally never needs to
+ * persist. The exception is the MFA branch: the challenge may span a page
+ * interaction boundary, so the verifier (paired with the login's `state`)
+ * is stashed there for verifyMfa/exchangeCode.
+ *
+ * PR #180 review M6 (RFC 7636 §4.6): the verifier only redeems codes of the
+ * flow it was minted for, so `state` is the correlation key — a stash left
+ * behind by a failed/abandoned MFA login must NOT qualify a later
+ * externally-initiated /callback landing.
  */
 const PKCE_VERIFIER_KEY = 'pkce_code_verifier'
 
+interface PkceStash {
+  state: string
+  verifier: string
+}
+
+function readPkceStash(): PkceStash | null {
+  try {
+    const raw = sessionStorage.getItem(PKCE_VERIFIER_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PkceStash>
+    if (typeof parsed.state === 'string' && typeof parsed.verifier === 'string') {
+      return { state: parsed.state, verifier: parsed.verifier }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function writePkceStash(stash: PkceStash) {
+  sessionStorage.setItem(PKCE_VERIFIER_KEY, JSON.stringify(stash))
+}
+
+function clearPkceStash() {
+  sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+}
+
 export const authService = {
   /**
-   * U-4 (browser-e2e 2026-09-08): true when THIS SPA holds the PKCE verifier
-   * for the flow that produced a /callback landing. PKCE is force-enabled
-   * server-side, so without our verifier a code cannot be redeemed here —
-   * attempting it only burns the one-time code that belongs to the flow's
-   * real initiator (an external app that drove the user through authorize).
-   * CallbackPage uses this to decide exchange vs. "return to your app".
+   * U-4 (browser-e2e 2026-09-08): true when THIS SPA holds the PKCE
+   * verifier FOR THIS FLOW — the stash's `state` must equal the `state` the
+   * callback was reached with. PKCE is force-enabled server-side, so
+   * redeeming a code without the matching verifier would only burn the
+   * one-time code that belongs to the flow's real initiator (an external
+   * app that drove the user through authorize). CallbackPage uses this to
+   * decide exchange vs. "return to your app".
    */
-  hasStashedVerifier(): boolean {
-    return sessionStorage.getItem(PKCE_VERIFIER_KEY) !== null
+  hasVerifierForState(state?: string | null): boolean {
+    if (!state) return false
+    const stash = readPkceStash()
+    return stash !== null && stash.state === state
   },
   async login(username: string, password: string, scope = 'openid profile email'): Promise<LoginResult> {
     // PKCE (RFC 7636): generate a verifier/challenge pair so the backend's
@@ -35,23 +71,23 @@ export const authService = {
     // return JSON (not a browser redirect), so the page does not reload and
     // the closure survives to the token-exchange step below.
     const pkce = await generatePkcePair()
+    const state = crypto.randomUUID()
 
     const resp = await http.post('/oauth2/login', new URLSearchParams({
       username, password,
       client_id: CLIENT_ID,
       redirect_uri: REDIRECT_URI,
       scope,
-      state: crypto.randomUUID(),
+      state,
       code_challenge: pkce.challenge,
       code_challenge_method: pkce.method,
       json: 'true',
     }))
 
     if (resp.data.mfa_required) {
-      // MFA path: stash the verifier so verifyMfa() can thread it through to
-      // the MFA code-exchange. Stored in sessionStorage (not memory) because
-      // the MFA challenge may span a page interaction boundary.
-      sessionStorage.setItem(PKCE_VERIFIER_KEY, pkce.verifier)
+      // MFA path: stash the verifier (bound to this flow's state) so
+      // verifyMfa() can thread it through to the MFA code-exchange.
+      writePkceStash({ state, verifier: pkce.verifier })
       return { mfaRequired: true, mfaToken: resp.data.mfa_token }
     }
 
@@ -79,12 +115,12 @@ export const authService = {
   },
 
   async verifyMfa(mfaToken: string, code: string): Promise<LoginResult> {
-    // The PKCE verifier generated during login() — needed if the backend
-    // MFA path threads the challenge through to the token exchange. It is
-    // consumed only on success: clearing it on a wrong-code attempt would
-    // make the retry fail PKCE (the token exchange rejects an empty verifier
-    // whenever a challenge is bound to the code).
-    const codeVerifier = sessionStorage.getItem(PKCE_VERIFIER_KEY) || ''
+    // The PKCE verifier stashed by login()'s MFA branch — needed if the
+    // backend MFA path threads the challenge through to the token exchange.
+    // It is consumed only on success: clearing it on a wrong-code attempt
+    // would make the retry fail PKCE (the token exchange rejects an empty
+    // verifier whenever a challenge is bound to the code).
+    const codeVerifier = readPkceStash()?.verifier ?? ''
 
     const params = new URLSearchParams({
       mfa_token: mfaToken,
@@ -96,7 +132,7 @@ export const authService = {
 
     const resp = await http.post<TokenResponse>('/oauth2/mfa/verify', params)
     if (resp.data.access_token) {
-      sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+      clearPkceStash()
       setTokens(resp.data.access_token, resp.data.refresh_token)
       return { success: true }
     }
@@ -118,20 +154,25 @@ export const authService = {
   /**
    * Exchange an authorization code for tokens (browser-redirect flow).
    * Called by CallbackPage after `/oauth2/authorize` redirects back with
-   * `?code=...`. The PKCE verifier was stashed in sessionStorage before the
-   * authorize redirect (see exchangeCode callers).
+   * `?code=...`. Only redeemable when the stashed verifier belongs to THIS
+   * flow (`state` matches — RFC 7636 §4.6 correlation, PR #180 review M6);
+   * the stash is consumed either way so an abandoned login cannot qualify a
+   * later landing.
    */
-  async exchangeCode(code: string): Promise<void> {
-    const codeVerifier = sessionStorage.getItem(PKCE_VERIFIER_KEY) || ''
-    if (codeVerifier) sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+  async exchangeCode(code: string, state?: string): Promise<void> {
+    const stash = readPkceStash()
+    clearPkceStash()
+    if (!stash || !state || stash.state !== state) {
+      throw new Error('No PKCE verifier matching this authorization flow')
+    }
 
     const params = new URLSearchParams({
       grant_type: 'authorization_code',
       code,
       redirect_uri: REDIRECT_URI,
       client_id: CLIENT_ID,
+      code_verifier: stash.verifier,
     })
-    if (codeVerifier) params.set('code_verifier', codeVerifier)
 
     const resp = await http.post<TokenResponse>('/oauth2/token', params)
     setTokens(resp.data.access_token, resp.data.refresh_token)

--- a/frontends/user/src/stores/auth.ts
+++ b/frontends/user/src/stores/auth.ts
@@ -100,10 +100,28 @@ export const useAuthStore = defineStore('auth', () => {
     markUnauthenticated()
   }
 
+  /**
+   * U-1 (browser-e2e 2026-09-08): drop the LOCAL session state without a
+   * server round-trip. Used after self-service password change: the server
+   * revoked every token for the account as part of the change, so the stored
+   * refresh token is dead weight and must not keep the SPA "optimistically
+   * authenticated" (which bounced the user off /login into a zombie
+   * dashboard).
+   */
+  function logoutLocal() {
+    user.value = null
+    httpClearTokens()
+    markUnauthenticated()
+  }
+
   // Initialize: try to restore session if refresh_token exists
   if (getRefreshToken()) {
     restoreSession()
   }
 
-  return { user, loading, error, errorText, isAuthenticated, login, verifyMfa, exchangeCode, fetchUser, logout, restoreSession, markAuthenticated }
+  return {
+    user, loading, error, errorText, isAuthenticated, sessionRestored,
+    login, verifyMfa, exchangeCode, fetchUser, logout, logoutLocal,
+    restoreSession, markAuthenticated,
+  }
 })

--- a/frontends/user/src/stores/auth.ts
+++ b/frontends/user/src/stores/auth.ts
@@ -21,6 +21,12 @@ export const useAuthStore = defineStore('auth', () => {
   })
   const tokenPresent = ref(!!getAccessToken() || !!getRefreshToken())
   const sessionRestored = ref(false)
+  // PR #180 review M3: restoreSession() used to set `sessionRestored` before
+  // awaiting, so the guest guard's `if (!sessionRestored) await` never
+  // waited — the optimistic tokenPresent flag decided the bounce. Cache the
+  // in-flight promise instead: concurrent callers join the same restore, and
+  // the flag flips only when the restore actually finished.
+  let restorePromise: Promise<boolean> | null = null
 
   const isAuthenticated = computed(() => tokenPresent.value)
 
@@ -28,19 +34,29 @@ export const useAuthStore = defineStore('auth', () => {
   function markUnauthenticated() { tokenPresent.value = false }
 
   /** Restore session from refresh_token on page reload */
-  async function restoreSession(): Promise<boolean> {
-    if (sessionRestored.value) return !!getAccessToken()
-    sessionRestored.value = true
-    if (getAccessToken()) return true
-    if (!getRefreshToken()) { markUnauthenticated(); return false }
-    const restored = await tryRestoreSession()
-    if (restored) {
-      markAuthenticated()
-      await fetchUser()
-    } else {
-      markUnauthenticated()
-    }
-    return restored
+  function restoreSession(): Promise<boolean> {
+    if (restorePromise) return restorePromise
+    restorePromise = (async () => {
+      if (getAccessToken()) {
+        sessionRestored.value = true
+        return true
+      }
+      if (!getRefreshToken()) {
+        markUnauthenticated()
+        sessionRestored.value = true
+        return false
+      }
+      const restored = await tryRestoreSession()
+      if (restored) {
+        markAuthenticated()
+        await fetchUser()
+      } else {
+        markUnauthenticated()
+      }
+      sessionRestored.value = true
+      return restored
+    })()
+    return restorePromise
   }
 
   async function login(username: string, password: string): Promise<LoginResult> {
@@ -79,8 +95,8 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  async function exchangeCode(code: string) {
-    await authService.exchangeCode(code)
+  async function exchangeCode(code: string, state?: string) {
+    await authService.exchangeCode(code, state)
     markAuthenticated()
     await fetchUser()
   }

--- a/frontends/user/tests/e2e/account.spec.ts
+++ b/frontends/user/tests/e2e/account.spec.ts
@@ -159,13 +159,26 @@ test.describe('Security', () => {
     await expect(page.locator('h2:has-text("Two-Factor Authentication")')).toBeVisible()
   })
 
-  test('can change password', async ({ page }) => {
+  test('can change password (drops session and lands on /login with a notice)', async ({ page }) => {
+    // loginUser seeds refresh_token via addInitScript, which re-runs on the
+    // FULL page load the password change triggers — resurrecting a session
+    // the app just cleared. Simulate the real state: on the post-change
+    // login load, no refresh token exists anymore.
+    await page.addInitScript(() => {
+      if (location.pathname === '/login' && location.search.includes('pw_changed=1')) {
+        localStorage.removeItem('refresh_token')
+      }
+    })
     await page.locator('input[autocomplete="current-password"]').fill('oldpass')
     const newPassFields = page.locator('input[autocomplete="new-password"]')
     await newPassFields.first().fill('NewPass123!')
     await newPassFields.nth(1).fill('NewPass123!')
     await page.locator('button:has-text("Change Password")').click()
-    await expect(page.locator('text=Password changed')).toBeVisible()
+    // U-1: the server revoked every session as part of the change; the SPA
+    // must drop its local state and land on /login with a notice (not stay
+    // on /security in a zombie authenticated state).
+    await expect(page).toHaveURL(/\/login\?pw_changed=1/, { timeout: 10000 })
+    await expect(page.getByTestId('password-changed-notice')).toBeVisible()
   })
 
   test('password mismatch shows error', async ({ page }) => {
@@ -229,6 +242,21 @@ test.describe('Security', () => {
     }
   })
 
+  // U-2 (browser-e2e 2026-09-08): blank-username accounts read
+  // profile.username === '', which made '' === '' pass with zero typing and
+  // enabled one-click self-deletion. The button must stay disabled for any
+  // EMPTY confirm input regardless of the profile username.
+  test('danger zone: empty or wrong confirm input keeps delete disabled', async ({ page }) => {
+    const confirmInput = page.locator('#delete-confirm-username')
+    const deleteBtn = page.locator('button:has-text("Delete My Account")')
+    await expect(confirmInput).toBeVisible()
+    // Zero typing (the U-2 one-click path):
+    await expect(deleteBtn).toBeDisabled()
+    // Wrong name:
+    await confirmInput.fill('not-the-username')
+    await expect(deleteBtn).toBeDisabled()
+  })
+
   test('shows MFA enable button when disabled', async ({ page }) => {
     await expect(page.locator('button:has-text("Enable MFA")')).toBeVisible()
   })
@@ -236,6 +264,10 @@ test.describe('Security', () => {
   test('can start MFA setup', async ({ page }) => {
     await page.click('button:has-text("Enable MFA")')
     await expect(page.locator('text=JBSWY3DPEHPK3PXP')).toBeVisible()
+    // U-5: the setup panel renders the otpauth:// URI as a scannable QR
+    // (canvas), not just the manual key.
+    await expect(page.getByTestId('mfa-setup-qr')).toBeVisible()
+    await expect(page.getByTestId('mfa-setup-qr').locator('canvas')).toBeVisible()
   })
 
   test('shows Danger Zone with delete account', async ({ page }) => {

--- a/frontends/user/tests/e2e/account.spec.ts
+++ b/frontends/user/tests/e2e/account.spec.ts
@@ -160,15 +160,6 @@ test.describe('Security', () => {
   })
 
   test('can change password (drops session and lands on /login with a notice)', async ({ page }) => {
-    // loginUser seeds refresh_token via addInitScript, which re-runs on the
-    // FULL page load the password change triggers — resurrecting a session
-    // the app just cleared. Simulate the real state: on the post-change
-    // login load, no refresh token exists anymore.
-    await page.addInitScript(() => {
-      if (location.pathname === '/login' && location.search.includes('pw_changed=1')) {
-        localStorage.removeItem('refresh_token')
-      }
-    })
     await page.locator('input[autocomplete="current-password"]').fill('oldpass')
     const newPassFields = page.locator('input[autocomplete="new-password"]')
     await newPassFields.first().fill('NewPass123!')
@@ -176,7 +167,8 @@ test.describe('Security', () => {
     await page.locator('button:has-text("Change Password")').click()
     // U-1: the server revoked every session as part of the change; the SPA
     // must drop its local state and land on /login with a notice (not stay
-    // on /security in a zombie authenticated state).
+    // on /security in a zombie authenticated state). M9: SPA navigation, so
+    // no seeded-refresh-token resurrection can occur either.
     await expect(page).toHaveURL(/\/login\?pw_changed=1/, { timeout: 10000 })
     await expect(page.getByTestId('password-changed-notice')).toBeVisible()
   })

--- a/frontends/user/tests/e2e/auth.spec.ts
+++ b/frontends/user/tests/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { setupMocks } from './helpers/mock-api'
+import { setupMocks, MOCK_TOKEN_PAIR } from './helpers/mock-api'
 
 test.describe('Login', () => {
   test.beforeEach(async ({ page }) => {
@@ -69,6 +69,85 @@ test.describe('Login', () => {
     await page.goto('/login')
     await page.click('a:has-text("create a new account")')
     await expect(page).toHaveURL('/register')
+  })
+})
+
+// U-3 (browser-e2e 2026-09-08): /oauth2/authorize bounces anonymous users to
+// /login with the OAuth parameters flattened onto the query (no `redirect`
+// param). A successful login must RESUME the flow by navigating back to
+// /oauth2/authorize with every flattened parameter preserved — not drop the
+// user on the dashboard.
+test.describe('Authorize flow resume (U-3)', () => {
+  const authorizeQuery = '/login?client_id=rp-app&redirect_uri=' +
+    encodeURIComponent('https://rp.example.com/cb') +
+    '&scope=openid%20profile&state=st4te123&response_type=code' +
+    '&code_challenge=ch4ll8910&code_challenge_method=S256&nonce=n0nce77'
+
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page)
+    // The resume is a full-page navigation to the (backend) authorize
+    // endpoint; intercept it so the mock run does not need a live server.
+    await page.route('**/oauth2/authorize*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'authorize endpoint reached (mock)',
+      })
+    })
+  })
+
+  test('password login resumes authorize with all parameters', async ({ page }) => {
+    await page.goto(authorizeQuery)
+    await page.locator('input[autocomplete="username"]').fill('testuser')
+    await page.locator('input[autocomplete="current-password"]').fill('password123')
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/oauth2\/authorize\?/, { timeout: 10000 })
+    const url = new URL(page.url())
+    expect(url.searchParams.get('client_id')).toBe('rp-app')
+    expect(url.searchParams.get('redirect_uri')).toBe('https://rp.example.com/cb')
+    expect(url.searchParams.get('scope')).toBe('openid profile')
+    expect(url.searchParams.get('state')).toBe('st4te123')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('code_challenge')).toBe('ch4ll8910')
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('nonce')).toBe('n0nce77')
+  })
+
+  test('MFA login resumes authorize with all parameters', async ({ page }) => {
+    await page.route('**/oauth2/login', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ mfa_required: true, mfa_token: 'mfa-token-123' }),
+      })
+    })
+    await page.route('**/oauth2/mfa/verify', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_TOKEN_PAIR),
+      })
+    })
+    await page.goto(authorizeQuery)
+    await page.locator('input[autocomplete="username"]').fill('testuser')
+    await page.locator('input[autocomplete="current-password"]').fill('password123')
+    await page.locator('button[type="submit"]').click()
+    await expect(page.locator('input[maxlength="6"]')).toBeVisible()
+    await page.locator('input[maxlength="6"]').fill('123456')
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/oauth2\/authorize\?/, { timeout: 10000 })
+    const url = new URL(page.url())
+    expect(url.searchParams.get('client_id')).toBe('rp-app')
+    expect(url.searchParams.get('state')).toBe('st4te123')
+    expect(url.searchParams.get('code_challenge')).toBe('ch4ll8910')
+  })
+
+  test('plain login (no OAuth query) still lands on the dashboard', async ({ page }) => {
+    await page.goto('/login')
+    await page.locator('input[autocomplete="username"]').fill('testuser')
+    await page.locator('input[autocomplete="current-password"]').fill('password123')
+    await page.locator('button[type="submit"]').click()
+    await expect(page).toHaveURL('/', { timeout: 10000 })
   })
 })
 

--- a/frontends/user/tests/e2e/oauth.spec.ts
+++ b/frontends/user/tests/e2e/oauth.spec.ts
@@ -75,7 +75,17 @@ test.describe('Callback Page', () => {
     await setupMocks(page)
   })
 
+  // U-4: the page only redeems a code when THIS SPA holds the PKCE verifier
+  // for the flow (sessionStorage 'pkce_code_verifier'). Without it the code
+  // belongs to an external app's flow and redeeming here would only burn it.
+  async function seedVerifier(page: import('@playwright/test').Page) {
+    await page.addInitScript(() => {
+      sessionStorage.setItem('pkce_code_verifier', 'mock-verifier-e2e-seeded')
+    })
+  }
+
   test('exchanges code for token and redirects', async ({ page }) => {
+    await seedVerifier(page)
     await page.goto('/callback?code=test-auth-code&state=test-state')
     // After successful token exchange, should redirect to /
     await expect(page).toHaveURL('/', { timeout: 10000 })
@@ -91,7 +101,22 @@ test.describe('Callback Page', () => {
     await expect(page.locator('text=No authorization code')).toBeVisible()
   })
 
+  test('without a local verifier shows the external-flow notice and never touches the token endpoint', async ({ page }) => {
+    let tokenCalled = false
+    await page.route('**/oauth2/token', async (route) => {
+      tokenCalled = true
+      await route.fulfill({ status: 400, contentType: 'application/json', body: '{}' })
+    })
+    await page.goto('/callback?code=external-flow-code&state=st-ext')
+    await expect(page.getByTestId('callback-external-flow')).toBeVisible()
+    await page.waitForTimeout(300)
+    expect(tokenCalled).toBe(false)
+    // Stays on the callback page (nothing to redeem, nowhere to go).
+    await expect(page).toHaveURL(/\/callback/)
+  })
+
   test('loading spinner shown while exchanging code', async ({ page }) => {
+    await seedVerifier(page)
     // Delay token exchange to observe spinner
     await page.route('**/oauth2/token', async (route) => {
       await new Promise(resolve => setTimeout(resolve, 800))

--- a/frontends/user/tests/e2e/oauth.spec.ts
+++ b/frontends/user/tests/e2e/oauth.spec.ts
@@ -76,16 +76,21 @@ test.describe('Callback Page', () => {
   })
 
   // U-4: the page only redeems a code when THIS SPA holds the PKCE verifier
-  // for the flow (sessionStorage 'pkce_code_verifier'). Without it the code
-  // belongs to an external app's flow and redeeming here would only burn it.
-  async function seedVerifier(page: import('@playwright/test').Page) {
-    await page.addInitScript(() => {
-      sessionStorage.setItem('pkce_code_verifier', 'mock-verifier-e2e-seeded')
-    })
+  // for THE FLOW — the stash is { state, verifier } JSON and its state must
+  // match the callback's state (PR #180 review M6). Without a matching stash
+  // the code belongs to an external app's flow and redeeming here would only
+  // burn it.
+  async function seedVerifier(page: import('@playwright/test').Page, state: string) {
+    await page.addInitScript((s: string) => {
+      sessionStorage.setItem(
+        'pkce_code_verifier',
+        JSON.stringify({ state: s, verifier: 'mock-verifier-e2e-seeded' }),
+      )
+    }, state)
   }
 
   test('exchanges code for token and redirects', async ({ page }) => {
-    await seedVerifier(page)
+    await seedVerifier(page, 'test-state')
     await page.goto('/callback?code=test-auth-code&state=test-state')
     // After successful token exchange, should redirect to /
     await expect(page).toHaveURL('/', { timeout: 10000 })
@@ -115,8 +120,23 @@ test.describe('Callback Page', () => {
     await expect(page).toHaveURL(/\/callback/)
   })
 
+  test('stale verifier from another flow (state mismatch) is not used to redeem', async ({ page }) => {
+    // M6: a stash left behind by an abandoned login must not qualify an
+    // externally-initiated landing — state is the correlation key.
+    let tokenCalled = false
+    await page.route('**/oauth2/token', async (route) => {
+      tokenCalled = true
+      await route.fulfill({ status: 400, contentType: 'application/json', body: '{}' })
+    })
+    await seedVerifier(page, 'login-flow-state')
+    await page.goto('/callback?code=external-code&state=external-state')
+    await expect(page.getByTestId('callback-external-flow')).toBeVisible()
+    await page.waitForTimeout(300)
+    expect(tokenCalled).toBe(false)
+  })
+
   test('loading spinner shown while exchanging code', async ({ page }) => {
-    await seedVerifier(page)
+    await seedVerifier(page, 'test-state')
     // Delay token exchange to observe spinner
     await page.route('**/oauth2/token', async (route) => {
       await new Promise(resolve => setTimeout(resolve, 800))

--- a/libs/common/include/fulla/common/config/ConfigTypes.h
+++ b/libs/common/include/fulla/common/config/ConfigTypes.h
@@ -36,10 +36,12 @@ inline const std::vector<EnvOverride> FULLA_ENV_OVERRIDES =
    {"custom_config.external_auth.wechat.appid", "FULLA_WECHAT_APPID", false},
    {"custom_config.external_auth.wechat.secret", "FULLA_WECHAT_SECRET", false},
    {"listeners.0.port", "FULLA_LISTEN_PORT", true},
-   {"vue_client.secret", "FULLA_VUE_CLIENT_SECRET", false},
    // "[name=OAuth2Plugin]" resolves the plugin by its drogon "name" field,
    // independent of array ordering — each config file inserts a different set
    // of plugins (Hodor, AccessLogger) so a numeric index would be fragile.
+   {"plugins[name=OAuth2Plugin].config.clients.vue-client.secret",
+    "FULLA_VUE_CLIENT_SECRET",
+    false},
    {"plugins[name=OAuth2Plugin].config.clients.vue-client.redirect_uri",
     "FULLA_VUE_REDIRECT_URI",
     false},

--- a/libs/drogon/include/fulla/drogon/services/DeviceCodeService.h
+++ b/libs/drogon/include/fulla/drogon/services/DeviceCodeService.h
@@ -45,16 +45,9 @@ class DeviceCodeService
       std::function<void(bool)> &&callback
     );
 
-    /// Find a device code by its hash. Returns nullptr if not found.
-    /// Replaces: SELECT ... FROM oauth2_device_codes WHERE device_code_hash = $1
-    static void findByDeviceCodeHash(
-      const std::string &deviceCodeHash,
-      ::drogon::orm::DbClientPtr db,
-      std::function<void(std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes>)> &&callback
-    );
-
     /// Mark a device code as consumed (status = 'approved', set user_id).
     /// Replaces: UPDATE oauth2_device_codes SET status = 'approved', user_id = $1
+    /// callback(false) covers any DB failure along the find/update chain.
     static void markApproved(
       const std::string &deviceCodeHash,
       const std::string &userId,
@@ -62,11 +55,13 @@ class DeviceCodeService
       std::function<void(bool)> &&callback
     );
 
-    /// Find a device code by its user_code. Returns nullptr if not found.
+    /// Find a device code by its user_code.
+    /// callback(ok, row): ok=true + row -> found; ok=true + nullptr -> no such
+    /// user_code (0 rows / ambiguous rows); ok=false -> DB failure (logged).
     static void findByUserCode(
       const std::string &userCode,
       ::drogon::orm::DbClientPtr db,
-      std::function<void(std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes>)> &&callback
+      std::function<void(bool, std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes>)> &&callback
     );
 };
 

--- a/libs/drogon/include/fulla/drogon/services/DeviceCodeService.h
+++ b/libs/drogon/include/fulla/drogon/services/DeviceCodeService.h
@@ -47,12 +47,15 @@ class DeviceCodeService
 
     /// Mark a device code as consumed (status = 'approved', set user_id).
     /// Replaces: UPDATE oauth2_device_codes SET status = 'approved', user_id = $1
-    /// callback(false) covers any DB failure along the find/update chain.
+    /// callback(dbOk, found): dbOk=false -> DB failure along the find/update
+    /// chain (logged); found=false -> the device_code_hash row disappeared
+    /// between lookup and update (reclaimed/expired-cleanup); both true ->
+    /// approved.
     static void markApproved(
       const std::string &deviceCodeHash,
       const std::string &userId,
       ::drogon::orm::DbClientPtr db,
-      std::function<void(bool)> &&callback
+      std::function<void(bool, bool)> &&callback
     );
 
     /// Find a device code by its user_code.

--- a/libs/drogon/src/AuthService.cc
+++ b/libs/drogon/src/AuthService.cc
@@ -3,15 +3,38 @@
 #include <fulla/storage/postgres/models/Roles.h>
 #include <fulla/storage/postgres/models/UserRoles.h>
 #include <fulla/drogon/utils/PasswordHasher.h>
+#include <fulla/drogon/utils/CryptoUtils.h>
 #include <fulla/common/utils/EmailNormalizer.h>
 #include <drogon/utils/Utilities.h>
 #include <algorithm>
+#include <cctype>
 
 using namespace drogon;
 using namespace ::drogon::orm;
 
 namespace fulla::drogon::services
 {
+
+namespace
+{
+// U-2 (browser-e2e 2026-09-08): generated username for email-first
+// registrations that leave the username blank. Same shape as the identity
+// AuthService's generator ("user_<8 lowercase hex>", charset-safe for Rule.h
+// USERNAME_PATTERN); uniqueness is enforced by the users table and the
+// registerUser retry loop covers the rare collision.
+std::string generateUsername()
+{
+    // hashToken returns UPPERCASE hex; USERNAME_PATTERN allows mixed case,
+    // but lowercase matches the identity-side generator byte-for-byte.
+    std::string hex = fulla::drogon::utils::hashToken(
+      fulla::drogon::utils::generateSecureToken(32)
+    );
+    std::transform(hex.begin(), hex.end(), hex.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return "user_" + hex.substr(0, 8);
+}
+}  // namespace
 
 void AuthService::validateUser(
   const std::string &identifier,
@@ -198,27 +221,38 @@ void AuthService::registerUser(
         return;
     }
 
-    drogon_model::fulla_db::Users newUser;
-    // username is optional in email-first model: leave NULL when absent
-    // (CHECK constraint forbids empty string, so only set when non-empty)
-    if (!username.empty())
-        newUser.setUsername(username);
-    newUser.setPasswordHash(passwordHash);
-    newUser.setSalt(salt);
-    if (!email.empty())
-        newUser.setEmail(fulla::common::utils::normalizeEmail(email));
+    // U-2: deliver the registration form's "leave the username blank and one
+    // is generated" promise (previously stored NULL, which read back as ""
+    // in the account center and defeated the Danger Zone confirm guard).
+    const bool generatedUsername = username.empty();
+    auto currentUser = std::make_shared<std::string>(
+      generatedUsername ? generateUsername() : username
+    );
+    auto attempts = std::make_shared<int>(0);
+    auto attemptCreate = std::make_shared<std::function<void()>>();
 
-    try
-    {
-        auto db = app().getDbClient();
-        // Start Transaction? For now, just chain.
+    *attemptCreate = [sharedCb, salt, passwordHash, email, generatedUsername, currentUser,
+                      attempts, attemptCreate]() {
+        drogon_model::fulla_db::Users newUser;
+        // CHECK constraint forbids the empty string; generated names and
+        // user-typed names are both non-empty here.
+        newUser.setUsername(*currentUser);
+        newUser.setPasswordHash(passwordHash);
+        newUser.setSalt(salt);
+        if (!email.empty())
+            newUser.setEmail(fulla::common::utils::normalizeEmail(email));
 
-        auto mapper = Mapper<drogon_model::fulla_db::Users>(db);
+        try
+        {
+            auto db = app().getDbClient();
+            // Start Transaction? For now, just chain.
 
-        // Async Insert
-        mapper.insert(
-          newUser,
-          [sharedCb, db](const drogon_model::fulla_db::Users &u) {
+            auto mapper = Mapper<drogon_model::fulla_db::Users>(db);
+
+            // Async Insert
+            mapper.insert(
+              newUser,
+              [sharedCb, db](const drogon_model::fulla_db::Users &u) {
               // Assign Default Role "user"
               try
               {
@@ -272,14 +306,25 @@ void AuthService::registerUser(
                   (*sharedCb)("");
               }
           },
-          [sharedCb](const DrogonDbException &e) {
+          [sharedCb, generatedUsername, currentUser, attempts, attemptCreate](const DrogonDbException &e) {
               const std::string what = e.base().what();
               LOG_ERROR << "Register Failed: " << what;
               // Map the failing DB constraint to a structured Error_Code so the
               // controller can forward it verbatim. Username conflict is checked
               // before email so a simultaneous conflict reports username first.
               if (what.find("users_username_key") != std::string::npos)
+              {
+                  // A GENERATED name can collide with an existing one; retry
+                  // with a fresh name instead of surfacing "username taken"
+                  // to a user who never typed a username.
+                  if (generatedUsername && ++(*attempts) < 3)
+                  {
+                      *currentUser = generateUsername();
+                      (*attemptCreate)();
+                      return;
+                  }
                   (*sharedCb)("VALIDATION_USERNAME_TAKEN");
+              }
               else if (what.find("idx_users_email_unique") != std::string::npos)
                   (*sharedCb)("VALIDATION_EMAIL_TAKEN");
               else
@@ -297,6 +342,9 @@ void AuthService::registerUser(
         LOG_ERROR << "Register Init Unknown Exception";
         (*sharedCb)("INTERNAL_ERROR");
     }
+    };
+
+    (*attemptCreate)();
 }
 
 void AuthService::getUserInfo(

--- a/libs/drogon/src/AuthService.cc
+++ b/libs/drogon/src/AuthService.cc
@@ -34,6 +34,135 @@ std::string generateUsername()
     });
     return "user_" + hex.substr(0, 8);
 }
+
+// PR #180 review M1: one registration insert attempt. A plain function (not
+// a std::function stored in a shared_ptr) makes the retry a plain recursive
+// call — no self-referential shared_ptr exists, so there is no capture
+// cycle to reason about, and every capture below is a strong, hop-surviving
+// copy that releases when the chain terminates.
+void attemptRegistrationInsert(
+  const std::string &salt,
+  const std::string &passwordHash,
+  const std::string &email,
+  bool generatedUsername,
+  const std::shared_ptr<std::string> &currentUser,
+  const std::shared_ptr<int> &attempts,
+  const std::shared_ptr<std::function<void(const std::string &errorCode)>> &sharedCb
+)
+{
+    drogon_model::fulla_db::Users newUser;
+    // CHECK constraint forbids the empty string; generated names and
+    // user-typed names are both non-empty here.
+    newUser.setUsername(*currentUser);
+    newUser.setPasswordHash(passwordHash);
+    newUser.setSalt(salt);
+    if (!email.empty())
+        newUser.setEmail(fulla::common::utils::normalizeEmail(email));
+
+    try
+    {
+        auto db = app().getDbClient();
+        // Start Transaction? For now, just chain.
+
+        auto mapper = Mapper<drogon_model::fulla_db::Users>(db);
+
+        // Async Insert
+        mapper.insert(
+          newUser,
+          [sharedCb, db](const drogon_model::fulla_db::Users &u) {
+              // Assign Default Role "user"
+              try
+              {
+                  auto roleMapper = Mapper<drogon_model::fulla_db::Roles>(db);
+                  roleMapper.findOne(
+                    Criteria(
+                      drogon_model::fulla_db::Roles::Cols::_name, CompareOperator::EQ, "user"
+                    ),
+                    [sharedCb,
+                     db,
+                     userId = u.getValueOfId()](const drogon_model::fulla_db::Roles &role) {
+                        try
+                        {
+                            auto urMapper = Mapper<drogon_model::fulla_db::UserRoles>(db);
+                            drogon_model::fulla_db::UserRoles ur;
+                            ur.setUserId(userId);
+                            ur.setRoleId(role.getValueOfId());
+
+                            urMapper.insert(
+                              ur,
+                              [sharedCb](const drogon_model::fulla_db::UserRoles &) {
+                                  (*sharedCb)("");  // Success
+                              },
+                              [sharedCb](const DrogonDbException &e) {
+                                  // Recoverable: the user has already been
+                                  // created; role assignment is a side effect.
+                                  // WARN is correct (not ERROR) because the
+                                  // registration itself succeeds.
+                                  LOG_WARN << "Assign Role Failed: " << e.base().what();
+                                  (*sharedCb)("");  // Treat as success
+                                                    // for now (User
+                                                    // created), but log
+                                                    // warning
+                              }
+                            );
+                        }
+                        catch (...)
+                        {
+                            (*sharedCb)("");
+                        }
+                    },
+                    [sharedCb](const DrogonDbException &e) {
+                        // Recoverable: user created without a role.
+                        LOG_WARN << "Default Role 'user' not found: " << e.base().what();
+                        (*sharedCb)("");  // User created w/o role
+                    }
+                  );
+              }
+              catch (...)
+              {
+                  (*sharedCb)("");
+              }
+          },
+          [sharedCb, salt, passwordHash, email, generatedUsername, currentUser, attempts](
+            const DrogonDbException &e) {
+              const std::string what = e.base().what();
+              LOG_ERROR << "Register Failed: " << what;
+              // Map the failing DB constraint to a structured Error_Code so the
+              // controller can forward it verbatim. Username conflict is checked
+              // before email so a simultaneous conflict reports username first.
+              if (what.find("users_username_key") != std::string::npos)
+              {
+                  // A GENERATED name can collide with an existing one; retry
+                  // with a fresh name instead of surfacing "username taken"
+                  // to a user who never typed a username.
+                  if (generatedUsername && ++(*attempts) < 3)
+                  {
+                      *currentUser = generateUsername();
+                      attemptRegistrationInsert(
+                        salt, passwordHash, email, generatedUsername, currentUser, attempts, sharedCb
+                      );
+                      return;
+                  }
+                  (*sharedCb)("VALIDATION_USERNAME_TAKEN");
+              }
+              else if (what.find("idx_users_email_unique") != std::string::npos)
+                  (*sharedCb)("VALIDATION_EMAIL_TAKEN");
+              else
+                  (*sharedCb)("VALIDATION_INVALID_INPUT");  // unrecognized constraint
+          }
+        );
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR << "Register Init Failed: " << e.what();
+        (*sharedCb)("INTERNAL_ERROR");
+    }
+    catch (...)
+    {
+        LOG_ERROR << "Register Init Unknown Exception";
+        (*sharedCb)("INTERNAL_ERROR");
+    }
+}
 }  // namespace
 
 void AuthService::validateUser(
@@ -229,122 +358,7 @@ void AuthService::registerUser(
       generatedUsername ? generateUsername() : username
     );
     auto attempts = std::make_shared<int>(0);
-    auto attemptCreate = std::make_shared<std::function<void()>>();
-
-    *attemptCreate = [sharedCb, salt, passwordHash, email, generatedUsername, currentUser,
-                      attempts, attemptCreate]() {
-        drogon_model::fulla_db::Users newUser;
-        // CHECK constraint forbids the empty string; generated names and
-        // user-typed names are both non-empty here.
-        newUser.setUsername(*currentUser);
-        newUser.setPasswordHash(passwordHash);
-        newUser.setSalt(salt);
-        if (!email.empty())
-            newUser.setEmail(fulla::common::utils::normalizeEmail(email));
-
-        try
-        {
-            auto db = app().getDbClient();
-            // Start Transaction? For now, just chain.
-
-            auto mapper = Mapper<drogon_model::fulla_db::Users>(db);
-
-            // Async Insert
-            mapper.insert(
-              newUser,
-              [sharedCb, db](const drogon_model::fulla_db::Users &u) {
-              // Assign Default Role "user"
-              try
-              {
-                  auto roleMapper = Mapper<drogon_model::fulla_db::Roles>(db);
-                  roleMapper.findOne(
-                    Criteria(
-                      drogon_model::fulla_db::Roles::Cols::_name, CompareOperator::EQ, "user"
-                    ),
-                    [sharedCb,
-                     db,
-                     userId = u.getValueOfId()](const drogon_model::fulla_db::Roles &role) {
-                        try
-                        {
-                            auto urMapper = Mapper<drogon_model::fulla_db::UserRoles>(db);
-                            drogon_model::fulla_db::UserRoles ur;
-                            ur.setUserId(userId);
-                            ur.setRoleId(role.getValueOfId());
-
-                            urMapper.insert(
-                              ur,
-                              [sharedCb](const drogon_model::fulla_db::UserRoles &) {
-                                  (*sharedCb)("");  // Success
-                              },
-                              [sharedCb](const DrogonDbException &e) {
-                                  // Recoverable: the user has already been
-                                  // created; role assignment is a side effect.
-                                  // WARN is correct (not ERROR) because the
-                                  // registration itself succeeds.
-                                  LOG_WARN << "Assign Role Failed: " << e.base().what();
-                                  (*sharedCb)("");  // Treat as success
-                                                    // for now (User
-                                                    // created), but log
-                                                    // warning
-                              }
-                            );
-                        }
-                        catch (...)
-                        {
-                            (*sharedCb)("");
-                        }
-                    },
-                    [sharedCb](const DrogonDbException &e) {
-                        // Recoverable: user created without a role.
-                        LOG_WARN << "Default Role 'user' not found: " << e.base().what();
-                        (*sharedCb)("");  // User created w/o role
-                    }
-                  );
-              }
-              catch (...)
-              {
-                  (*sharedCb)("");
-              }
-          },
-          [sharedCb, generatedUsername, currentUser, attempts, attemptCreate](const DrogonDbException &e) {
-              const std::string what = e.base().what();
-              LOG_ERROR << "Register Failed: " << what;
-              // Map the failing DB constraint to a structured Error_Code so the
-              // controller can forward it verbatim. Username conflict is checked
-              // before email so a simultaneous conflict reports username first.
-              if (what.find("users_username_key") != std::string::npos)
-              {
-                  // A GENERATED name can collide with an existing one; retry
-                  // with a fresh name instead of surfacing "username taken"
-                  // to a user who never typed a username.
-                  if (generatedUsername && ++(*attempts) < 3)
-                  {
-                      *currentUser = generateUsername();
-                      (*attemptCreate)();
-                      return;
-                  }
-                  (*sharedCb)("VALIDATION_USERNAME_TAKEN");
-              }
-              else if (what.find("idx_users_email_unique") != std::string::npos)
-                  (*sharedCb)("VALIDATION_EMAIL_TAKEN");
-              else
-                  (*sharedCb)("VALIDATION_INVALID_INPUT");  // unrecognized constraint
-          }
-        );
-    }
-    catch (const std::exception &e)
-    {
-        LOG_ERROR << "Register Init Failed: " << e.what();
-        (*sharedCb)("INTERNAL_ERROR");
-    }
-    catch (...)
-    {
-        LOG_ERROR << "Register Init Unknown Exception";
-        (*sharedCb)("INTERNAL_ERROR");
-    }
-    };
-
-    (*attemptCreate)();
+    attemptRegistrationInsert(salt, passwordHash, email, generatedUsername, currentUser, attempts, sharedCb);
 }
 
 void AuthService::getUserInfo(

--- a/libs/drogon/src/controllers/DeviceAuthController.cc
+++ b/libs/drogon/src/controllers/DeviceAuthController.cc
@@ -387,8 +387,16 @@ void DeviceAuthController::approveDevice(
       userCode,
       dbClient,
       [sharedCb, userCode, req, userId, dbClient](
+        bool dbOk,
         std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes> code
       ) {
+          if (!dbOk)
+          {
+              respondError(
+                req, sharedCb, "DB_CONNECTION_ERROR", "approveDevice: device code lookup failed"
+              );
+              return;
+          }
           if (!code)
           {
               respondError(
@@ -428,10 +436,12 @@ void DeviceAuthController::approveDevice(
             [sharedCb, userCode, req](bool success) {
                 if (!success)
                 {
+                    // markApproved reports false only for DB failures (find or
+                    // update chain); the user_code itself was already validated.
                     respondError(
                       req,
                       sharedCb,
-                      "VALIDATION_DEVICE_CODE_INVALID",
+                      "DB_CONNECTION_ERROR",
                       "approveDevice: failed to approve device code"
                     );
                     return;

--- a/libs/drogon/src/controllers/DeviceAuthController.cc
+++ b/libs/drogon/src/controllers/DeviceAuthController.cc
@@ -433,16 +433,27 @@ void DeviceAuthController::approveDevice(
             code->getValueOfDeviceCodeHash(),
             userId,
             dbClient,
-            [sharedCb, userCode, req](bool success) {
-                if (!success)
+            [sharedCb, userCode, req](bool dbOk, bool found) {
+                if (!dbOk)
                 {
-                    // markApproved reports false only for DB failures (find or
-                    // update chain); the user_code itself was already validated.
                     respondError(
                       req,
                       sharedCb,
                       "DB_CONNECTION_ERROR",
                       "approveDevice: failed to approve device code"
+                    );
+                    return;
+                }
+                if (!found)
+                {
+                    // The row vanished between our lookup and the update
+                    // (reclaimed by cleanup) — a protocol-level miss, not an
+                    // infrastructure fault. (PR #180 review M4.)
+                    respondError(
+                      req,
+                      sharedCb,
+                      "VALIDATION_DEVICE_CODE_INVALID",
+                      "approveDevice: user_code no longer pending"
                     );
                     return;
                 }

--- a/libs/drogon/src/controllers/HealthController.cc
+++ b/libs/drogon/src/controllers/HealthController.cc
@@ -109,31 +109,43 @@ void HealthController::healthReady(
           "SELECT 1",
           [sharedCb](const ::drogon::orm::Result &) {
               // DB OK - check Redis
+              //
+              // Drogon's Redis client with no ready connection queues the
+              // PING (both callbacks attached) in an internal buffer and,
+              // on connect failure, only schedules a reconnect — the
+              // queued callbacks are never invoked. Guard readiness with
+              // a one-shot timeout so the endpoint always answers; first
+              // answer wins (CAS) and cancels the pending timer so a fast
+              // answer does not pin the response callback for the full
+              // budget (PR #180 review M5). Every branch — including the
+              // not-configured catch below — answers through the same
+              // guard, so the single-answer invariant is structural.
+              auto loop = ::drogon::app().getLoop();
+              auto responded = std::make_shared<std::atomic<bool>>(false);
+              auto timerId = std::make_shared<::trantor::TimerId>();
+              auto answer =
+                [sharedCb, responded, loop, timerId](bool redisOk, const char *redisState) {
+                    bool expected = false;
+                    if (!responded->compare_exchange_strong(expected, true))
+                        return;
+                    // invalidateTimer must run on the loop that owns the
+                    // timer; the redis callbacks may fire on another IO
+                    // thread. Cancelling an already-fired timer is a no-op.
+                    loop->runInLoop([loop, timerId]() {
+                        loop->invalidateTimer(*timerId);
+                    });
+                    Json::Value json;
+                    json["status"] = redisOk ? "ok" : "degraded";
+                    json["database"] = "connected";
+                    json["redis"] = redisState;
+                    auto resp = ::drogon::HttpResponse::newHttpJsonResponse(json);
+                    if (!redisOk)
+                        resp->setStatusCode(::drogon::k503ServiceUnavailable);
+                    (*sharedCb)(resp);
+                };
               try
               {
                   auto redis = ::drogon::app().getRedisClient("default");
-                  // Drogon's Redis client with no ready connection queues the
-                  // PING (both callbacks attached) in an internal buffer and,
-                  // on connect failure, only schedules a reconnect — the
-                  // queued callbacks are never invoked. Guard readiness with
-                  // a one-shot timeout so the endpoint always answers; first
-                  // answer wins, the losers no-op (health-status body contract
-                  // identical to the disconnected branch).
-                  auto responded = std::make_shared<std::atomic<bool>>(false);
-                  auto answer =
-                    [sharedCb, responded](bool redisOk, const char *redisState) {
-                        bool expected = false;
-                        if (!responded->compare_exchange_strong(expected, true))
-                            return;
-                        Json::Value json;
-                        json["status"] = redisOk ? "ok" : "degraded";
-                        json["database"] = "connected";
-                        json["redis"] = redisState;
-                        auto resp = ::drogon::HttpResponse::newHttpJsonResponse(json);
-                        if (!redisOk)
-                            resp->setStatusCode(::drogon::k503ServiceUnavailable);
-                        (*sharedCb)(resp);
-                    };
                   redis->execCommandAsync(
                     [answer](const ::drogon::nosql::RedisResult &) {
                         answer(true, "connected");
@@ -143,7 +155,7 @@ void HealthController::healthReady(
                     },
                     "PING"
                   );
-                  ::drogon::app().getLoop()->runAfter(
+                  *timerId = loop->runAfter(
                     2.0,
                     [answer]() { answer(false, "timeout"); }
                   );
@@ -151,11 +163,7 @@ void HealthController::healthReady(
               catch (...)
               {
                   // Redis not configured - that's OK for some deployments
-                  Json::Value json;
-                  json["status"] = "ok";
-                  json["database"] = "connected";
-                  json["redis"] = "not_configured";
-                  (*sharedCb)(::drogon::HttpResponse::newHttpJsonResponse(json));
+                  answer(true, "not_configured");
               }
           },
           [sharedCb](const ::drogon::orm::DrogonDbException &e) {

--- a/libs/drogon/src/controllers/HealthController.cc
+++ b/libs/drogon/src/controllers/HealthController.cc
@@ -3,6 +3,8 @@
 #include <drogon/drogon.h>
 #include <json/json.h>
 
+#include <atomic>
+
 namespace fulla::drogon::controllers
 {
 
@@ -110,24 +112,40 @@ void HealthController::healthReady(
               try
               {
                   auto redis = ::drogon::app().getRedisClient("default");
-                  redis->execCommandAsync(
-                    [sharedCb](const ::drogon::nosql::RedisResult &) {
+                  // Drogon's Redis client with no ready connection queues the
+                  // PING (both callbacks attached) in an internal buffer and,
+                  // on connect failure, only schedules a reconnect — the
+                  // queued callbacks are never invoked. Guard readiness with
+                  // a one-shot timeout so the endpoint always answers; first
+                  // answer wins, the losers no-op (health-status body contract
+                  // identical to the disconnected branch).
+                  auto responded = std::make_shared<std::atomic<bool>>(false);
+                  auto answer =
+                    [sharedCb, responded](bool redisOk, const char *redisState) {
+                        bool expected = false;
+                        if (!responded->compare_exchange_strong(expected, true))
+                            return;
                         Json::Value json;
-                        json["status"] = "ok";
+                        json["status"] = redisOk ? "ok" : "degraded";
                         json["database"] = "connected";
-                        json["redis"] = "connected";
-                        (*sharedCb)(::drogon::HttpResponse::newHttpJsonResponse(json));
-                    },
-                    [sharedCb](const std::exception &) {
-                        Json::Value json;
-                        json["status"] = "degraded";
-                        json["database"] = "connected";
-                        json["redis"] = "disconnected";
+                        json["redis"] = redisState;
                         auto resp = ::drogon::HttpResponse::newHttpJsonResponse(json);
-                        resp->setStatusCode(::drogon::k503ServiceUnavailable);
+                        if (!redisOk)
+                            resp->setStatusCode(::drogon::k503ServiceUnavailable);
                         (*sharedCb)(resp);
+                    };
+                  redis->execCommandAsync(
+                    [answer](const ::drogon::nosql::RedisResult &) {
+                        answer(true, "connected");
+                    },
+                    [answer](const std::exception &) {
+                        answer(false, "disconnected");
                     },
                     "PING"
+                  );
+                  ::drogon::app().getLoop()->runAfter(
+                    2.0,
+                    [answer]() { answer(false, "timeout"); }
                   );
               }
               catch (...)

--- a/libs/drogon/src/services/DeviceCodeService.cc
+++ b/libs/drogon/src/services/DeviceCodeService.cc
@@ -112,12 +112,12 @@ void DeviceCodeService::markApproved(
   const std::string &deviceCodeHash,
   const std::string &userId,
   ::drogon::orm::DbClientPtr db,
-  std::function<void(bool)> &&callback
+  std::function<void(bool, bool)> &&callback
 )
 {
-    // Same shared-callback discipline as findByUserCode: the callback is moved
-    // once; every lambda below captures the shared_ptr by value.
-    auto sharedCb = std::make_shared<std::function<void(bool)>>(std::move(callback));
+    // Same shared-callback discipline as findByUserCode: the callback is
+    // moved once; every lambda below captures the shared_ptr by value.
+    auto sharedCb = std::make_shared<std::function<void(bool, bool)>>(std::move(callback));
 
     try
     {
@@ -135,40 +135,48 @@ void DeviceCodeService::markApproved(
               {
                   Mapper<Oauth2DeviceCodes>(db).update(
                     updated,
-                    [sharedCb](const size_t) { (*sharedCb)(true); },
+                    [sharedCb](const size_t) { (*sharedCb)(true, true); },
                     [sharedCb](const DrogonDbException &e) {
                         LOG_ERROR << "DeviceCodeService::markApproved update failed: "
                                   << e.base().what();
-                        (*sharedCb)(false);
+                        (*sharedCb)(false, true);
                     }
                   );
               }
               catch (const std::exception &e)
               {
                   LOG_ERROR << "DeviceCodeService::markApproved update Exception: " << e.what();
-                  (*sharedCb)(false);
+                  (*sharedCb)(false, true);
               }
               catch (...)
               {
                   LOG_ERROR << "DeviceCodeService::markApproved update Unknown Exception";
-                  (*sharedCb)(false);
+                  (*sharedCb)(false, true);
               }
           },
           [sharedCb](const DrogonDbException &e) {
+              // Same distinction as findByUserCode (PR #180 review M4): the
+              // row vanishing between the caller's lookup and this update is
+              // a protocol-level miss, not an infrastructure fault.
+              if (dynamic_cast<const UnexpectedRows *>(&e) != nullptr)
+              {
+                  (*sharedCb)(true, false);
+                  return;
+              }
               LOG_ERROR << "DeviceCodeService::markApproved find failed: " << e.base().what();
-              (*sharedCb)(false);
+              (*sharedCb)(false, false);
           }
         );
     }
     catch (const std::exception &e)
     {
         LOG_ERROR << "DeviceCodeService::markApproved Exception: " << e.what();
-        (*sharedCb)(false);
+        (*sharedCb)(false, false);
     }
     catch (...)
     {
         LOG_ERROR << "DeviceCodeService::markApproved Unknown Exception";
-        (*sharedCb)(false);
+        (*sharedCb)(false, false);
     }
 }
 

--- a/libs/drogon/src/services/DeviceCodeService.cc
+++ b/libs/drogon/src/services/DeviceCodeService.cc
@@ -3,6 +3,7 @@
 #include <fulla/storage/postgres/models/Oauth2DeviceCodes.h>
 
 #include <drogon/drogon.h>
+#include <drogon/orm/Exception.h>
 
 namespace fulla::drogon::services
 {
@@ -57,38 +58,54 @@ void DeviceCodeService::createDeviceCode(
     }
 }
 
-void DeviceCodeService::findByDeviceCodeHash(
-  const std::string &deviceCodeHash,
-  ::drogon::orm::DbClientPtr db,
-  std::function<void(std::shared_ptr<Oauth2DeviceCodes>)> &&callback
-)
-{
-    Criteria crit(Oauth2DeviceCodes::Cols::_device_code_hash, CompareOperator::EQ, deviceCodeHash);
-    Mapper<Oauth2DeviceCodes> mapper(db);
-    mapper.findOne(
-      crit,
-      [cb = std::move(callback)](const Oauth2DeviceCodes &code) {
-          cb(std::make_shared<Oauth2DeviceCodes>(code));
-      },
-      [cb = std::move(callback)](const DrogonDbException &) { cb(nullptr); }
-    );
-}
-
 void DeviceCodeService::findByUserCode(
   const std::string &userCode,
   ::drogon::orm::DbClientPtr db,
-  std::function<void(std::shared_ptr<Oauth2DeviceCodes>)> &&callback
+  std::function<void(bool, std::shared_ptr<Oauth2DeviceCodes>)> &&callback
 )
 {
-    Criteria crit(Oauth2DeviceCodes::Cols::_user_code, CompareOperator::EQ, userCode);
-    Mapper<Oauth2DeviceCodes> mapper(db);
-    mapper.findOne(
-      crit,
-      [cb = std::move(callback)](const Oauth2DeviceCodes &code) {
-          cb(std::make_shared<Oauth2DeviceCodes>(code));
-      },
-      [cb = std::move(callback)](const DrogonDbException &) { cb(nullptr); }
-    );
+    // The callback is moved ONCE into a shared_ptr so both the row-found and
+    // exception lambdas hold a live copy. A previous version moved the same
+    // callback into each lambda; whichever lambda lost the race held an empty
+    // std::function, and calling it aborted the event loop (bad_function_call)
+    // — the crash formerly triggered by every /oauth2/device/approve miss.
+    auto sharedCb =
+      std::make_shared<std::function<void(bool, std::shared_ptr<Oauth2DeviceCodes>)>>(
+        std::move(callback)
+      );
+
+    try
+    {
+        Mapper<Oauth2DeviceCodes> mapper(db);
+        Criteria crit(Oauth2DeviceCodes::Cols::_user_code, CompareOperator::EQ, userCode);
+        mapper.findOne(
+          crit,
+          [sharedCb](const Oauth2DeviceCodes &code) {
+              (*sharedCb)(true, std::make_shared<Oauth2DeviceCodes>(code));
+          },
+          [sharedCb](const DrogonDbException &e) {
+              // findOne reports "no such row" (and "more than one row") as
+              // UnexpectedRows; that is a miss for the caller, not a DB fault.
+              if (dynamic_cast<const UnexpectedRows *>(&e) != nullptr)
+              {
+                  (*sharedCb)(true, nullptr);
+                  return;
+              }
+              LOG_ERROR << "DeviceCodeService::findByUserCode failed: " << e.base().what();
+              (*sharedCb)(false, nullptr);
+          }
+        );
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR << "DeviceCodeService::findByUserCode Exception: " << e.what();
+        (*sharedCb)(false, nullptr);
+    }
+    catch (...)
+    {
+        LOG_ERROR << "DeviceCodeService::findByUserCode Unknown Exception";
+        (*sharedCb)(false, nullptr);
+    }
 }
 
 void DeviceCodeService::markApproved(
@@ -98,28 +115,61 @@ void DeviceCodeService::markApproved(
   std::function<void(bool)> &&callback
 )
 {
-    Criteria crit(Oauth2DeviceCodes::Cols::_device_code_hash, CompareOperator::EQ, deviceCodeHash);
-    Mapper<Oauth2DeviceCodes> mapper(db);
-    mapper.findOne(
-      crit,
-      [db, userId, cb = std::move(callback)](const Oauth2DeviceCodes &code) {
-          Oauth2DeviceCodes updated = code;
-          updated.setUserId(userId);
-          updated.setStatus("approved");
-          Mapper<Oauth2DeviceCodes>(db).update(
-            updated,
-            [cb](const size_t) { cb(true); },
-            [cb](const DrogonDbException &e) {
-                LOG_ERROR << "DeviceCodeService::markApproved update failed: " << e.base().what();
-                cb(false);
-            }
-          );
-      },
-      [cb = std::move(callback)](const DrogonDbException &e) {
-          LOG_ERROR << "DeviceCodeService::markApproved find failed: " << e.base().what();
-          cb(false);
-      }
-    );
+    // Same shared-callback discipline as findByUserCode: the callback is moved
+    // once; every lambda below captures the shared_ptr by value.
+    auto sharedCb = std::make_shared<std::function<void(bool)>>(std::move(callback));
+
+    try
+    {
+        Mapper<Oauth2DeviceCodes> mapper(db);
+        Criteria crit(Oauth2DeviceCodes::Cols::_device_code_hash, CompareOperator::EQ, deviceCodeHash);
+        mapper.findOne(
+          crit,
+          [db, userId, sharedCb](const Oauth2DeviceCodes &code) {
+              Oauth2DeviceCodes updated = code;
+              updated.setUserId(userId);
+              updated.setStatus("approved");
+              // Async callback scope: needs its own Mapper try/catch — the
+              // outer one no longer covers us here (db-operations.md).
+              try
+              {
+                  Mapper<Oauth2DeviceCodes>(db).update(
+                    updated,
+                    [sharedCb](const size_t) { (*sharedCb)(true); },
+                    [sharedCb](const DrogonDbException &e) {
+                        LOG_ERROR << "DeviceCodeService::markApproved update failed: "
+                                  << e.base().what();
+                        (*sharedCb)(false);
+                    }
+                  );
+              }
+              catch (const std::exception &e)
+              {
+                  LOG_ERROR << "DeviceCodeService::markApproved update Exception: " << e.what();
+                  (*sharedCb)(false);
+              }
+              catch (...)
+              {
+                  LOG_ERROR << "DeviceCodeService::markApproved update Unknown Exception";
+                  (*sharedCb)(false);
+              }
+          },
+          [sharedCb](const DrogonDbException &e) {
+              LOG_ERROR << "DeviceCodeService::markApproved find failed: " << e.base().what();
+              (*sharedCb)(false);
+          }
+        );
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR << "DeviceCodeService::markApproved Exception: " << e.what();
+        (*sharedCb)(false);
+    }
+    catch (...)
+    {
+        LOG_ERROR << "DeviceCodeService::markApproved Unknown Exception";
+        (*sharedCb)(false);
+    }
 }
 
 }  // namespace fulla::drogon::services

--- a/libs/identity/src/AuthService.cc
+++ b/libs/identity/src/AuthService.cc
@@ -60,6 +60,17 @@ bool isLegacyHash(const std::string &storedHash)
     return storedHash.find("$pbkdf2-sha256$") != 0;
 }
 
+// U-2 (browser-e2e 2026-09-08): generated username for email-first
+// registrations that leave the username blank ("user_<8 lowercase hex>",
+// charset-safe for Rule.h USERNAME_PATTERN). Uniqueness is enforced by the
+// users table; the registerUser retry loop covers the rare collision.
+std::string generateUsername(fulla::common::ports::ICryptoProvider &crypto)
+{
+    unsigned char raw[4];
+    crypto.secureRandomBytes(raw, sizeof(raw));
+    return "user_" + bytesToHex(raw, sizeof(raw));
+}
+
 std::string hashPassword(
   const std::string &password,
   fulla::common::ports::ICryptoProvider &crypto
@@ -284,15 +295,42 @@ void AuthService::registerUser(
         return;
     }
 
-    UserData newUser;
-    newUser.username = username;
-    newUser.passwordHash = passwordHash;
-    newUser.salt = "";  // PBKDF2 embeds its own salt in the hash string
-    newUser.email = email;
+    // Value-capture the dependencies: async callbacks must not capture
+    // `this` (db-operations rule 4 -- do not rely on the instance's
+    // process-lifetime binding).
+    auto sharedCb =
+      std::make_shared<std::function<void(const std::string &errorCode)>>(std::move(callback));
+    auto crypto = crypto_;
+    auto userRepo = userRepo_;
 
-    userRepo_->create(
-      newUser,
-      [callback = std::move(callback)](std::optional<int32_t> newUserId, std::string errorCode) {
+    // U-2: deliver the registration form's "leave the username blank and one
+    // is generated" promise. Storing NULL instead made every empty-username
+    // account read username "" in the account center (Drogon maps a NULL
+    // column to ""), which defeated the Danger Zone confirm guard.
+    const bool generatedUsername = username.empty();
+    auto currentUser = std::make_shared<std::string>();
+    try
+    {
+        *currentUser = generatedUsername ? generateUsername(*crypto) : username;
+    }
+    catch (const std::exception &)
+    {
+        (*sharedCb)("INTERNAL_ERROR");
+        return;
+    }
+    auto attempts = std::make_shared<int>(0);
+    auto attemptCreate = std::make_shared<std::function<void()>>();
+
+    *attemptCreate = [sharedCb, crypto, userRepo, passwordHash, email, generatedUsername,
+                      currentUser, attempts, attemptCreate]() {
+        UserData newUser;
+        newUser.username = *currentUser;
+        newUser.passwordHash = passwordHash;
+        newUser.salt = "";  // PBKDF2 embeds its own salt in the hash string
+        newUser.email = email;
+
+        userRepo->create(
+          newUser,
           // IUserRepository::create() is responsible for default-role
           // assignment (repository-owned concern -- mirrors
           // OAuth2Server/AuthService.cc's registerUser, which assigns the
@@ -303,14 +341,37 @@ void AuthService::registerUser(
           // VALIDATION_USERNAME_TAKEN/VALIDATION_EMAIL_TAKEN) -- forward
           // verbatim, falling back to INTERNAL_ERROR only if the
           // repository didn't classify the failure.
-          if (newUserId)
-          {
-              callback("");
-              return;
+          [sharedCb, crypto, generatedUsername, currentUser, attempts, attemptCreate](
+            std::optional<int32_t> newUserId, std::string errorCode) {
+              if (newUserId)
+              {
+                  (*sharedCb)("");
+                  return;
+              }
+              // A GENERATED name can collide with an existing one; retry
+              // with a fresh name instead of surfacing "username taken" to
+              // a user who never typed a username.
+              if (errorCode == "VALIDATION_USERNAME_TAKEN" && generatedUsername &&
+                  ++(*attempts) < 3)
+              {
+                  try
+                  {
+                      *currentUser = generateUsername(*crypto);
+                  }
+                  catch (const std::exception &)
+                  {
+                      (*sharedCb)("INTERNAL_ERROR");
+                      return;
+                  }
+                  (*attemptCreate)();
+                  return;
+              }
+              (*sharedCb)(errorCode.empty() ? "INTERNAL_ERROR" : errorCode);
           }
-          callback(errorCode.empty() ? "INTERNAL_ERROR" : errorCode);
-      }
-    );
+        );
+    };
+
+    (*attemptCreate)();
 }
 
 void AuthService::getUserInfo(

--- a/libs/identity/src/AuthService.cc
+++ b/libs/identity/src/AuthService.cc
@@ -1,5 +1,6 @@
 #include <fulla/identity/AuthService.h>
 #include <fulla/identity/IUserRepository.h>
+#include <fulla/common/utils/EmailNormalizer.h>
 
 #include <algorithm>
 #include <sstream>
@@ -55,6 +56,76 @@ std::vector<unsigned char> hexToBytes(const std::string &hex)
     return bytes;
 }
 
+// PR #180 review M1: one registration insert attempt. A plain function (not
+// a std::function stored in a shared_ptr) makes the retry a plain recursive
+// call — no self-referential shared_ptr exists, so there is no capture
+// cycle to reason about, and every capture below is a strong, hop-surviving
+// copy that releases when the chain terminates.
+std::string generateUsername(fulla::common::ports::ICryptoProvider &crypto);
+
+void attemptRegistrationInsert(
+  const std::shared_ptr<IUserRepository> &userRepo,
+  const std::shared_ptr<fulla::common::ports::ICryptoProvider> &crypto,
+  const std::string &passwordHash,
+  const std::string &email,
+  bool generatedUsername,
+  const std::shared_ptr<std::string> &currentUser,
+  const std::shared_ptr<int> &attempts,
+  const std::shared_ptr<std::function<void(const std::string &errorCode)>> &sharedCb
+)
+{
+    UserData newUser;
+    newUser.username = *currentUser;
+    newUser.passwordHash = passwordHash;
+    newUser.salt = "";  // PBKDF2 embeds its own salt in the hash string
+    // Canonical form, mirroring the legacy path: storage, the unique index,
+    // and the (normalized) login lookup must agree. (PR #180 review M7.)
+    newUser.email = email.empty() ? std::string() : fulla::common::utils::normalizeEmail(email);
+
+    userRepo->create(
+      newUser,
+      // IUserRepository::create() is responsible for default-role
+      // assignment (repository-owned concern -- mirrors
+      // OAuth2Server/AuthService.cc's registerUser, which assigns the
+      // "user" role as part of the same transaction/continuation
+      // chain rather than as a separate caller-driven step). It is
+      // also responsible for classifying constraint-violation
+      // failures into structured Error_Codes (e.g.
+      // VALIDATION_USERNAME_TAKEN/VALIDATION_EMAIL_TAKEN) -- forward
+      // verbatim, falling back to INTERNAL_ERROR only if the
+      // repository didn't classify the failure.
+      [=](std::optional<int32_t> newUserId, std::string errorCode) {
+          if (newUserId)
+          {
+              (*sharedCb)("");
+              return;
+          }
+          // A GENERATED name can collide with an existing one; retry
+          // with a fresh name instead of surfacing "username taken" to
+          // a user who never typed a username.
+          if (errorCode == "VALIDATION_USERNAME_TAKEN" && generatedUsername &&
+              ++(*attempts) < 3)
+          {
+              try
+              {
+                  *currentUser = generateUsername(*crypto);
+              }
+              catch (const std::exception &)
+              {
+                  (*sharedCb)("INTERNAL_ERROR");
+                  return;
+              }
+              attemptRegistrationInsert(
+                userRepo, crypto, passwordHash, email, generatedUsername, currentUser, attempts,
+                sharedCb
+              );
+              return;
+          }
+          (*sharedCb)(errorCode.empty() ? "INTERNAL_ERROR" : errorCode);
+      }
+    );
+}
+
 bool isLegacyHash(const std::string &storedHash)
 {
     return storedHash.find("$pbkdf2-sha256$") != 0;
@@ -64,10 +135,17 @@ bool isLegacyHash(const std::string &storedHash)
 // registrations that leave the username blank ("user_<8 lowercase hex>",
 // charset-safe for Rule.h USERNAME_PATTERN). Uniqueness is enforced by the
 // users table; the registerUser retry loop covers the rare collision.
+// PR #180 review M2: secureRandomBytes leaves the buffer untouched on
+// failure (the contract TotpUtils.cc documents for its PR #157 review
+// finding), so the return value MUST be checked — an unchecked read draws
+// from uninitialized stack. Fail closed: registration surfaces
+// INTERNAL_ERROR rather than creating an account on a broken RNG. (The
+// legacy path is fail-closed too, via its fresh-UUID fallback.)
 std::string generateUsername(fulla::common::ports::ICryptoProvider &crypto)
 {
     unsigned char raw[4];
-    crypto.secureRandomBytes(raw, sizeof(raw));
+    if (!crypto.secureRandomBytes(raw, sizeof(raw)))
+        throw std::runtime_error("secureRandomBytes failed");
     return "user_" + bytesToHex(raw, sizeof(raw));
 }
 
@@ -186,10 +264,13 @@ void AuthService::validateUser(
     auto userRepo = userRepo_;
 
     // Login-identifier routing: contains '@' -> email lookup, else username.
-    // (Callers are expected to have normalized the email already, matching
-    // OAuth2Server/AuthService.cc's contract -- this service does not own
-    // email-normalization policy, which is deployment-specific.)
+    // Email identifiers are canonicalized before lookup (mirroring the
+    // legacy AuthService): registration stores the canonical form, so a
+    // mixed-case login input must not miss the row. Usernames stay
+    // case-sensitive by design. (PR #180 review M7.)
     bool isEmail = identifier.find('@') != std::string::npos;
+    const std::string lookupKey =
+      isEmail ? fulla::common::utils::normalizeEmail(identifier) : identifier;
 
     // Value-capture the policy flag: async callbacks must not capture
     // `this` (db-operations rule 4 -- do not rely on the instance's
@@ -266,7 +347,7 @@ void AuthService::validateUser(
     };
 
     if (isEmail)
-        userRepo_->findByEmail(identifier, std::move(onFound));
+        userRepo_->findByEmail(lookupKey, std::move(onFound));
     else
         userRepo_->findByUsername(identifier, std::move(onFound));
 }
@@ -319,59 +400,7 @@ void AuthService::registerUser(
         return;
     }
     auto attempts = std::make_shared<int>(0);
-    auto attemptCreate = std::make_shared<std::function<void()>>();
-
-    *attemptCreate = [sharedCb, crypto, userRepo, passwordHash, email, generatedUsername,
-                      currentUser, attempts, attemptCreate]() {
-        UserData newUser;
-        newUser.username = *currentUser;
-        newUser.passwordHash = passwordHash;
-        newUser.salt = "";  // PBKDF2 embeds its own salt in the hash string
-        newUser.email = email;
-
-        userRepo->create(
-          newUser,
-          // IUserRepository::create() is responsible for default-role
-          // assignment (repository-owned concern -- mirrors
-          // OAuth2Server/AuthService.cc's registerUser, which assigns the
-          // "user" role as part of the same transaction/continuation
-          // chain rather than as a separate caller-driven step). It is
-          // also responsible for classifying constraint-violation
-          // failures into structured Error_Codes (e.g.
-          // VALIDATION_USERNAME_TAKEN/VALIDATION_EMAIL_TAKEN) -- forward
-          // verbatim, falling back to INTERNAL_ERROR only if the
-          // repository didn't classify the failure.
-          [sharedCb, crypto, generatedUsername, currentUser, attempts, attemptCreate](
-            std::optional<int32_t> newUserId, std::string errorCode) {
-              if (newUserId)
-              {
-                  (*sharedCb)("");
-                  return;
-              }
-              // A GENERATED name can collide with an existing one; retry
-              // with a fresh name instead of surfacing "username taken" to
-              // a user who never typed a username.
-              if (errorCode == "VALIDATION_USERNAME_TAKEN" && generatedUsername &&
-                  ++(*attempts) < 3)
-              {
-                  try
-                  {
-                      *currentUser = generateUsername(*crypto);
-                  }
-                  catch (const std::exception &)
-                  {
-                      (*sharedCb)("INTERNAL_ERROR");
-                      return;
-                  }
-                  (*attemptCreate)();
-                  return;
-              }
-              (*sharedCb)(errorCode.empty() ? "INTERNAL_ERROR" : errorCode);
-          }
-        );
-    };
-
-    (*attemptCreate)();
+    attemptRegistrationInsert(userRepo, crypto, passwordHash, email, generatedUsername, currentUser, attempts, sharedCb);
 }
 
 void AuthService::getUserInfo(

--- a/libs/identity/test/AuthServiceTest.cc
+++ b/libs/identity/test/AuthServiceTest.cc
@@ -447,6 +447,111 @@ TEST_F(AuthServiceTest, GetUserInfoReturnsNulloptForUnknownUser)
     EXPECT_FALSE(info.has_value());
 }
 
+// U-2 (PR #180): blank-username registrations generate "user_<8 hex>".
+// These fakes drive the two new branches of that path: a generated-name
+// collision (retry) and RNG unavailability (fail-closed).
+namespace
+{
+class FlakyGeneratedNameRepository : public InMemoryUserRepository
+{
+  public:
+    void create(
+      const UserData &userData,
+      std::function<void(std::optional<int32_t>, std::string)> &&cb
+    ) override
+    {
+        if (
+          !userData.username.empty() && userData.username.rfind("user_", 0) == 0
+          && generatedCreateCalls_++ == 0
+        )
+        {
+            // First attempt at a generated name reports a collision; the
+            // retry must come back with a FRESH name and succeed.
+            cb(std::nullopt, "VALIDATION_USERNAME_TAKEN");
+            return;
+        }
+        if (!userData.username.empty() && userData.username.rfind("user_", 0) == 0)
+        {
+            ++generatedCreateCalls_;
+        }
+        InMemoryUserRepository::create(userData, std::move(cb));
+    }
+
+    int generatedCreateCalls() const
+    {
+        return generatedCreateCalls_;
+    }
+
+  private:
+    int generatedCreateCalls_ = 0;
+};
+
+class FailingRandomCrypto : public FakeCryptoProvider
+{
+  public:
+    bool secureRandomBytes(unsigned char * /*buffer*/, size_t /*length*/) override
+    {
+        return false;
+    }
+};
+}  // namespace
+
+TEST_F(AuthServiceTest, RegisterBlankUsernameRetriesOnGeneratedNameCollision)
+{
+    auto flakyRepo = std::make_shared<FlakyGeneratedNameRepository>();
+    service = std::make_unique<AuthService>(flakyRepo, crypto, clock);
+
+    std::string errorCode;
+    service->registerUser("", "pw", "retry@example.com", [&](const std::string &err) {
+        errorCode = err;
+    });
+    EXPECT_EQ(errorCode, "");
+    EXPECT_GE(flakyRepo->generatedCreateCalls(), 2);
+
+    // The surviving account is the RETRY's identity, reachable by email.
+    std::optional<AuthResult> login;
+    service->validateUser("retry@example.com", "pw", [&](std::optional<AuthResult> r) {
+        login = r;
+    });
+    EXPECT_TRUE(login.has_value());
+}
+
+TEST_F(AuthServiceTest, RegisterBlankUsernameFailsClosedWhenRandomUnavailable)
+{
+    crypto = std::make_shared<FailingRandomCrypto>();
+    service = std::make_unique<AuthService>(repo, crypto, clock);
+
+    std::string errorCode = "unset";
+    service->registerUser("", "pw", "rngfail@example.com", [&](const std::string &err) {
+        errorCode = err;
+    });
+    EXPECT_EQ(errorCode, "INTERNAL_ERROR");
+
+    // Fail-closed: no account exists.
+    std::optional<AuthResult> login;
+    service->validateUser("rngfail@example.com", "pw", [&](std::optional<AuthResult> r) {
+        login = r;
+    });
+    EXPECT_FALSE(login.has_value());
+}
+
+// PR #180 review M7: both registration and login canonicalize the email,
+// so a mixed-case registration is reachable from any-case input.
+TEST_F(AuthServiceTest, RegisterNormalizesEmailAndCaseInsensitiveLogin)
+{
+    std::string errorCode;
+    service->registerUser("dana", "pw", "Dana@Example.COM", [&](const std::string &err) {
+        errorCode = err;
+    });
+    ASSERT_EQ(errorCode, "");
+
+    std::optional<AuthResult> login;
+    service->validateUser("dana@example.com", "pw", [&](std::optional<AuthResult> r) {
+        login = r;
+    });
+    EXPECT_TRUE(login.has_value());
+}
+
 // Task 24 slice 4 (fulla-sdk-refactor): AuthService::registerUser must
 // forward the repository's structured Error_Code verbatim (not collapse
 // every failure into a generic code) -- mirrors OAuth2Server/

--- a/scripts/backend/run_server.bat
+++ b/scripts/backend/run_server.bat
@@ -36,10 +36,17 @@ if exist "%PRESET_DIR%\conanrun.bat" (
     echo [Warning] conanrun.bat not found in build directory.
 )
 
+REM cmd's `if exist` mishandles the forward slashes used by paths.env values
+REM (SERVER_BUILD_SUBDIR=apps/server): the exe exists yet the check reports
+REM "not found" (M-4, browser-e2e 2026-09-08). Normalize to backslashes first
+REM (same fix build.bat applies for its copy commands).
 set "EXE_PATH=%PRESET_DIR%\%SERVER_BUILD_SUBDIR%\%BUILD_TYPE%\%SERVER_BINARY_NAME%.exe"
+set "EXE_PATH=%EXE_PATH:/=\%"
+set "EXE_RUN_DIR=%PRESET_DIR%\%SERVER_BUILD_SUBDIR%\%BUILD_TYPE%"
+set "EXE_RUN_DIR=%EXE_RUN_DIR:/=\%"
 if exist "%EXE_PATH%" (
     echo Starting %SERVER_BINARY_NAME% (%BUILD_TYPE%)
-    cd /d "%PRESET_DIR%\%SERVER_BUILD_SUBDIR%\%BUILD_TYPE%"
+    cd /d "%EXE_RUN_DIR%"
     %SERVER_BINARY_NAME%.exe
 ) else (
     echo [Error] %SERVER_BINARY_NAME%.exe not found at %EXE_PATH%.

--- a/tests/integration/auth/RegistrationWithoutUsernameTest.cc
+++ b/tests/integration/auth/RegistrationWithoutUsernameTest.cc
@@ -1,16 +1,29 @@
 #include <drogon/drogon_test.h>
 #include <drogon/drogon.h>
+#include <drogon/utils/Utilities.h>
 #include <fulla/drogon/plugin/OAuth2Plugin.h>
+#include <fulla/drogon/utils/CryptoUtils.h>
 #include <fulla/storage/postgres/models/Users.h>
 #include <fulla/common/utils/EmailNormalizer.h>
-#include <future>
+#include "HttpTestClient.h"
 #include <chrono>
+#include <future>
+#include <regex>
+#include <string>
 
 using namespace drogon;
 using namespace drogon::orm;
 
 namespace
 {
+// Throwaway credential minted at runtime for the dedicated test user (fresh
+// per run; nothing reusable leaves the process).
+const std::string &registrationPassword()
+{
+    static const std::string v = fulla::drogon::utils::generateSecureToken(12) + "aA1!";
+    return v;
+}
+
 // Drop any leftover row so the unique-email index (V019) doesn't trip reuse.
 void cleanupEmail(const std::string &email)
 {
@@ -28,10 +41,14 @@ void cleanupEmail(const std::string &email)
 }
 }  // namespace
 
-// Covers Finding 1 (JSON body) + Finding 5 (missing test):
-// an email-only registration via JSON persists username as NULL and a
-// canonical email, with a non-empty password hash.
-DROGON_TEST(Integration_P1_Registration_EmailOnly_JsonBody)
+// U-2 (browser-e2e 2026-09-08): the registration form promises "leave the
+// username blank and one is generated for you". The service used to store
+// NULL instead (email-first), which read back as "" in the account center
+// and defeated the Danger Zone confirm guard. The contract is now: an
+// email-only registration persists a GENERATED username of the shape
+// user_<8 lowercase hex> (charset-valid for Rule.h USERNAME_PATTERN) plus a
+// canonical email — never NULL.
+DROGON_TEST(Integration_P1_Registration_EmailOnly_GeneratesUsername)
 {
     auto plugin = app().getPlugin<OAuth2Plugin>();
     if (!plugin || plugin->getStorageType() == "memory")
@@ -41,44 +58,50 @@ DROGON_TEST(Integration_P1_Registration_EmailOnly_JsonBody)
     }
     auto db = app().getDbClient();
     REQUIRE(db != nullptr);
+    if (!fulla::test::http::serverReachable())
+    {
+        CHECK(true);
+        return;
+    }
 
-    const std::string rawEmail = "Alice+promo@Example.COM";
-    const std::string canonical = fulla::common::utils::normalizeEmail(rawEmail);
+    const std::string uniqueRun = std::to_string(
+      std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+      )
+        .count()
+    );
+    const std::string rawEmail = "AliceU2" + uniqueRun + "@Example.COM";
     cleanupEmail(rawEmail);
 
-    // Insert the way AuthService::registerUser would (validate the contract):
-    // username omitted -> NULL; email normalized; password hashed non-empty.
-    drogon_model::fulla_db::Users u;
-    u.setPasswordHash("$argon2id$placeholder$notempty");  // shape only
-    u.setSalt("");
-    u.setEmail(canonical);
-    // username deliberately NOT set (NULL)
-
-    std::promise<bool> pIns;
-    Mapper<drogon_model::fulla_db::Users>(db).insert(
-      u,
-      [&](const drogon_model::fulla_db::Users &) { pIns.set_value(true); },
-      [&](const DrogonDbException &e) {
-          LOG_ERROR << "insert failed: " << e.base().what();
-          pIns.set_value(false);
-      }
+    // Real registration path: POST /api/register with no username field.
+    const std::string form =
+      "email=" + drogon::utils::urlEncodeComponent(rawEmail) +
+      "&password=" + registrationPassword();
+    auto resp = fulla::test::http::sendPostForm("/api/register", form);
+    REQUIRE(resp != nullptr);
+    CHECK(
+      (resp->getStatusCode() == k200OK || resp->getStatusCode() == k201Created)
     );
-    REQUIRE(pIns.get_future().get() == true);
 
-    // Verify stored shape
+    // Verify stored shape: generated username + case-insensitive email match
+    // (the wired identity registration path stores the email verbatim; the
+    // legacy fallback normalizes — accept either, compare lowercased).
     std::promise<bool> pRead;
     db->execSqlAsync(
-      "SELECT username, email FROM users WHERE email = $1",
+      "SELECT username, lower(email) AS email_lc FROM users WHERE lower(email) = lower($1)",
       [&](const Result &r) {
           bool ok = !r.empty();
           if (ok)
-              ok = r[0]["username"].isNull();
+              ok = !r[0]["username"].isNull();
           if (ok)
-              ok = r[0]["email"].as<std::string>() == canonical;
+          {
+              const std::regex generatedPattern("^user_[0-9a-f]{8}$");
+              ok = std::regex_match(r[0]["username"].as<std::string>(), generatedPattern);
+          }
           pRead.set_value(ok);
       },
       [&](const DrogonDbException &) { pRead.set_value(false); },
-      canonical
+      rawEmail
     );
     CHECK(pRead.get_future().get() == true);
 

--- a/tests/integration/auth/RegistrationWithoutUsernameTest.cc
+++ b/tests/integration/auth/RegistrationWithoutUsernameTest.cc
@@ -83,12 +83,14 @@ DROGON_TEST(Integration_P1_Registration_EmailOnly_GeneratesUsername)
       (resp->getStatusCode() == k200OK || resp->getStatusCode() == k201Created)
     );
 
-    // Verify stored shape: generated username + case-insensitive email match
-    // (the wired identity registration path stores the email verbatim; the
-    // legacy fallback normalizes — accept either, compare lowercased).
+    // Verify stored shape: generated username + CANONICAL email (both
+    // registration paths normalize; PR #180 review M7 restored this
+    // assertion once the identity path normalized too, and V031 backfills
+    // pre-existing rows).
+    const std::string usedEmail = fulla::common::utils::normalizeEmail(rawEmail);
     std::promise<bool> pRead;
     db->execSqlAsync(
-      "SELECT username, lower(email) AS email_lc FROM users WHERE lower(email) = lower($1)",
+      "SELECT username, email FROM users WHERE email = $1",
       [&](const Result &r) {
           bool ok = !r.empty();
           if (ok)
@@ -98,10 +100,12 @@ DROGON_TEST(Integration_P1_Registration_EmailOnly_GeneratesUsername)
               const std::regex generatedPattern("^user_[0-9a-f]{8}$");
               ok = std::regex_match(r[0]["username"].as<std::string>(), generatedPattern);
           }
+          if (ok)
+              ok = r[0]["email"].as<std::string>() == usedEmail;
           pRead.set_value(ok);
       },
       [&](const DrogonDbException &) { pRead.set_value(false); },
-      rawEmail
+      usedEmail
     );
     CHECK(pRead.get_future().get() == true);
 

--- a/tests/integration/controllers/DeviceAuthEndpointHttpTest.cc
+++ b/tests/integration/controllers/DeviceAuthEndpointHttpTest.cc
@@ -13,14 +13,18 @@
 //
 // Route map (DeviceAuthController.h):
 //   POST /oauth2/device_authorization -> deviceAuthorization (no auth)
-//   POST /oauth2/device/approve       -> approveDevice (admin-gated, not here)
+//   POST /oauth2/device/approve       -> approveDevice (admin-gated; covered
+//                                         by the two tests at the bottom)
 
 #include <drogon/drogon_test.h>
 #include <drogon/drogon.h>
+#include <fulla/drogon/utils/CryptoUtils.h>
 #include <json/json.h>
 
 #include "HttpTestClient.h"
 
+#include <chrono>
+#include <future>
 #include <string>
 
 using fulla::test::http::loginAsAdmin;
@@ -113,4 +117,148 @@ DROGON_TEST(Integration_P1_DeviceAuth_UnknownClientId_Returns4xxError)
     Json::Value body;
     REQUIRE(parseJsonBody(resp, body));
     CHECK(body.isMember("error"));
+}
+
+// ---------------------------------------------------------------------------
+// Helpers shared by the /oauth2/device/approve tests below (admin-gated leg
+// of RFC 8628). Seeding mirrors DeviceCodeRaceConditionTest: direct SQL on
+// oauth2_device_codes + the idempotent PUBLIC device-flow client.
+// ---------------------------------------------------------------------------
+namespace
+{
+constexpr const char *kApprovePubClient = "p1-test-pub-device";
+
+bool approveExecSql(const std::string &sql)
+{
+    auto db = drogon::app().getDbClient();
+    if (!db)
+        return false;
+    // Sync-from-async bridge; the migrations/tests elsewhere already rely on
+    // the test DB client being alive for the process lifetime.
+    std::promise<bool> p;
+    db->execSqlAsync(
+      sql,
+      [&](const drogon::orm::Result &) { p.set_value(true); },
+      [&](const drogon::orm::DrogonDbException &e) {
+          LOG_ERROR << "execSql failed: " << e.base().what() << " :: " << sql;
+          p.set_value(false);
+      }
+    );
+    return p.get_future().get();
+}
+
+bool approveEnsurePubDeviceClient()
+{
+    return approveExecSql(
+      "INSERT INTO oauth2_clients "
+      "(client_id, client_type, client_secret, salt, name, redirect_uris, "
+      "allowed_grant_types) VALUES ('" +
+      std::string(kApprovePubClient) +
+      "', 'PUBLIC', '', '', 'P1 test public device client', '', "
+      "'urn:ietf:params:oauth:grant-type:device_code') "
+      "ON CONFLICT (client_id) DO NOTHING"
+    );
+}
+
+// Seeds a PENDING device code and returns its user_code via the out-param.
+bool approveSeedPendingCode(const std::string &rawDeviceCode, const std::string &userCode)
+{
+    const std::string hash = fulla::drogon::utils::hashToken(rawDeviceCode);
+    const int64_t expiresAt = std::chrono::duration_cast<std::chrono::seconds>(
+                                std::chrono::system_clock::now().time_since_epoch()
+                              )
+                                .count() +
+                              3600;
+    if (!approveExecSql("DELETE FROM oauth2_device_codes WHERE device_code_hash = '" + hash + "'"))
+        return false;
+    return approveExecSql(
+      "INSERT INTO oauth2_device_codes "
+      "(device_code_hash, user_code, client_id, scope, status, expires_at) VALUES ('" +
+      hash + "', '" + userCode + "', '" + kApprovePubClient + "', 'read', 'pending', " +
+      std::to_string(expiresAt) + ")"
+    );
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// approve + unknown user_code: must return 400 VALIDATION_DEVICE_CODE_INVALID
+// and — critically — the server must STILL BE ALIVE afterwards. This is the
+// regression test for the 2026-09-08 crash where the same callback was
+// std::move'd into both Mapper::findOne lambdas; the loser held an empty
+// std::function and calling it aborted the event loop (bad_function_call),
+// killing the process on every approval miss.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P0_DeviceAuth_ApproveUnknownUserCode_Returns400_ServerSurvives)
+{
+    DEVICEAUTH_SKIP_GUARD;
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    auto resp = sendPostForm(
+      "/oauth2/device/approve",
+      "user_code=NOSUCH77&user_id=1",
+      *token);
+    REQUIRE(resp != nullptr);
+    CHECK(statusIs(resp, drogon::k400BadRequest));
+    Json::Value body;
+    REQUIRE(parseJsonBody(resp, body));
+    CHECK(body["error"]["code"].asString() == "VALIDATION_DEVICE_CODE_INVALID");
+
+    // Server liveness: a subsequent request must still be served. Before the
+    // fix this (and any other request after the approval miss) got nothing —
+    // the process was gone.
+    auto followUp = sendPostForm(
+      "/oauth2/device_authorization",
+      "client_id=admin-console&scope=openid");
+    REQUIRE(followUp != nullptr);
+    CHECK(
+      (followUp->getStatusCode() == drogon::k200OK ||
+       followUp->getStatusCode() == drogon::k201Created)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// approve happy path, closed through the token endpoint (browser-e2e scenario
+// C3): seed a pending device_code -> admin approves via
+// /oauth2/device/approve -> the device redeems device_code at /oauth2/token
+// (device_code grant) and gets an access token.
+// ---------------------------------------------------------------------------
+DROGON_TEST(Integration_P0_DeviceAuth_ApprovePendingCode_ThenDeviceRedeemsToken)
+{
+    DEVICEAUTH_SKIP_GUARD;
+
+    REQUIRE(approveEnsurePubDeviceClient());
+
+    const std::string deviceCode = "p0-approve-device-code-fixed";
+    // user_code is VARCHAR(8) in the schema — keep the marker 8 chars.
+    const std::string userCode = "APRVTS01";
+    REQUIRE(approveSeedPendingCode(deviceCode, userCode));
+
+    auto token = loginAsAdmin();
+    REQUIRE(token.has_value());
+
+    auto approveResp = sendPostForm(
+      "/oauth2/device/approve",
+      "user_code=" + userCode + "&user_id=1",
+      *token);
+    REQUIRE(approveResp != nullptr);
+    CHECK(statusIs(approveResp, drogon::k200OK));
+    Json::Value approveBody;
+    REQUIRE(parseJsonBody(approveResp, approveBody));
+    CHECK(approveBody["status"].asString() == "approved");
+    CHECK(approveBody["user_code"].asString() == userCode);
+
+    // Device leg: poll-style single redemption of the approved device_code.
+    auto tokenResp = sendPostForm(
+      "/oauth2/token",
+      "grant_type=urn:ietf:params:oauth:grant-type:device_code"
+      "&device_code=" +
+        deviceCode + "&client_id=" + kApprovePubClient);
+    REQUIRE(tokenResp != nullptr);
+    CHECK(statusIs(tokenResp, drogon::k200OK));
+    Json::Value tokenBody;
+    REQUIRE(parseJsonBody(tokenResp, tokenBody));
+    CHECK(tokenBody.isMember("access_token"));
+    CHECK(tokenBody.isMember("refresh_token"));
 }

--- a/tests/integration/controllers/DeviceAuthEndpointHttpTest.cc
+++ b/tests/integration/controllers/DeviceAuthEndpointHttpTest.cc
@@ -261,4 +261,13 @@ DROGON_TEST(Integration_P0_DeviceAuth_ApprovePendingCode_ThenDeviceRedeemsToken)
     REQUIRE(parseJsonBody(tokenResp, tokenBody));
     CHECK(tokenBody.isMember("access_token"));
     CHECK(tokenBody.isMember("refresh_token"));
+
+    // Teardown (PR #180 review M8): remove the seeded row so row-count
+    // sensitive assertions elsewhere see no residue. The redeemed tokens
+    // stay, consistent with the other device-code tests (the shared
+    // p1-test-pub-device client must also survive — DeviceCodeRaceCondition
+    // tests reuse it via their own idempotent ensure()).
+    CHECK(approveExecSql(
+      "DELETE FROM oauth2_device_codes WHERE user_code = '" + userCode + "'"
+    ));
 }

--- a/tests/unit/config/ConfigManagerTest.cc
+++ b/tests/unit/config/ConfigManagerTest.cc
@@ -175,6 +175,33 @@ DROGON_TEST(Unit_P0_ConfigManager_EnvOverride_VueRedirect_ByNameLookup)
     unsetenv("FULLA_VUE_REDIRECT_URI");
 }
 
+// Companion to the redirect_uri case above: FULLA_VUE_CLIENT_SECRET must land on
+// the same plugin client entry. Regression guard for the override having been
+// declared against a non-existent top-level "vue_client.secret" path, which made
+// ConfigManager::applyEnvOverrides a silent no-op.
+DROGON_TEST(Unit_P0_ConfigManager_EnvOverride_VueClientSecret_ByNameLookup)
+{
+    setenv("FULLA_VUE_CLIENT_SECRET", "prod-strong-vue-secret", 1);
+
+    std::string configPath = "./config.json";
+    if (!std::filesystem::exists(configPath))
+        configPath = "../config.json";
+    if (!std::filesystem::exists(configPath))
+        configPath = "../../config.json";
+    if (!std::filesystem::exists(configPath))
+        configPath = "../../../config.json";
+
+    Json::Value config;
+    CHECK(fulla::common::config::ConfigManager::load(configPath, config) == true);
+
+    auto secret = fulla::common::config::ConfigManager::get<std::string>(
+      config, "plugins[name=OAuth2Plugin].config.clients.vue-client.secret"
+    );
+    CHECK(secret == "prod-strong-vue-secret");
+
+    unsetenv("FULLA_VUE_CLIENT_SECRET");
+}
+
 
 // ============================================================================
 // #102: production-mode signing-key and weak-secret gates

--- a/tools/api-diff/api-baseline.txt
+++ b/tools/api-diff/api-baseline.txt
@@ -3094,7 +3094,7 @@ static void markApproved(
 const std::string &deviceCodeHash,
 const std::string &userId,
 ::drogon::orm::DbClientPtr db,
-std::function<void(bool)> &&callback
+std::function<void(bool, bool)> &&callback
 );
 static void findByUserCode(
 const std::string &userCode,

--- a/tools/api-diff/api-baseline.txt
+++ b/tools/api-diff/api-baseline.txt
@@ -59,7 +59,9 @@ inline const std::vector<EnvOverride> FULLA_ENV_OVERRIDES =
 {"custom_config.external_auth.wechat.appid", "FULLA_WECHAT_APPID", false},
 {"custom_config.external_auth.wechat.secret", "FULLA_WECHAT_SECRET", false},
 {"listeners.0.port", "FULLA_LISTEN_PORT", true},
-{"vue_client.secret", "FULLA_VUE_CLIENT_SECRET", false},
+{"plugins[name=OAuth2Plugin].config.clients.vue-client.secret",
+"FULLA_VUE_CLIENT_SECRET",
+false},
 {"plugins[name=OAuth2Plugin].config.clients.vue-client.redirect_uri",
 "FULLA_VUE_REDIRECT_URI",
 false},
@@ -3088,11 +3090,6 @@ int32_t intervalSeconds,
 ::drogon::orm::DbClientPtr db,
 std::function<void(bool)> &&callback
 );
-static void findByDeviceCodeHash(
-const std::string &deviceCodeHash,
-::drogon::orm::DbClientPtr db,
-std::function<void(std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes>)> &&callback
-);
 static void markApproved(
 const std::string &deviceCodeHash,
 const std::string &userId,
@@ -3102,7 +3099,7 @@ std::function<void(bool)> &&callback
 static void findByUserCode(
 const std::string &userCode,
 ::drogon::orm::DbClientPtr db,
-std::function<void(std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes>)> &&callback
+std::function<void(bool, std::shared_ptr<::drogon_model::fulla_db::Oauth2DeviceCodes>)> &&callback
 );
 };
 }

--- a/tools/migration-check/baseline.json
+++ b/tools/migration-check/baseline.json
@@ -27,5 +27,7 @@
   "V026__token_redundant_index_cleanup.sql": "fc1bc4c51737c20deab14b07fd1719770baad78c7251908776e4fa68cac8464d",
   "V027__local_subject_mapping_backfill.sql": "5965f1553c53b6e3a05cfe7ad1dda7f9a34154b80c3f29338a5ea55835248bc8",
   "V028__webauthn_purge_unverified_credentials.sql": "4419bb7ea8ad1c54fb759e10d47153087919ba5c3b408dcbd4d3494383aeb970",
-  "V029__users_must_change_password.sql": "88bb480064d45eec4eaa7c67d455293ce543c8771c82264a562e7db641fd63a2"
+  "V029__users_must_change_password.sql": "88bb480064d45eec4eaa7c67d455293ce543c8771c82264a562e7db641fd63a2",
+  "V030__backfill_generated_usernames.sql": "361c1d123b1c4bb0f852379e9ca00f8310d2ca94ab1d4c8a0c58c5453ac8cc54",
+  "V031__normalize_user_emails.sql": "9a73f57e63a72d841ee4640e95bef3f954943de042c9400517c1cefd60a8b126"
 }

--- a/tools/refactor-baseline/fixtures/ctest-N.sample.txt
+++ b/tools/refactor-baseline/fixtures/ctest-N.sample.txt
@@ -1,4 +1,4 @@
-Test project D:/work/development/Repos/backend/drogon-plugin/fulla/build/OAuth2Server
+Test project build/OAuth2Server
   Test #1: AuthServiceGetUserInfoTest
   Test #2: ErrorHandlerTest
   Test #3: OpenApiGeneratorTest

--- a/tools/refactor-baseline/fixtures/ctest-pass.sample.txt
+++ b/tools/refactor-baseline/fixtures/ctest-pass.sample.txt
@@ -1,4 +1,4 @@
-Test project D:/work/development/Repos/backend/drogon-plugin/fulla/build/OAuth2Server
+Test project build/OAuth2Server
     Start  1: AuthServiceGetUserInfoTest
 1/10 Test  #1: AuthServiceGetUserInfoTest .........   Passed    0.31 sec
     Start  2: ErrorHandlerTest


### PR DESCRIPTION
## Summary

Fixes the bug list from the 2026-09-08 full browser E2E pass (report in `docs-local/browser-e2e/2026-09-08-test-report.md`, 74 steps / 69 pass). Every touched behavior was re-verified end-to-end against real frontends + backend; the previously **blocked device-flow scenario (C3)** now passes its full closure.

### P0

- **A-2 [CRITICAL] server crash on device approval** — `DeviceCodeService` moved the same callback into both `Mapper::findOne` lambdas (`findByUserCode`, `markApproved`, dead `findByDeviceCodeHash`); the loser held an empty `std::function` → `bad_function_call` escaped the event loop and killed the process on **every** approval miss. Fixed with the shared-callback pattern (same as `createDeviceCode` in f1f418b5), DB faults now distinguishable from "code not found" (`DB_CONNECTION_ERROR` vs `VALIDATION_DEVICE_CODE_INVALID`), dead function removed, and the admin approve leg gets its first integration coverage (invalid-code-survives + approve→redeem closure).
- **U-3 anonymous OAuth flow never resumed after login** — `/oauth2/authorize` bounces anonymous users to `/login` with the OAuth params flattened (no `redirect`); login used to land on the dashboard and the relying party never got its code. LoginPage now rebuilds the authorize URL from those params (whitelisted keys, PKCE triple + nonce preserved) for both password and MFA branches.
- **U-2 one-click self-deletion for blank-username accounts** — registration promised auto-generated usernames but stored NULL; `profile.username === ''` made the Danger Zone confirm guard match empty input. Backend now generates `user_<8 hex>` (both registration paths, collision retry), **V030** backfills existing NULL rows, and the frontend guard rejects empty confirm input outright.

### P1

- **A-1 `/health/ready` hung forever when Redis was configured but unreachable** (Drogon queues the PING and never fires its callbacks on connect failure) — 2s one-shot timeout guard answering 503 `degraded/timeout`; the admin dashboard decouples stats from readiness (allSettled + timeouts + 503 bodies accepted) so the cards always render.
- **U-6 MFA lockout from redirect_uri drift** (`localhost` in `.env` vs `127.0.0.1` in the seed; the MFA verify leg strictly validates) — seed + dev configs register both loopback spellings; a fresh clone no longer reproduces. Error-code mapping intentionally unchanged (ADR-0007 mandates the unified `AUTH_INVALID_CREDENTIALS` anti-enumeration contract).
- **U-1 zombie session after password change** — the SPA now drops local state and lands on `/login?pw_changed=1` with a notice; the guest guard restores the session before bouncing.

### P2

- **U-4** CallbackPage no longer burns one-time codes of externally-initiated flows (only redeems with its own stashed PKCE verifier; otherwise shows a "return to your app" notice).
- **U-5** MFA setup renders the backend's `otpauth_uri` as a QR code (qrcode.vue; size gate passes without a baseline raise).
- **M-1** for/id + aria-labels on the security/login inputs; **M-3** passkey failures classified instead of "network connection failed"; **M-4** run_server.bat forward-slash `if exist` fix.

### Not fixed, with evidence

- **M-2** by design per ADR-0007 (anti-enumeration). **M-5** pagination UI exists (48 < perPage 50). **M-7** roles-save banner already present (`UserDetailPage.vue:107`). **M-6** "Revoke All for User" is a filter-bar button gated on a typed `user_id` filter, not a dropdown entry — works as designed (screenshot evidence), noted for discoverability.

## Test plan

- [x] Backend `full_test`: 585/591 green; the 6 failures are Redis-repository contract tests that require a live Redis (unavailable on this workstation; covered by CI's Redis service). New integration tests included and green.
- [x] Frontends: `test:unit`, `lint` (0 errors), `build`, Playwright mock e2e (user 126/126 incl. new authorize-resume / external-flow / password-change / danger-zone / QR cases; admin 190 passed + 6 skipped), `check-ui-sync`, size gate — all green.
- [x] Live acceptance (docs-local/browser-e2e/2026-09-09-fix-acceptance.md): device flow 3/3 (invalid code no crash, admin approve, device_code→token), `/health/ready` answers 503 in 2.0s with Redis unreachable (was: infinite hang), portal scenarios p1 8/8 · p2 9/9 · p3 7/7 · p4 4/4, admin p1 7/7, tokens/C2 5/5, MFA lifecycle passes with **zero manual DB surgery**.
- [ ] Error codes synced at all five points (spec, catalog test, SDKs where applicable) — no error codes added or changed in this PR.