### PR TITLE
fix(deploy): WSL rehearsal findings — migrate build section, doc drift, bootstrap password passthrough

### DIFF
--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -7,7 +7,7 @@
 # the local build with the same name). Schema migrations run through the
 # one-shot `migrate` service (profile "migrate"), not at app startup:
 #   docker compose -f docker-compose.prod.yml --env-file <your-env> \
-#     --profile migrate run --rm migrate
+#     --profile migrate run --rm --build migrate
 # The app itself keeps FULLA_AUTO_MIGRATE=false and only self-checks.
 # NOTE: the migrate service also carries a build: section so a fresh
 # deployment can migrate from LOCAL sources with --build even when the
@@ -154,7 +154,9 @@ services:
 
   # One-shot schema migration executor (Task 37). Not started by default:
   #   docker compose -f docker-compose.prod.yml --env-file .env.docker \
-  #     --profile migrate run --rm migrate
+  #     --profile migrate run --rm --build migrate
+  # (--build migrates from LOCAL sources; without it compose pulls the
+  # released image, which may predate unreleased migrations.)
   # Exit code 0 = schema up to date, 1 = failure (compose surfaces it).
   migrate:
     image: ghcr.io/voidvec/fulla-backend:${FULLA_VERSION:-latest}

--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -1,13 +1,20 @@
 # Production Docker Compose
-# Usage: cp .env.docker.example .env.docker && docker-compose -f docker-compose.prod.yml --env-file .env.docker up -d
+# Usage: create an env file (variable table in docs/operate/deployment.md),
+# then: docker compose -f docker-compose.prod.yml --env-file <your-env> up -d --build
 #
 # Task 37: services reference the versioned ghcr images published by
 # release.yml (set FULLA_VERSION to pin; `--build` still works and tags
 # the local build with the same name). Schema migrations run through the
 # one-shot `migrate` service (profile "migrate"), not at app startup:
-#   docker compose -f docker-compose.prod.yml --env-file .env.docker \
+#   docker compose -f docker-compose.prod.yml --env-file <your-env> \
 #     --profile migrate run --rm migrate
 # The app itself keeps FULLA_AUTO_MIGRATE=false and only self-checks.
+# NOTE: the migrate service also carries a build: section so a fresh
+# deployment can migrate from LOCAL sources with --build even when the
+# released ghcr image is unavailable (mirrored/offline hosts) or stale
+# relative to unreleased migrations — the WSL 2026-09-12 rehearsal hit
+# exactly that: `run --rm migrate` pulled the released image and silently
+# applied one migration fewer than the local sources ship.
 
 services:
   nginx:
@@ -113,6 +120,10 @@ services:
       # the app only self-checks the schema at startup.
       - FULLA_AUTO_MIGRATE=${FULLA_AUTO_MIGRATE:-false}
       - DETAILED_VALIDATION_ERRORS=${DETAILED_VALIDATION_ERRORS:-false}
+      # Optional: set the bootstrap admin's initial password explicitly;
+      # when empty AdminBootstrapper generates a random one and prints it
+      # ONCE to the container log (read it via `docker compose logs backend`).
+      - FULLA_BOOTSTRAP_ADMIN_PASSWORD=${FULLA_BOOTSTRAP_ADMIN_PASSWORD:-}
       # External auth (optional)
       - FULLA_GITHUB_CLIENT_ID=${FULLA_GITHUB_CLIENT_ID:-}
       - FULLA_GITHUB_CLIENT_SECRET=${FULLA_GITHUB_CLIENT_SECRET:-}
@@ -147,6 +158,10 @@ services:
   # Exit code 0 = schema up to date, 1 = failure (compose surfaces it).
   migrate:
     image: ghcr.io/voidvec/fulla-backend:${FULLA_VERSION:-latest}
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+      target: backend-runtime
     profiles: ["migrate"]
     command: ["./fulla-server", "--migrate-only"]
     restart: "no"

--- a/deploy/env/docker.env.example
+++ b/deploy/env/docker.env.example
@@ -65,7 +65,9 @@ FULLA_VUE_CLIENT_SECRET=CHANGE_ME_STRONG_SECRET
 FULLA_GOOGLE_REDIRECT_URI=https://your-domain.com/callback
 
 # ===== Migration / error verbosity =====
-FULLA_AUTO_MIGRATE=true
+# Keep false in production: migrations run through the one-shot `migrate`
+# service (compose profile "migrate") — see docs/operate/deployment.md.
+FULLA_AUTO_MIGRATE=false
 # When false, validation errors return a generic message (recommended for prod,
 # avoids leaking field-level hints to attackers).
 DETAILED_VALIDATION_ERRORS=false

--- a/docs/operate/deployment.md
+++ b/docs/operate/deployment.md
@@ -584,7 +584,7 @@ The frontend (the user-facing OAuth2Frontend) is configured through Vite environ
 
 ## Database initialization
 
-On first deployment the backend runs database migrations automatically (`FULLA_AUTO_MIGRATE=true`), creating all required tables. The **administrator account is bootstrapped automatically** on first start (see next step); OAuth2 clients are not — create them manually.
+On first deployment the one-shot `migrate` service creates all required tables (the compose stack keeps `FULLA_AUTO_MIGRATE=false`; run `docker compose -f docker-compose.prod.yml --env-file <your-env> --profile migrate run --rm migrate` after `up` of the postgres/redis services). The **administrator account is bootstrapped automatically** on first start (see next step); OAuth2 clients are not — create them manually.
 
 > The `dev_*.sql` files in `apps/server/seed/` use hard-coded passwords and localhost redirect URIs. **Do not use them in production.** Follow the steps below instead.
 
@@ -657,7 +657,7 @@ ON CONFLICT (client_id) DO NOTHING;
 
 INSERT INTO oauth2_client_scopes (client_id, scope_name)
 SELECT 'vue-client', name FROM oauth2_scopes
-WHERE is_default = TRUE
+WHERE name IN ('openid', 'profile', 'email')
 ON CONFLICT (client_id, scope_name) DO NOTHING;
 
 -- Admin console client (PUBLIC, PKCE)

--- a/docs/operate/deployment.md
+++ b/docs/operate/deployment.md
@@ -501,7 +501,7 @@ curl -k https://localhost/admin/
 | Base image | ubuntu:24.04 (minimal) |
 | Internal port | 5555 |
 | Access path | `https://your-domain.com/api/*`, `/oauth2/*` |
-| Database migration | Executed automatically at startup (FULLA_AUTO_MIGRATE=true) |
+| Database migration | One-shot `migrate` service (compose profile `migrate`; `FULLA_AUTO_MIGRATE=false`) |
 
 ### Infrastructure
 
@@ -540,7 +540,7 @@ The backend overrides configuration-file values with environment variables (prec
 | `FULLA_VUE_REDIRECT_URI` | vue-client OAuth callback URI | localhost value from config |
 | `FULLA_GOOGLE_REDIRECT_URI` | Google OAuth callback URI | localhost value from config |
 | `FULLA_VUE_CLIENT_SECRET` | vue-client secret | 123456 |
-| `FULLA_AUTO_MIGRATE` | Run database migrations automatically | true |
+| `FULLA_AUTO_MIGRATE` | Run database migrations automatically | false (use the one-shot `migrate` service) |
 | `DETAILED_VALIDATION_ERRORS` | Whether to return field-level validation errors (false recommended in production) | false |
 | `FULLA_GITHUB_CLIENT_ID` / `FULLA_GITHUB_CLIENT_SECRET` | GitHub OAuth (optional) | (empty) |
 | `FULLA_GOOGLE_CLIENT_ID` / `FULLA_GOOGLE_CLIENT_SECRET` | Google OAuth (optional) | (empty) |
@@ -584,7 +584,7 @@ The frontend (the user-facing OAuth2Frontend) is configured through Vite environ
 
 ## Database initialization
 
-On first deployment the one-shot `migrate` service creates all required tables (the compose stack keeps `FULLA_AUTO_MIGRATE=false`; run `docker compose -f docker-compose.prod.yml --env-file <your-env> --profile migrate run --rm migrate` after `up` of the postgres/redis services). The **administrator account is bootstrapped automatically** on first start (see next step); OAuth2 clients are not — create them manually.
+On first deployment the one-shot `migrate` service creates all required tables (the compose stack keeps `FULLA_AUTO_MIGRATE=false`; run `docker compose -f docker-compose.prod.yml --env-file <your-env> --profile migrate run --rm --build migrate` after `up` of the postgres/redis services — `--build` is REQUIRED on a clean checkout, otherwise compose pulls the released image, which may predate your local migrations). The **administrator account is bootstrapped automatically** on first start (see next step); OAuth2 clients are not — create them manually.
 
 > The `dev_*.sql` files in `apps/server/seed/` use hard-coded passwords and localhost redirect URIs. **Do not use them in production.** Follow the steps below instead.
 

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/deployment.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operate/deployment.md
@@ -500,7 +500,7 @@ curl -k https://localhost/admin/
 | 基础镜像 | ubuntu:24.04 (minimal) |
 | 内部端口 | 5555 |
 | 访问路径 | `https://your-domain.com/api/*`, `/oauth2/*` |
-| 数据库迁移 | 启动时自动执行（FULLA_AUTO_MIGRATE=true） |
+| 数据库迁移 | 一次性 `migrate` 服务（compose profile `migrate`；`FULLA_AUTO_MIGRATE=false`） |
 
 ### 基础设施
 
@@ -539,7 +539,7 @@ curl -k https://localhost/admin/
 | `FULLA_VUE_REDIRECT_URI` | vue-client OAuth 回调 URI | config 中的 localhost 值 |
 | `FULLA_GOOGLE_REDIRECT_URI` | Google OAuth 回调 URI | config 中的 localhost 值 |
 | `FULLA_VUE_CLIENT_SECRET` | vue-client 密钥 | 123456 |
-| `FULLA_AUTO_MIGRATE` | 自动执行数据库迁移 | true |
+| `FULLA_AUTO_MIGRATE` | 自动执行数据库迁移 | false（改用一次性 `migrate` 服务） |
 | `DETAILED_VALIDATION_ERRORS` | 是否返回字段级校验错误（生产建议 false） | false |
 | `FULLA_GITHUB_CLIENT_ID` / `FULLA_GITHUB_CLIENT_SECRET` | GitHub OAuth（可选） | (空) |
 | `FULLA_GOOGLE_CLIENT_ID` / `FULLA_GOOGLE_CLIENT_SECRET` | Google OAuth（可选） | (空) |
@@ -583,7 +583,7 @@ curl -k https://localhost/admin/
 
 ## 数据库初始化
 
-首次部署时，后端会自动执行数据库迁移（`FULLA_AUTO_MIGRATE=true`），创建所有必要的表。但**不会自动创建种子数据**——需要手动创建管理员用户和 OAuth2 客户端。
+首次部署时，由一次性 `migrate` 服务创建所有必要的表（compose 栈保持 `FULLA_AUTO_MIGRATE=false`；在启动 postgres/redis 服务后执行 `docker compose -f docker-compose.prod.yml --env-file <your-env> --profile migrate run --rm --build migrate`——干净环境**必须带 `--build`**，否则 compose 会拉取已发布镜像，其中可能缺少你本地的新迁移）。但**不会自动创建种子数据**——需要手动创建管理员用户和 OAuth2 客户端。
 
 > `apps/server/seed/` 下的 `dev_*.sql` 文件使用硬编码密码和 localhost 回调地址，**不要在生产环境使用**。请按以下步骤操作。
 
@@ -646,7 +646,7 @@ ON CONFLICT (client_id) DO NOTHING;
 
 INSERT INTO oauth2_client_scopes (client_id, scope_name)
 SELECT 'vue-client', name FROM oauth2_scopes
-WHERE is_default = TRUE
+WHERE name IN ('openid', 'profile', 'email')
 ON CONFLICT (client_id, scope_name) DO NOTHING;
 
 -- 管理后台客户端（PUBLIC，PKCE）


### PR DESCRIPTION
## Summary

Small operational fixes surfaced by the WSL production-stack rehearsal on 2026-09-12 (domain fulla.synapthub.com, FULLA_ENV=production, full five-step flow). The rehearsal itself validated the PR #197 security fixes over the real TLS topology (nonce round-trip, issuance guards, revocation cascade — all green end-to-end); these are the deployment-blocking or doc-drift items found along the way.

- **migrate service could not migrate from local sources.** The one-shot `migrate` service carried only `image:` — `compose run --rm migrate` pulls the RELEASED ghcr image. On the rehearsal that was the v1.1.1-era image: it applied 31 migrations while the freshly built backend (built from master) ships V032. A release-to-deploy window of any length means a new backend can boot against a schema missing its migrations — for V032 that silently broke the authorization-code flow (missing nonce column). Give the migrate service the same `build:` section as the backend so `--build` migrates from local sources; document the gotcha in the header.
- **`FULLA_BOOTSTRAP_ADMIN_PASSWORD` was a dead variable.** main.cc reads it (AdminBootstrapper) but compose never forwarded it, so operators could not set the bootstrap admin password explicitly and had to scrape a one-time log line — which the rehearsal showed is easy to lose (the first boot crashed on an unrelated gate and the printed password was gone). Pass it through.
- **docs/operate/deployment.md scope drift:** the vue-client scope grant used `WHERE is_default = TRUE`, which does not include `email` — the same drift PR #197 fixed in the dev seed (found live: the strict scope allowlist rejects `openid profile email` logins when the client only got default scopes). Use the explicit three-scope list.
- **docs/operate/deployment.md migration-flow drift:** the text claimed `FULLA_AUTO_MIGRATE=true`; the stack ships `AUTO_MIGRATE=false` with the one-shot migrate profile (Task 37). Describe the actual flow.
- Compose header referenced `.env.docker.example`, which does not exist — point at the deployment doc's variable table instead.

## Related

- Found during the rehearsal and filed separately: #198 — self-registration deadlock (verification email is never sent; resend requires a token the unverified user cannot obtain). Not fixed here; the rehearsal used the documented SQL fallback to proceed.

## Testing

- `docker compose ... config` validates.
- The rehearsal stack itself ran end-to-end after these changes (migrate re-run applied V032 from the local build; full OAuth2/OIDC E2E 8/8 green over https).